### PR TITLE
Add shift-enter to show previous match

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -22,12 +22,14 @@
   'ctrl-e': 'find-and-replace:use-selection-as-find-pattern'
 
 '.platform-darwin .find-and-replace':
+  'shift-enter': 'find-and-replace:show-previous'
   'cmd-enter': 'find-and-replace:replace-all'
   'cmd-alt-/': 'find-and-replace:toggle-regex-option'
   'cmd-alt-c': 'find-and-replace:toggle-case-option'
   'cmd-alt-s': 'find-and-replace:toggle-selection-option'
 
 '.platform-win32 .find-and-replace, .platform-linux .find-and-replace':
+  'shift-enter': 'find-and-replace:show-previous'
   'ctrl-enter': 'find-and-replace:replace-all'
   'ctrl-alt-/': 'find-and-replace:toggle-regex-option'
   'ctrl-alt-c': 'find-and-replace:toggle-case-option'

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -94,6 +94,8 @@ class FindView extends View
     @handleReplaceEvents()
 
     @findEditor.on 'core:confirm', => @confirm()
+    @findEditor.on 'find-and-replace:show-previous', => @showPrevious()
+
     @replaceEditor.on 'core:confirm', => @replaceNext()
 
     @on 'find-and-replace:focus-next', @toggleFocus
@@ -164,6 +166,9 @@ class FindView extends View
 
   confirm: ->
     @findNext(atom.config.get('find-and-replace.focusEditorAfterSearch'))
+
+  showPrevious: ->
+    @findPrevious(atom.config.get('find-and-replace.focusEditorAfterSearch'))
 
   liveSearch: ->
     pattern = @findEditor.getText()

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -362,6 +362,15 @@ describe 'FindView', ->
       expect(editor.getSelectedBufferRange()).toEqual [[2, 34], [2, 39]]
       expect(editorView).toHaveFocus()
 
+    it "selects the previous match before the cursor when the 'find-and-replace:show-previous' event is triggered", ->
+      expect(findView.resultCounter.text()).toEqual('2 of 6')
+      expect(editor.getSelectedBufferRange()).toEqual [[2, 8], [2, 13]]
+
+      findView.findEditor.trigger 'find-and-replace:show-previous'
+      expect(findView.resultCounter.text()).toEqual('1 of 6')
+      expect(editor.getSelectedBufferRange()).toEqual [[1, 22], [1, 27]]
+      expect(findView.findEditor).toHaveFocus()
+
     it "will re-run search if 'find-and-replace:find-next' is triggered after changing the findEditor's text", ->
       findView.findEditor.setText 'sort'
       findView.findEditor.trigger 'find-and-replace:find-next'


### PR DESCRIPTION
- Keybinding only active in the find editor field
- Matches Sublime finder functionality

Ref: https://github.com/atom/find-and-replace/issues/67
