### PR TITLE
:penguin: Update linux keymaps.

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -15,9 +15,15 @@
   'cmd-d': 'find-and-replace:select-next'
   'cmd-e': 'find-and-replace:use-selection-as-find-pattern'
 
-'.platform-win32 .editor, .platform-linux .editor':
+'.platform-win32 .editor':
   'ctrl-g': 'find-and-replace:find-next'
   'ctrl-G': 'find-and-replace:find-previous'
+
+  'ctrl-e': 'find-and-replace:use-selection-as-find-pattern'
+
+'.platform-linux .editor':
+  'f3': 'find-and-replace:find-next'
+  'shift-f3': 'find-and-replace:find-previous'
 
   'ctrl-e': 'find-and-replace:use-selection-as-find-pattern'
 


### PR DESCRIPTION
`f3/shift-f3` are used in sublime/kate/brackets/rubymine. Also `ctrl-g` conflicts with `go-to-line`
