### PR TITLE
Fix collapsing search results not revealing more results

### DIFF
--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -39,6 +39,7 @@ class ResultsView extends ScrollView
       view = $(target).view()
       view.addClass('selected')
       view.confirm() if which is 1 and not ctrlKey
+      @renderResults() if @shouldRenderMoreResults()
 
     @subscriptions.add @model.onDidAddResult @addResult
     @subscriptions.add @model.onDidRemoveResult @removeResult


### PR DESCRIPTION
This should fix #272.
Just telling it to render more result if needed. :grimacing: 

Again maybe a test would be handy. @benogle if you could help? :yellow_heart: 
