### PR TITLE
Handle splits

### DIFF
--- a/lib/project/results-pane.coffee
+++ b/lib/project/results-pane.coffee
@@ -24,6 +24,7 @@ class ResultsPaneView extends ScrollView
 
   initialize: (model) ->
     super
+    @loadingMessage.hide()
     @setModel(model) if model
 
   getPane: ->
@@ -45,6 +46,7 @@ class ResultsPaneView extends ScrollView
   setModel: (@model) ->
     @resultsView.setModel(@model)
     @handleEvents()
+    @onFinishedSearching()
 
   getResultCountText: ->
     if @resultsView.getPathCount() > 0
@@ -53,31 +55,35 @@ class ResultsPaneView extends ScrollView
       "No matches found for '#{@model.getPattern()}'"
 
   handleEvents: ->
-    @model.on 'search', (deferred) =>
-      @loadingMessage.show()
+    @model.on 'search', @onSearch
+    @model.on 'finished-searching', @onFinishedSearching
+    @model.on 'paths-searched', @onPathsSearched
 
-      @previewCount.text('Searching...')
-      @searchedCount.text('0')
-      @searchedCountBlock.hide()
+  onSearch: (deferred) =>
+    @loadingMessage.show()
 
-      @previewCount.show()
-      @resultsView.focus()
+    @previewCount.text('Searching...')
+    @searchedCount.text('0')
+    @searchedCountBlock.hide()
 
-      # We'll only show the paths searched message after 500ms. It's too fast to
-      # see on short searches, and slows them down.
-      @showSearchedCountBlock = false
-      timeout = setTimeout =>
-        @searchedCountBlock.show()
-        @showSearchedCountBlock = true
-      , 500
+    @previewCount.show()
+    @resultsView.focus()
 
-      deferred.done =>
-        @loadingMessage.hide()
-        @previewCount.text(@getResultCountText())
+    # We'll only show the paths searched message after 500ms. It's too fast to
+    # see on short searches, and slows them down.
+    @showSearchedCountBlock = false
+    timeout = setTimeout =>
+      @searchedCountBlock.show()
+      @showSearchedCountBlock = true
+    , 500
 
-    @model.on 'finished-searching', =>
+    deferred.done =>
+      @loadingMessage.hide()
       @previewCount.text(@getResultCountText())
 
-    @model.on 'paths-searched', (numberOfPathsSearched) =>
-      if @showSearchedCountBlock
-        @searchedCount.text(numberOfPathsSearched)
+  onPathsSearched: (numberOfPathsSearched) =>
+    if @showSearchedCountBlock
+      @searchedCount.text(numberOfPathsSearched)
+
+  onFinishedSearching: =>
+    @previewCount.text(@getResultCountText())

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -36,6 +36,8 @@ class ResultsView extends ScrollView
     @model.on 'result-removed', @removeResult
     @model.on 'cleared', @clear
 
+    @renderResults()
+
   beforeRemove: ->
     @clear()
 

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -50,6 +50,35 @@ describe 'ProjectFindView', ->
         $(document.activeElement).trigger 'core:cancel'
         expect(rootView.find('.project-find')).not.toExist()
 
+    describe "splitting into a second pane", ->
+      beforeEach ->
+        rootView.height(1000)
+        editor.trigger 'project-find:show'
+
+      it "can be duplicated", ->
+        projectFindView.findEditor.setText('items')
+        projectFindView.trigger 'core:confirm'
+
+        waitsForPromise ->
+          searchPromise
+
+        runs ->
+          resultsPaneView1 = getExistingResultsPane()
+          pane1 = rootView.getActivePane()
+          pane1.splitRight(pane1.copyActiveItem())
+
+          pane2 = rootView.getActivePane()
+          resultsPaneView2 = pane2.itemForUri(ResultsPaneView.URI)
+
+          expect(pane1[0]).not.toBe pane2[0]
+          expect(resultsPaneView1[0]).not.toBe resultsPaneView2[0]
+
+          length = resultsPaneView1.find('li > ul > li').length
+          expect(length).toBeGreaterThan 0
+          expect(resultsPaneView2.find('li > ul > li')).toHaveLength length
+
+          expect(resultsPaneView2.previewCount.html()).toEqual resultsPaneView1.previewCount.html()
+
     describe "serialization", ->
       it "serializes if the view is attached", ->
         expect(projectFindView.hasParent()).toBeFalsy()


### PR DESCRIPTION
This makes splitting not break. It splits like any file: duplication. I dont like the way it splits.
- duplication uses serialization and this thing depends on a model. I'm abusing serialization and retuning the model from `serialize()`. Not sure of a better way. 
- I really only want one of these things ever. So when it is split, it should move the item to the desired pane.
