### PR TITLE
Don't show Find panel on use-selection

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -54,9 +54,7 @@ module.exports =
       return if @projectFindPanel?.isVisible() or @findPanel?.isVisible()
 
       @createViews()
-      @projectFindPanel.hide()
-      @findPanel.show()
-      @findView.focusFindEditor()
+      @findView.setSelectionAsFindPattern()
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:toggle', =>
       @createViews()


### PR DESCRIPTION
use-selection-as-find-pattern still does what it says on the tin, but much
more efficiently for keyboard users. Fixes atom/find-and-replace#332.

All specs still pass. 