### PR TITLE
Don't auto-set search text to selection

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -132,7 +132,6 @@ class FindView extends View
 
   showFind: =>
     editor = atom.workspaceView.getActivePaneItem()
-    @findEditor.setText(editor.getSelectedText()) if editor?.getSelectedText?
 
     @attach() if not @hasParent()
     @findEditor.focus()

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -29,7 +29,7 @@ describe 'FindView', ->
       runs ->
         expect(atom.workspaceView.find('.find-and-replace')).toExist()
 
-    it "populates the findEditor with selection when there is a selection", ->
+    it "preserves the findEditor's last value when there is a selection", ->
       editor.setSelectedBufferRange([[2, 8], [2, 13]])
       editorView.trigger 'find-and-replace:show'
 
@@ -37,15 +37,14 @@ describe 'FindView', ->
         activationPromise
 
       runs ->
+        findView.findEditor.setText('items')
         expect(atom.workspaceView.find('.find-and-replace')).toExist()
         expect(findView.findEditor.getText()).toBe('items')
-
-        findView.findEditor.setText('')
 
         editor.setSelectedBufferRange([[2, 14], [2, 20]])
         editorView.trigger 'find-and-replace:show'
         expect(atom.workspaceView.find('.find-and-replace')).toExist()
-        expect(findView.findEditor.getText()).toBe('length')
+        expect(findView.findEditor.getText()).toBe('items')
 
   describe "when FindView's replace editor is visible", ->
     it "keeps the replace editor visible when find-and-replace:show is triggered", ->

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -57,18 +57,16 @@ describe 'ProjectFindView', ->
         projectFindView.findEditor.setText('')
         editor = atom.workspaceView.openSync('sample.js')
 
-      it "populates the findEditor with selection when there is a selection", ->
+      it "preserves the findEditor's last value when there is a selection", ->
         editor.setSelectedBufferRange([[2, 8], [2, 13]])
         atom.workspaceView.trigger 'project-find:show'
         expect(atom.workspaceView.find('.project-find')).toExist()
         expect(projectFindView.findEditor.getText()).toBe('items')
 
-        projectFindView.findEditor.setText('')
-
         editor.setSelectedBufferRange([[2, 14], [2, 20]])
         atom.workspaceView.trigger 'project-find:show'
         expect(atom.workspaceView.find('.project-find')).toExist()
-        expect(projectFindView.findEditor.getText()).toBe('length')
+        expect(projectFindView.findEditor.getText()).toBe('items')
 
     describe "when thethe ProjectFindView is already attached", ->
       beforeEach ->


### PR DESCRIPTION
Possible solution for #141

Still leaves the possibility for a user to ⌘E with a large block and break the UI, but that's much less likely.
