### PR TITLE
Modify live search to begin searching after 1st char

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -115,7 +115,12 @@ class FindView extends View
     atom.workspaceView.on 'selection:changed', @setCurrentMarkerFromSelection
 
   handleFindEvents: ->
-    @findEditor.getEditor().on 'contents-modified', => @liveSearch()
+    @findEditor.getEditor().on 'contents-modified', =>
+      if @findEditor.getText().length > 1
+        @liveSearch()
+      else if @findEditor.getText().length == 0
+        @descriptionLabel.text('Find in Current Buffer')
+
     @nextButton.on 'click', => @findNext(true)
     @previousButton.on 'click', => @findPrevious(true)
     atom.workspaceView.command 'find-and-replace:find-next', => @findNext(true)

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -116,10 +116,10 @@ class FindView extends View
 
   handleFindEvents: ->
     @findEditor.getEditor().on 'contents-modified', =>
-      if @findEditor.getText().length > 1
+      if @findEditor.getText().length isnt 1
         @liveSearch()
-      else if @findEditor.getText().length == 0
-        @descriptionLabel.text('Find in Current Buffer')
+      else
+        @updateDescription()
 
     @nextButton.on 'click', => @findNext(true)
     @previousButton.on 'click', => @findPrevious(true)
@@ -241,7 +241,7 @@ class FindView extends View
       index = @markers.indexOf(@currentResultMarker)
       text = "#{ index + 1} of #{@markers.length}"
     else
-      if not @markers? or @markers.length == 0
+      if not @markers? or @markers.length == 0 or @findEditor.getText().length == 1
         text = "no results"
       else if @markers.length == 1
         text = "1 found"
@@ -251,9 +251,14 @@ class FindView extends View
     @resultCounter.text text
 
   updateDescription: ->
-    results = @markers.length
-    resultsStr = if results then _.pluralize(results, 'result') else 'No results'
-    @descriptionLabel.text("#{resultsStr} found for '#{@findModel.pattern}'")
+    if @findEditor.getText().length > 1
+      results = @markers.length
+      resultsStr = if results then _.pluralize(results, 'result') else 'No results'
+      text = "#{resultsStr} found for '#{@findModel.pattern}'"
+    else
+      text = 'Find in Current Buffer'
+
+    @descriptionLabel.text text
 
   selectFirstMarkerAfterCursor: =>
     markerIndex = @firstMarkerIndexAfterCursor()

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -517,7 +517,7 @@ describe 'FindView', ->
 
         findView.findEditor.setText ''
         advance()
-        expect(findView.descriptionLabel.text()).toContain "No results"
+        expect(findView.descriptionLabel.text()).toContain "Find in Current Buffer"
         expect(findView).toHaveFocus()
 
         findView.findEditor.setText 'sort'


### PR DESCRIPTION
Starting the search after the first character improves the performance/experience when editing large files. Maybe we can bring it back?

I've also added a small cosmetic change. When the find textfield is cleared the description will now be returned to `'Find in current buffer'` instead of showing `'No results for ''`

This is related to issue #145. Live search was introduced via #113