### PR TITLE
Allow configuration of find-and-replace options

### DIFF
--- a/lib/find-model.coffee
+++ b/lib/find-model.coffee
@@ -9,9 +9,9 @@ class FindModel
 
   constructor: (state={}) ->
     @pattern = ''
-    @useRegex = state.useRegex ? false
-    @inCurrentSelection = state.inCurrentSelection ? false
-    @caseSensitive = state.caseSensitive ? false
+    @useRegex = state.useRegex ? atom.config.get('find-and-replace.useRegex') ? false
+    @inCurrentSelection = state.inCurrentSelection ? atom.config.get('find-and-replace.inCurrentSelection') ? false
+    @caseSensitive = state.caseSensitive ? atom.config.get('find-and-replace.caseSensitive') ? false
     @valid = false
 
     @activePaneItemChanged()


### PR DESCRIPTION
Find-and-replace options are sticky within a project currently, but not globally configurable. This PR pulls the settings from the `find-and-replace.useRegex`, `find-and-replace.inCurrentSelection`, and `find-and-replace.caseSensitive` config keys.

Thanks to @nathansobo for getting me started with this. 
/cc @benogle
