### PR TITLE
Add views above status bar

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -144,7 +144,7 @@ class FindView extends View
 
   attach: =>
     @findResultsView.attach()
-    atom.workspaceView.vertical.append(this)
+    atom.workspaceView.panes.after(this)
 
   detach: =>
     @hideAllTooltips()

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -115,7 +115,7 @@ class ProjectFindView extends View
         @setInfoMessage("Nothing replaced")
 
   attach: ->
-    atom.workspaceView.vertical.append(this) unless @hasParent()
+    atom.workspaceView.panes.after(this) unless @hasParent()
 
     unless @findEditor.getText()
       editorView = atom.workspaceView.getActiveView()


### PR DESCRIPTION
This fixes atom/atom#1304 but it has a code smell. I see two options;
1. Add a method on workspace that adds tool-panels above status bar.
2. Move the status bar div into core (but keep all the status bar logic in packages)

I'm leaning towards option two because it also solves the problem of other packages talking to the status bar package.
