### PR TITLE
Fix search results below fold not being rendered on scroll since v0.149.0

### DIFF
--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -26,7 +26,6 @@ class ResultsView extends ScrollView
       'core:move-up': => @selectPreviousResult()
       'core:move-left': => @collapseResult()
       'core:move-right': => @expandResult()
-      'scroll resize': => @renderResults() if @shouldRenderMoreResults()
       'core:confirm': =>
         @find('.selected').view()?.confirm?()
         false
@@ -39,6 +38,9 @@ class ResultsView extends ScrollView
       view = $(target).view()
       view.addClass('selected')
       view.confirm() if which is 1 and not ctrlKey
+
+    @on 'scroll resize', =>
+      @renderResults() if @shouldRenderMoreResults()
 
     @subscriptions.add @model.onDidAddResult @addResult
     @subscriptions.add @model.onDidRemoveResult @removeResult


### PR DESCRIPTION
In Atom `v0.153.0` search results are not being appended when you try to scroll below the fold. #272 looks like exactly this problem so I didn't create a separate issue.

Looking in the spec it looks like [this test](https://github.com/atom/find-and-replace/blob/9a1a5ec9cc3964f8987b89a4eff890abea7a2922/spec/results-view-spec.coffee#L102-L124) should be catching it, but it didn't. So... cc @benogle :grimacing: 
