### PR TITLE
Turn off default up/down scrolling from ScrollView's core:move-up/down event handling

### DIFF
--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -13,6 +13,10 @@ class ResultsView extends ScrollView
     @pixelOverdraw = 100
     @lastRenderedResultIndex = 0
 
+    # turn off default scrolling behavior from ScrollView
+    @off 'core:move-up'
+    @off 'core:move-down'
+
     @on 'core:move-down', =>
       @selectNextResult()
 


### PR DESCRIPTION
Fixes #238. Basically the same patch as in https://github.com/atom/tree-view/pull/153.

cc @kevinsawicki 

![](http://garimeacham.com/wp-content/uploads/whack-a-mole_3697068_GIFSoup.com_.gif)
