### PR TITLE
find-and-replace:select-next binding for Linux

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -24,6 +24,7 @@
 '.platform-linux .editor':
   'f3': 'find-and-replace:find-next'
   'shift-f3': 'find-and-replace:find-previous'
+  'ctrl-d': 'find-and-replace:select-next'
 
   'ctrl-e': 'find-and-replace:use-selection-as-find-pattern'
 


### PR DESCRIPTION
I noticed that Atom on Linux does not support ctrl-d out of the box like Sublime does. I guess ctrl-d on Windows is chosen because of Sublime's binding, so I thought it should be set on Linux as well.
