### PR TITLE
Sorting search results

### DIFF
--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -66,8 +66,6 @@ class ResultsView extends ScrollView
     resultView.renderResult(null) if resultView
 
   renderResults: ({renderAll}={}) ->
-    return unless renderAll or @shouldRenderMoreResults()
-
     paths = @model.getPaths()
     @foldFilledAt ?= 0
     for filePath in paths[@lastRenderedResultIndex..]

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -69,6 +69,7 @@ class ResultsView extends ScrollView
     return unless renderAll or @shouldRenderMoreResults()
 
     paths = @model.getPaths()
+    @foldFilledAt ?= 0
     for filePath in paths[@lastRenderedResultIndex..]
       result = @model.getResult(filePath)
       listItems = @children()
@@ -78,7 +79,10 @@ class ResultsView extends ScrollView
           insertPoint = index
           false
 
-      break if not listItems[insertPoint] not renderAll and not @shouldRenderMoreResults()
+      if @foldFilledAt is 0 and not @shouldRenderMoreResults()
+        @foldFilledAt = listItems.length
+
+      break if not renderAll and insertPoint > @foldFilledAt and not @shouldRenderMoreResults()
 
       resultView = new ResultView(@model, filePath, result)
       if listItems[insertPoint] then $(listItems[insertPoint]).before(resultView) else @append(resultView)

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -71,15 +71,14 @@ class ResultsView extends ScrollView
     paths = @model.getPaths()
     for filePath in paths[@lastRenderedResultIndex..]
       result = @model.getResult(filePath)
-      break if not renderAll and not @shouldRenderMoreResults()
-      resultView = new ResultView(@model, filePath, result)
-
       listItems = @children()
       paths = listItems.map( -> $(this).attr('data-path')).get()
       paths.push(filePath)
-
       index = paths.sort().indexOf(filePath.toString())
-      index = listItems.length - 1 if index > listItems.length
+
+      break if not listItems[index] and not renderAll and not @shouldRenderMoreResults()
+
+      resultView = new ResultView(@model, filePath, result)
       if listItems[index] then $(listItems[index]).before(resultView) else @append(resultView)
 
       @lastRenderedResultIndex++

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -72,14 +72,16 @@ class ResultsView extends ScrollView
     for filePath in paths[@lastRenderedResultIndex..]
       result = @model.getResult(filePath)
       listItems = @children()
-      paths = listItems.map( -> $(this).attr('data-path')).get()
-      paths.push(filePath)
-      index = paths.sort().indexOf(filePath.toString())
+      insertPoint = 0
+      listItems.each (index, item) ->
+        if item.dataset.path > filePath
+          insertPoint = index
+          false
 
-      break if not listItems[index] and not renderAll and not @shouldRenderMoreResults()
+      break if not listItems[insertPoint] not renderAll and not @shouldRenderMoreResults()
 
       resultView = new ResultView(@model, filePath, result)
-      if listItems[index] then $(listItems[index]).before(resultView) else @append(resultView)
+      if listItems[insertPoint] then $(listItems[insertPoint]).before(resultView) else @append(resultView)
 
       @lastRenderedResultIndex++
 

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -72,10 +72,10 @@ class ResultsView extends ScrollView
       result = @model.getResult(filePath)
       listItems = @children()
       insertPoint = listItems.length
-      listItems.each (index, item) ->
-        if (item.dataset.path).localeCompare(filePath) >= 0
+      for item, index in listItems
+        if item.dataset.path.localeCompare(filePath) >= 0
           insertPoint = index
-          false
+          break
 
       if @foldFilledAt is 0 and not @shouldRenderMoreResults()
         @foldFilledAt = listItems.length

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -71,7 +71,7 @@ class ResultsView extends ScrollView
     for filePath in paths[@lastRenderedResultIndex..]
       result = @model.getResult(filePath)
       listItems = @children()
-      insertPoint = 0
+      insertPoint = listItems.length
       listItems.each (index, item) ->
         if item.dataset.path > filePath
           insertPoint = index

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -73,7 +73,7 @@ class ResultsView extends ScrollView
       listItems = @children()
       insertPoint = listItems.length
       listItems.each (index, item) ->
-        if item.dataset.path > filePath
+        if (item.dataset.path).localeCompare(filePath) >= 0
           insertPoint = index
           false
 

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -73,7 +73,15 @@ class ResultsView extends ScrollView
       result = @model.getResult(filePath)
       break if not renderAll and not @shouldRenderMoreResults()
       resultView = new ResultView(@model, filePath, result)
-      @append(resultView)
+
+      listItems = @children()
+      paths = listItems.map( -> $(this).attr('data-path')).get()
+      paths.push(filePath)
+
+      index = paths.sort().indexOf(filePath.toString())
+      index = listItems.length - 1 if index > listItems.length
+      if listItems[index] then $(listItems[index]).before(resultView) else @append(resultView)
+
       @lastRenderedResultIndex++
 
     null # dont return an array


### PR DESCRIPTION
Fixes #64. :grimacing: 

Before

![image](https://cloud.githubusercontent.com/assets/1153134/5326112/203d3258-7cba-11e4-8027-6482bdd6e634.png)

After

![image](https://cloud.githubusercontent.com/assets/1153134/5326114/4b2478b4-7cba-11e4-8198-b1c237ad65f3.png)

Would be nice to do some benchmarking on how this effects performance. I can potentially try figuring that out myself, but help would be mucho appreciated :heart:

It's also probably debatable if `item.dataset.path > filePath` is the best sorting mechanism. For example in the screenshot, it probably makes more sense if `lib/select-next.coffee` comes before `lib/project/*`, as Sublime does.