### PR TITLE
Disambiguate relative paths in project results view

### DIFF
--- a/lib/project/helpers.coffee
+++ b/lib/project/helpers.coffee
@@ -1,0 +1,9 @@
+path = require "path"
+
+# TODO: move this functionality to core. Other packages need it as well.
+module.exports =
+  splitProjectPath: (filePath) ->
+    for projectPath in atom.project?.getPaths() ? []
+      if filePath is projectPath or filePath.startsWith(projectPath + path.sep)
+        return [projectPath, path.relative(projectPath, filePath)]
+    return [null, filePath]

--- a/lib/project/result-view.coffee
+++ b/lib/project/result-view.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore-plus'
 {$, View} = require 'atom-space-pen-views'
 fs = require 'fs-plus'
 MatchView = require './match-view'
+{splitProjectPath} = require "./helpers"
 path = require 'path'
 
 module.exports =
@@ -10,11 +11,15 @@ class ResultView extends View
     iconClass = if fs.isReadmePath(filePath) then 'icon-book' else 'icon-file-text'
     fileBasename = path.basename(filePath)
 
+    [rootPath, relativePath] = splitProjectPath(filePath)
+    if rootPath? and atom.project.getDirectories().length > 1
+      relativePath = path.join(path.basename(rootPath), relativePath)
+
     @li class: 'path list-nested-item', 'data-path': _.escapeAttribute(filePath), =>
       @div outlet: 'pathDetails', class: 'path-details list-item', =>
         @span class: 'disclosure-arrow'
         @span class: iconClass + ' icon', 'data-name': fileBasename
-        @span class: 'path-name bright', filePath.replace(atom.project?.getPaths()[0] + path.sep, '')
+        @span class: 'path-name bright', relativePath
         @span outlet: 'description', class: 'path-match-number'
       @ul outlet: 'matches', class: 'matches list-tree'
 

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -1,6 +1,6 @@
 path = require 'path'
 _ = require 'underscore-plus'
-path = require 'path'
+temp = require "temp"
 
 ResultsPaneView = require '../lib/project/results-pane'
 
@@ -45,9 +45,25 @@ describe 'ResultsView', ->
       runs ->
         resultsView = getResultsView()
 
+        expect(resultsView.find('.path-name').text()).toBe "one-long-line.coffee"
         expect(resultsView.find('.preview').length).toBe 1
         expect(resultsView.find('.preview').text()).toBe 'test test test test test test test test test test test a b c d e f g h i j k l abcdefghijklmnopqrstuvwxyz'
         expect(resultsView.find('.match').text()).toBe 'ghijkl'
+
+  describe "when there are multiple project paths", ->
+    beforeEach ->
+      atom.project.addPath(temp.mkdirSync("another-project-path"))
+
+    it "includes the basename of the project path that contains the match", ->
+      projectFindView.findEditor.setText('ghijkl')
+      atom.commands.dispatch projectFindView.element, 'core:confirm'
+
+      waitsForPromise ->
+        searchPromise
+
+      runs ->
+        resultsView = getResultsView()
+        expect(resultsView.find('.path-name').text()).toBe path.join("fixtures", "one-long-line.coffee")
 
   describe "rendering replacement text", ->
     modifiedDelay = null
@@ -65,6 +81,7 @@ describe 'ResultsView', ->
       runs ->
         resultsView = getResultsView()
 
+        expect(resultsView.find('.path-name').text()).toBe "one-long-line.coffee"
         expect(resultsView.find('.preview').length).toBe 1
         expect(resultsView.find('.match').text()).toBe 'ghijkl'
         expect(resultsView.find('.replacement').text()).toBe 'cats'


### PR DESCRIPTION
This way, when there are multiple project paths (say `atom` and `find-and-replace`), you'll see paths like `atom/spec/spec-helper.coffee` and `find-and-replace/package.json`, so you can tell which root directory each path belongs to.