### PR TITLE
Add option to open project results in the right pane

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -7,7 +7,7 @@ ResultsPaneView = require './project/results-pane'
 
 module.exports =
   configDefaults:
-    openProjectResultsInRightPane: false
+    openProjectFindResultsInRightPane: false
 
   activate: ({viewState, projectViewState, resultsModelState, paneViewState}={}) ->
     @resultsModel = new ResultsModel(resultsModelState)

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -138,7 +138,7 @@ class ProjectFindView extends View
 
   showResultPane: ->
     options = null
-    options = {split: 'right'} if config.get('find-and-replace.openProjectResultsInRightPane')
+    options = {split: 'right'} if config.get('find-and-replace.openProjectFindResultsInRightPane')
     rootView.openSingletonSync(ResultsPaneView.URI, options)
 
   clearMessages: ->

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -26,7 +26,7 @@ describe 'ProjectFindView', ->
     pack = atom.activatePackage("find-and-replace", immediate: true)
     projectFindView = pack.mainModule.projectFindView
 
-    config.set('find-and-replace.openProjectResultsInRightPane', false)
+    config.set('find-and-replace.openProjectFindResultsInRightPane', false)
 
     spy = spyOn(projectFindView, 'confirm').andCallFake ->
       searchPromise = spy.originalValue.call(projectFindView)
@@ -60,7 +60,7 @@ describe 'ProjectFindView', ->
 
       it "splits when option is true", ->
         initialPane = rootView.getActivePane()
-        config.set('find-and-replace.openProjectResultsInRightPane', true)
+        config.set('find-and-replace.openProjectFindResultsInRightPane', true)
         projectFindView.findEditor.setText('items')
         projectFindView.trigger 'core:confirm'
 
@@ -84,7 +84,7 @@ describe 'ProjectFindView', ->
           expect(pane1[0]).toBe initialPane[0]
 
       it "can be duplicated", ->
-        config.set('find-and-replace.openProjectResultsInRightPane', true)
+        config.set('find-and-replace.openProjectFindResultsInRightPane', true)
         projectFindView.findEditor.setText('items')
         projectFindView.trigger 'core:confirm'
 


### PR DESCRIPTION
This is a potential fix for #74.

Leave feedback! I'm going to merge it soon. Hopefully for today's release.

It defaults to false, so will open the results in the active pane.
