### PR TITLE
Fix the leak in #101

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -29,9 +29,7 @@ module.exports =
 
     @paneView = null
     atom.project.registerOpener (filePath) =>
-      if filePath is ResultsPaneView.URI
-        @paneView = new ResultsPaneView() unless @paneView
-        @paneView
+      @paneView ?= new ResultsPaneView() if filePath is ResultsPaneView.URI
 
     atom.workspaceView.command 'project-find:show', =>
       @findView.detach()


### PR DESCRIPTION
Each time you would run a new search, it would create a new 
ResultsViewPane. The worst part is that the old one would still be 
bound to the model, and so still run the search, create nodes, etc.
No more. This reuses the paneView.
