### PR TITLE
keep focus on findEditor when focusEditorAfter is false

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -185,7 +185,10 @@ class FindView extends View
       atom.beep()
     else
       selectFunction()
-      atom.workspaceView.focus() if focusEditorAfter
+      if focusEditorAfter
+        atom.workspaceView.focus()
+      else
+        @findEditor.focus()
 
   replaceNext: =>
     @replace('findNext', 'firstMarkerIndexAfterCursor')


### PR DESCRIPTION
At least on linux pressing enter key in findEditor set focus to the editor pane even when _focusEditorAfter_ is set to false. 
This ensures the findEditor to keep focus when asked to do so. Now hitting enter key again correctly search for the next occurence instead of inserting a new line.

fixes #220
