### PR TITLE
Change default to not focus after search

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -170,10 +170,10 @@ class FindView extends View
     pattern = @findEditor.getText()
     @updateModel { pattern }
 
-  findNext: (focusEditorAfter = true) =>
+  findNext: (focusEditorAfter = false) =>
     @findAndSelectResult(@selectFirstMarkerAfterCursor, focusEditorAfter)
 
-  findPrevious: (focusEditorAfter = true) =>
+  findPrevious: (focusEditorAfter = false) =>
     @findAndSelectResult(@selectFirstMarkerBeforeCursor, focusEditorAfter)
 
   findAndSelectResult: (selectFunction, focusEditorAfter = true) =>


### PR DESCRIPTION
The current Find defaults to returning focus to the editor after hitting enter. It seems like you are expected to hit command+g to get the next search result. Maybe it is just me, but it seems like not sending focus to the editor should be the default.  Right now if you do command+f..enter a search term..hit enter..and then hit enter again you end up deleting the first found match and inserting a newline. Maybe there is a good reason and/or other people expect this. If supporting both approaches sounds appealing we could add a setting.

/cc @benogle @probablycorey @gregose (since we both weren't thrilled with the default behavior :smile:)
