### PR TITLE
Project find view always goes on the top of buffer find

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -106,7 +106,7 @@ class FindView extends View
 
   attach: =>
     @findResultsView.attach()
-    rootView.vertical.append(this)
+    rootView.vertical.find('.find-and-replace-container').append(this)
 
   detach: =>
     @findResultsView.detach()

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -1,12 +1,13 @@
 FindModel = require './find-model'
 FindView = require './find-view'
 ProjectFindView = require './project-find-view'
-{_} = require 'atom'
+{_, $$} = require 'atom'
 
 module.exports =
   activate: ({viewState, projectViewState}={}) ->
     @projectFindView = new ProjectFindView(projectViewState)
     @findView = new FindView(viewState)
+    rootView.vertical.append($$ -> @div class: 'find-and-replace-container')
 
   deactivate: ->
     @findView.remove()

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -100,7 +100,7 @@ class ProjectFindView extends View
       el.focus()
       el.selectAll() if el.selectAll
     else
-      rootView.vertical.append(this)
+      rootView.vertical.find('.find-and-replace-container').prepend(this)
       @findEditor.focus()
       @findEditor.selectAll()
 


### PR DESCRIPTION
Add a container div to the vertical pane, then add each find view at a specific place: project view is prepended to the container so as to be on top, buffer find is appended to the container so it's always on the bottom.
