### PR TITLE
setSelectionAsFindPattern updates

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -329,7 +329,7 @@ class FindView extends View
       editor.scrollToCursorPosition(center: true)
 
   setSelectionAsFindPattern: =>
-    pattern = @findModel.getEditor()?.getSelectedText()
+    pattern = @findModel.getEditor()?.getSelectedText() or @findModel.getEditor()?.getWordUnderCursor()
     @updateModel {pattern} if pattern
 
   updateOptionsLabel: ->

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -329,8 +329,8 @@ class FindView extends View
       editor.scrollToCursorPosition(center: true)
 
   setSelectionAsFindPattern: =>
-    pattern = @findModel.getEditor().getSelectedText()
-    @updateModel {pattern}
+    pattern = @findModel.getEditor()?.getSelectedText()
+    @updateModel {pattern} if pattern
 
   updateOptionsLabel: ->
     label = []

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -266,6 +266,5 @@ class ProjectFindView extends View
 
   setSelectionAsFindPattern: =>
     editor = atom.workspace.getActivePaneItem()
-    if editor?.getSelectedText?
-      pattern = editor.getSelectedText()
-      @findEditor.setText(pattern)
+    pattern = editor?.getSelectedText() or editor?.getWordUnderCursor()
+    @findEditor.setText(pattern) if pattern


### PR DESCRIPTION
These update the <kbd>cmd+e</kbd> behavior to use the word under the cursor if no word is selected (like <kbd>cmd+d</kbd> does) and to not clear the find pattern if nothing's selected and there's no word under the cursor.