### PR TITLE
Prevent search field from collapsing when layout space is insufficient

### DIFF
--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -141,6 +141,7 @@ atom-workspace.find-visible {
     z-index: 2;
     font-size: .9em;
     line-height: @component-line-height;
+    pointer-events: none;
 
     .result-counter {
       margin-right: @component-padding;

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -72,6 +72,7 @@ atom-workspace.find-visible {
     .editor-container {
       position: relative;
       -webkit-flex: 1;
+      overflow: hidden;
 
       atom-text-editor {
         width: 100%;
@@ -144,6 +145,10 @@ atom-workspace.find-visible {
     .result-counter {
       margin-right: @component-padding;
     }
+  }
+
+  .block {
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
The changes that I brought to the LESS stylesheet aim to fix the issue mentioned in #358.

Line-wrapping fix|Overflow fix
-----------------------|----------------
![atom-fnr line wrap](https://cloud.githubusercontent.com/assets/920910/6497511/b932cbd2-c2ae-11e4-914e-fbca5f3cb8bd.png)|![atom-fnr tiny layout](https://cloud.githubusercontent.com/assets/920910/6497512/c4a1043e-c2ae-11e4-9fd2-8624acfc2f8c.png)

Oh, and that also prevents the `.find-meta-container` from overflowing and blocking interaction with the search field.