### PR TITLE
Mark the current marker with class current-result

### DIFF
--- a/lib/find-model.coffee
+++ b/lib/find-model.coffee
@@ -94,7 +94,7 @@ class FindModel
     _.find @editSession.findMarkers(attributes), (marker) -> marker.isValid()
 
   createMarker: (range) ->
-    markerAttributes = { class: @constructor.markerClass, invalidation: 'inside', replicate: false }
+    markerAttributes = { class: @constructor.markerClass, invalidation: 'inside', replicate: false, isCurrent: false }
     @editSession.markBufferRange(range, markerAttributes)
 
   destroyAllMarkers: ->

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -229,10 +229,23 @@ class FindView extends View
       @findModel.getEditSession().setSelectedBufferRange(marker.getBufferRange(), autoscroll: true)
 
   setCurrentMarkerFromSelection: =>
+    if @currentResultMarker
+      # HACK/TODO: telepath does not emit an event when attributes change. This
+      # is the event I want, so emitting myself.
+      @currentResultMarker.setAttributes(isCurrent: false)
+      @currentResultMarker.emit('attributes-changed', {isCurrent: false})
+
     @currentResultMarker = null
     if @markers? and @markers.length and editSession = @findModel.getEditSession()
       selectedBufferRange = editSession.getSelectedBufferRange()
       @currentResultMarker = @findModel.findMarker(selectedBufferRange)
+
+      if @currentResultMarker
+        # HACK/TODO: telepath does not emit an event when attributes change. This
+        # is the event I want, so emitting myself.
+        @currentResultMarker.setAttributes(isCurrent: true)
+        @currentResultMarker.emit('attributes-changed', {isCurrent: true})
+
     @updateResultCounter()
 
   setSelectionAsFindPattern: =>

--- a/lib/marker-view.coffee
+++ b/lib/marker-view.coffee
@@ -1,4 +1,4 @@
-{_} = require 'atom'
+{$, _} = require 'atom'
 {Subscriber} = require 'emissary'
 
 module.exports =
@@ -13,6 +13,7 @@ class MarkerView
     @updateNeeded = @marker.isValid()
 
     @subscribe @marker, 'changed', (event) => @onMarkerChanged(event)
+    @subscribe @marker, 'attributes-changed', ({isCurrent}) => @updateCurrentClass(isCurrent)
     @subscribe @marker, 'destroyed', => @remove()
     @subscribe @editor, 'editor:display-updated', => @updateDisplay()
 
@@ -38,6 +39,12 @@ class MarkerView
     {start, end} = @getScreenRange()
     [firstRenderedRow, lastRenderedRow] = [@editor.firstRenderedScreenRow, @editor.lastRenderedScreenRow]
     end.row >= firstRenderedRow and start.row <= lastRenderedRow
+
+  updateCurrentClass: (isCurrent) ->
+    if isCurrent
+      $(@element).addClass('current-result')
+    else
+      $(@element).removeClass('current-result')
 
   updateDisplay: ->
     return unless @isUpdateNeeded()


### PR DESCRIPTION
#73 brought up a good point: it's hard to see where the current search result is. It does flash, but it's still hard to see. This adds a class to the current result so it can be styled by the syntax theme:

![screen shot 2013-11-05 at 3 05 01 pm](https://f.cloud.github.com/assets/69169/1478595/b9d7a53e-466e-11e3-8171-04bc1cb5347b.png)
