### PR TITLE
Highlight occurences of selected word

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -52,12 +52,17 @@ module.exports =
       @findView?.detach()
       @projectFindView?.detach()
 
-    atom.workspaceView.eachEditorView (editorView) ->
+    atom.workspaceView.eachEditorView (editorView) =>
       selectNext = new SelectNext(editorView.editor)
-      editorView.command 'find-and-replace:select-next', ->
+      editorView.command 'find-and-replace:select-next', =>
         selectNext.findAndSelectNext()
+        @createFindView().setSelectionAsFindPattern()
       editorView.command 'find-and-replace:select-all', ->
         selectNext.findAndSelectAll()
+
+    atom.workspaceView.on 'mousedown.find-and-replace', '.editor .line', (event) =>
+      if event.originalEvent?.detail is 2
+        @createFindView().setSelectionAsFindPattern()
 
   createProjectFindView: ->
     @resultsModel ?= new ResultsModel(@resultsModelState)
@@ -95,6 +100,7 @@ module.exports =
     atom.workspaceView.off 'find-and-replace:show'
     atom.workspaceView.off 'find-and-replace:use-selection-as-find-pattern'
     atom.workspaceView.off 'project-find:show-in-current-directory'
+    atom.workspaceView.off '.find-and-replace'
 
   serialize: ->
     viewState: @findView?.serialize() ? @viewState

--- a/spec/select-next-spec.coffee
+++ b/spec/select-next-spec.coffee
@@ -25,6 +25,9 @@ describe "SelectNext", ->
         editorView.trigger 'find-and-replace:select-next'
         expect(editor.getSelectedBufferRanges()).toEqual [[[1, 2], [1, 5]]]
 
+      it "marks all the occurrences", ->
+        expect(findResultsView.parent()[0]).toBe editorView.underlayer[0]
+
     describe "when a word is selected", ->
       it "selects the next occurrence of the selected word skipping any non-word matches", ->
         editor.setText """


### PR DESCRIPTION
When you:
- double click a word
- trigger `find-and-replace:select-next` command (`Cmd+d` by default)

it will select the word under the cursor.
Now it will also highlight all the other occurrences of the word in the file.

Partially addresses #138.

---

This is working, but it is not the complete feature from Sublime Text.

The activation events thing in Atom is nice, but it could be quite limiting.

Right now the double-click action is not triggered until the package has not
been activated in another way.