### PR TITLE
Uses the success handler to handle cancel

### DIFF
--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -73,11 +73,12 @@ class ResultsModel
       @setResult(result.filePath, Result.create(result))
 
     @emit('search', @inProgressSearchPromise)
-    @inProgressSearchPromise.then =>
-      @inProgressSearchPromise = null
-      @emit('finished-searching', @getResultsSummary())
-    , (reason) =>
-      @emit('cancelled-searching') if reason == 'cancelled'
+    @inProgressSearchPromise.then (message) =>
+      if message == 'cancelled'
+        @emit('cancelled-searching')
+      else
+        @inProgressSearchPromise = null
+        @emit('finished-searching', @getResultsSummary())
 
   replace: (pattern, searchPaths, replacementPattern, replacementPaths) ->
     regex = @getRegex(pattern)


### PR DESCRIPTION
Fixes the error when a search is canceled. I think there was an issue about this, but I cant find it. I bet @kevinsawicki knows what it is. Relies on atom/atom#1400
