### PR TITLE
Fix search result message wrapping

### DIFF
--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -14,10 +14,10 @@ class ProjectFindView extends View
   @content: ->
     @div tabIndex: -1, class: 'project-find padded', =>
       @div class: 'block', =>
-        @span outlet: 'descriptionLabel', class: 'description'
         @span class: 'options-label pull-right', =>
           @span 'Finding with Options: '
           @span outlet: 'optionsLabel', class: 'options'
+        @span outlet: 'descriptionLabel', class: 'description'
 
       @div outlet: 'replacmentInfoBlock', class: 'block', =>
         @progress outlet: 'replacementProgress', class: 'inline-block'


### PR DESCRIPTION
Fixes #288. Floated content should always come first. :heart:

Before

![image](https://cloud.githubusercontent.com/assets/1153134/5326160/99d3bb8a-7cbc-11e4-991e-013457a6868f.png)

After

![image](https://cloud.githubusercontent.com/assets/1153134/5326161/b20713b4-7cbc-11e4-8d21-fcde635f1e2a.png)
