### PR TITLE
Wrap UI on narrow width

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -8,37 +8,36 @@ module.exports =
 class FindView extends View
   @content: ->
     @div tabIndex: -1, class: 'find-and-replace', =>
-      @div class: 'block', =>
-        @span outlet: 'descriptionLabel', class: 'description', 'Find in Current Buffer'
-        @span class: 'options-label pull-right', =>
+      @div class: 'info-block', =>
+        @span outlet: 'descriptionLabel', class: 'info-block-item description', 'Find in Current Buffer'
+        @span class: 'info-block-item options-label pull-right', =>
           @span 'Finding with Options: '
           @span outlet: 'optionsLabel', class: 'options'
 
-      @div class: 'find-container block', =>
-        @div class: 'editor-container', =>
+      @div class: 'input-block find-container', =>
+        @div class: 'input-block-item input-block-item--flex editor-container', =>
           @subview 'findEditor', new TextEditorView(mini: true, placeholderText: 'Find in current buffer')
-
           @div class: 'find-meta-container', =>
             @span outlet: 'resultCounter', class: 'text-subtle result-counter', ''
 
-        @div class: 'btn-group btn-group-find', =>
-          @button outlet: 'nextButton', class: 'btn', 'Find'
+        @div class: 'input-block-item', =>
+          @div class: 'btn-group btn-group-find', =>
+            @button outlet: 'nextButton', class: 'btn', 'Find'
+          @div class: 'btn-group btn-toggle btn-group-options', =>
+            @button outlet: 'regexOptionButton', class: 'btn', '.*'
+            @button outlet: 'caseOptionButton', class: 'btn', 'Aa'
+            @button outlet: 'selectionOptionButton', class: 'btn option-selection', '"'
+            @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', '\\b'
 
-        @div class: 'btn-group btn-toggle btn-group-options', =>
-          @button outlet: 'regexOptionButton', class: 'btn', '.*'
-          @button outlet: 'caseOptionButton', class: 'btn', 'Aa'
-          @button outlet: 'selectionOptionButton', class: 'btn option-selection', '"'
-          @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', '\\b'
-
-      @div class: 'replace-container block', =>
-        @div class: 'editor-container', =>
+      @div class: 'input-block replace-container', =>
+        @div class: 'input-block-item input-block-item--flex editor-container', =>
           @subview 'replaceEditor', new TextEditorView(mini: true, placeholderText: 'Replace in current buffer')
 
-        @div class: 'btn-group btn-group-replace', =>
-          @button outlet: 'replaceNextButton', class: 'btn btn-next', 'Replace'
-
-        @div class: 'btn-group btn-group-replace-all', =>
-          @button outlet: 'replaceAllButton', class: 'btn btn-all', 'Replace All'
+        @div class: 'input-block-item', =>
+          @div class: 'btn-group btn-group-replace', =>
+            @button outlet: 'replaceNextButton', class: 'btn btn-next', 'Replace'
+          @div class: 'btn-group btn-group-replace-all', =>
+            @button outlet: 'replaceAllButton', class: 'btn btn-all', 'Replace All'
 
   initialize: (@findModel, {findHistory, replaceHistory}) ->
     @subscriptions = new CompositeDisposable

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -8,13 +8,13 @@ module.exports =
 class FindView extends View
   @content: ->
     @div tabIndex: -1, class: 'find-and-replace', =>
-      @div class: 'info-block', =>
-        @span outlet: 'descriptionLabel', class: 'info-block-item description', 'Find in Current Buffer'
-        @span class: 'info-block-item options-label pull-right', =>
+      @header class: 'header', =>
+        @span outlet: 'descriptionLabel', class: 'header-item description', 'Find in Current Buffer'
+        @span class: 'header-item options-label pull-right', =>
           @span 'Finding with Options: '
           @span outlet: 'optionsLabel', class: 'options'
 
-      @div class: 'input-block find-container', =>
+      @section class: 'input-block find-container', =>
         @div class: 'input-block-item input-block-item--flex editor-container', =>
           @subview 'findEditor', new TextEditorView(mini: true, placeholderText: 'Find in current buffer')
           @div class: 'find-meta-container', =>
@@ -29,7 +29,7 @@ class FindView extends View
             @button outlet: 'selectionOptionButton', class: 'btn option-selection', '"'
             @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', '\\b'
 
-      @div class: 'input-block replace-container', =>
+      @section class: 'input-block replace-container', =>
         @div class: 'input-block-item input-block-item--flex editor-container', =>
           @subview 'replaceEditor', new TextEditorView(mini: true, placeholderText: 'Replace in current buffer')
 

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -14,17 +14,17 @@ module.exports =
 class ProjectFindView extends View
   @content: ->
     @div tabIndex: -1, class: 'project-find padded', =>
-      @div class: 'info-block', =>
-        @span outlet: 'descriptionLabel', class: 'info-block-item description'
-        @span class: 'info-block-item options-label pull-right', =>
+      @header class: 'header', =>
+        @span outlet: 'descriptionLabel', class: 'header-item description'
+        @span class: 'header-item options-label pull-right', =>
           @span 'Finding with Options: '
           @span outlet: 'optionsLabel', class: 'options'
 
-      @div outlet: 'replacmentInfoBlock', class: 'input-block', =>
+      @section outlet: 'replacmentInfoBlock', class: 'input-block', =>
         @progress outlet: 'replacementProgress', class: 'inline-block'
         @span outlet: 'replacmentInfo', class: 'inline-block', 'Replaced 2 files of 10 files'
 
-      @div class: 'input-block find-container', =>
+      @section class: 'input-block find-container', =>
         @div class: 'input-block-item input-block-item--flex editor-container', =>
           @subview 'findEditor', new TextEditorView(mini: true, placeholderText: 'Find in project')
         @div class: 'input-block-item', =>
@@ -32,14 +32,14 @@ class ProjectFindView extends View
             @button outlet: 'regexOptionButton', class: 'btn option-regex', '.*'
             @button outlet: 'caseOptionButton', class: 'btn option-case-sensitive', 'Aa'
 
-      @div class: 'input-block replace-container', =>
+      @section class: 'input-block replace-container', =>
         @div class: 'input-block-item input-block-item--flex editor-container', =>
           @subview 'replaceEditor', new TextEditorView(mini: true, placeholderText: 'Replace in project')
         @div class: 'input-block-item', =>
           @div class: 'btn-group btn-group-replace-all', =>
             @button outlet: 'replaceAllButton', class: 'btn', 'Replace All'
 
-      @div class: 'input-block paths-container', =>
+      @section class: 'input-block paths-container', =>
         @div class: 'input-block-item editor-container', =>
           @subview 'pathsEditor', new TextEditorView(mini: true, placeholderText: 'File/directory pattern. eg. `src` to search in the "src" directory or `*.js` to search all javascript files.')
 

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -14,33 +14,33 @@ module.exports =
 class ProjectFindView extends View
   @content: ->
     @div tabIndex: -1, class: 'project-find padded', =>
-      @div class: 'block', =>
-        @span class: 'options-label pull-right', =>
+      @div class: 'info-block', =>
+        @span outlet: 'descriptionLabel', class: 'info-block-item description'
+        @span class: 'info-block-item options-label pull-right', =>
           @span 'Finding with Options: '
           @span outlet: 'optionsLabel', class: 'options'
-        @span outlet: 'descriptionLabel', class: 'description'
 
-      @div outlet: 'replacmentInfoBlock', class: 'block', =>
+      @div outlet: 'replacmentInfoBlock', class: 'input-block', =>
         @progress outlet: 'replacementProgress', class: 'inline-block'
         @span outlet: 'replacmentInfo', class: 'inline-block', 'Replaced 2 files of 10 files'
 
-      @div class: 'find-container block', =>
-        @div class: 'editor-container', =>
+      @div class: 'input-block find-container', =>
+        @div class: 'input-block-item input-block-item--flex editor-container', =>
           @subview 'findEditor', new TextEditorView(mini: true, placeholderText: 'Find in project')
+        @div class: 'input-block-item', =>
+          @div class: 'btn-group btn-toggle btn-group-options', =>
+            @button outlet: 'regexOptionButton', class: 'btn option-regex', '.*'
+            @button outlet: 'caseOptionButton', class: 'btn option-case-sensitive', 'Aa'
 
-        @div class: 'btn-group btn-toggle btn-group-options', =>
-          @button outlet: 'regexOptionButton', class: 'btn option-regex', '.*'
-          @button outlet: 'caseOptionButton', class: 'btn option-case-sensitive', 'Aa'
-
-      @div class: 'replace-container block', =>
-        @div class: 'editor-container', =>
+      @div class: 'input-block replace-container', =>
+        @div class: 'input-block-item input-block-item--flex editor-container', =>
           @subview 'replaceEditor', new TextEditorView(mini: true, placeholderText: 'Replace in project')
+        @div class: 'input-block-item', =>
+          @div class: 'btn-group btn-group-replace-all', =>
+            @button outlet: 'replaceAllButton', class: 'btn', 'Replace All'
 
-        @div class: 'btn-group btn-group-replace-all', =>
-          @button outlet: 'replaceAllButton', class: 'btn', 'Replace All'
-
-      @div class: 'paths-container block', =>
-        @div class: 'editor-container', =>
+      @div class: 'input-block paths-container', =>
+        @div class: 'input-block-item editor-container', =>
           @subview 'pathsEditor', new TextEditorView(mini: true, placeholderText: 'File/directory pattern. eg. `src` to search in the "src" directory or `*.js` to search all javascript files.')
 
   initialize: (@findInBufferModel, @model, {findHistory, replaceHistory, pathsHistory}) ->

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -41,39 +41,66 @@ atom-workspace.find-visible {
 // Both project and buffer FNR styles
 .find-and-replace,
 .project-find {
-  .options-label {
-    color: @text-color-subtle;
-    position: relative;
+  min-width: 320px; // fit find input + find-meta-container
+  -webkit-user-select: none;
+  padding: @component-padding / 2;
 
-    .options {
-      color: @text-color;
+  // replaces default blocks, adds wrapping when narrow
+  .info-block {
+    padding: @component-padding/4 @component-padding/2;
+  }
+  .info-block-item {
+    margin: @component-padding/4 0;
+  }
+
+  .input-block {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+  }
+  .input-block-item {
+    flex: 1;
+    padding: @component-padding / 2;
+    display: flex;
+    .btn-group {
+      flex: 1;
+      display: flex;
+      .btn {
+        flex: 1;
+      }
+      & + .btn-group {
+        margin-left: @component-padding;
+      }
     }
   }
 
-  .subtle-info-message {
-    padding-left: 5px;
+  .description {
+    display: inline-block;
+    margin-bottom: .75em;
+    .subtle-info-message {
+      padding-left: 5px;
+      color: @text-color-subtle;
+      .highlight {
+        color: @text-color;
+        font-weight: normal;
+      }
+    }
+  }
+
+  .options-label {
     color: @text-color-subtle;
-    .highlight {
+    position: relative;
+    .options {
       color: @text-color;
-      font-weight: normal;
     }
   }
 
   .find-container,
   .replace-container,
   .paths-container {
-    display: -webkit-flex;
-    -webkit-flex-direction: row;
-
-    .btn-group {
-      margin-left: @component-padding;
-    }
 
     .editor-container {
       position: relative;
-      -webkit-flex: 1;
-      overflow: hidden;
-
       atom-text-editor {
         width: 100%;
       }
@@ -84,44 +111,33 @@ atom-workspace.find-visible {
 
 // Buffer find and replace
 .find-and-replace {
-  @button-width: 240px;
-  @option-button-width: 140px;
-  @find-button-width: @button-width - @option-button-width - @component-padding;
+  @button-width: 120px;
+  @option-button-width: 200px;
 
-  padding: @component-padding;
-  -webkit-user-select: none;
-
-  .btn-group-replace.btn-group {
-    width: @find-button-width;
-    .btn {
-      width: 100%;
-    }
+  .input-block-item {
+    flex: 1 1 260px;
   }
-
+  .input-block-item--flex {
+    flex: 100 1 260px;
+  }
+  .btn-group-replace.btn-group {
+    flex: 1 1 @button-width;
+  }
   .btn-group-replace-all.btn-group {
-    width: @option-button-width;
-    .btn {
-      width: 100%;
-    }
+    flex: 1 1 @option-button-width;
   }
 
   .btn-group-find.btn-group {
-    width: @find-button-width;
-    .btn {
-      width: 100%;
-    }
+    flex: 1 1 @button-width;
   }
   .btn-group-options.btn-group {
-    width: @option-button-width;
+    flex: 1 1 @option-button-width;
+
     .btn {
       .option-button();
-
-      // The -1px margin reduces the size, so add one to those with the neg margin.
-      width: @option-button-width / 4 + 1px;
-      &:first-child {
-        width: @option-button-width / 4;
-      }
-
+      flex: 1 1 25%;
+      padding: 0;
+      text-align: center;
       &.option-selection {
         font-family: "Times New Roman";
         font-size: 20px;
@@ -138,6 +154,7 @@ atom-workspace.find-visible {
     position: absolute;
     top: 1px;
     right: 0;
+    margin: @component-padding/2 @component-padding/2 0 0;
     z-index: 2;
     font-size: .9em;
     line-height: @component-line-height;
@@ -147,17 +164,18 @@ atom-workspace.find-visible {
       margin-right: @component-padding;
     }
   }
-
-  .block {
-    overflow: hidden;
-  }
 }
 
 // Project find and replace
 .project-find {
-  @project-button-width: 90px;
+  @project-button-width: 100px;
 
-  -webkit-user-select: none;
+  .input-block-item {
+    flex: 1 1 @project-button-width;
+  }
+  .input-block-item--flex {
+    flex: 100 1 260px;
+  }
 
   .loading,
   .preview-block,

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -41,7 +41,7 @@ atom-workspace.find-visible {
 // Both project and buffer FNR styles
 .find-and-replace,
 .project-find {
-  @min-width: 100px;           // min width before it starts scrolling
+  @min-width: 200px; // min width before it starts scrolling
 
   -webkit-user-select: none;
   padding: @component-padding/2;

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -41,15 +41,14 @@ atom-workspace.find-visible {
 // Both project and buffer FNR styles
 .find-and-replace,
 .project-find {
-  min-width: 320px; // fit find input + find-meta-container
+  min-width: 320px; // fit find input + result counter
   -webkit-user-select: none;
-  padding: @component-padding / 2;
+  padding: @component-padding/2;
 
-  // replaces default blocks, adds wrapping when narrow
-  .info-block {
+  .header {
     padding: @component-padding/4 @component-padding/2;
   }
-  .info-block-item {
+  .header-item {
     margin: @component-padding/4 0;
   }
 
@@ -59,24 +58,24 @@ atom-workspace.find-visible {
     width: 100%;
   }
   .input-block-item {
+    display: flex;
     flex: 1;
     padding: @component-padding / 2;
+  }
+
+  .btn-group {
     display: flex;
-    .btn-group {
+    flex: 1;
+    .btn {
       flex: 1;
-      display: flex;
-      .btn {
-        flex: 1;
-      }
-      & + .btn-group {
-        margin-left: @component-padding;
-      }
+    }
+    & + .btn-group {
+      margin-left: @component-padding;
     }
   }
 
   .description {
     display: inline-block;
-    margin-bottom: .75em;
     .subtle-info-message {
       padding-left: 5px;
       color: @text-color-subtle;
@@ -95,15 +94,10 @@ atom-workspace.find-visible {
     }
   }
 
-  .find-container,
-  .replace-container,
-  .paths-container {
-
-    .editor-container {
-      position: relative;
-      atom-text-editor {
-        width: 100%;
-      }
+  .editor-container {
+    position: relative;
+    atom-text-editor {
+      width: 100%;
     }
   }
 
@@ -111,28 +105,27 @@ atom-workspace.find-visible {
 
 // Buffer find and replace
 .find-and-replace {
-  @button-width: 120px;
-  @option-button-width: 200px;
+  @button-width: 120px;        // Find + Replace buttons
+  @option-button-width: 200px; // Replace All + option buttons
+  @item-width: 260px;          // wrap block width
 
   .input-block-item {
-    flex: 1 1 260px;
+    flex: 1 1 @item-width;
   }
   .input-block-item--flex {
-    flex: 100 1 260px;
+    flex: 100 1 @item-width;
   }
-  .btn-group-replace.btn-group {
+
+  .btn-group-find,
+  .btn-group-replace {
     flex: 1 1 @button-width;
   }
-  .btn-group-replace-all.btn-group {
+  .btn-group-replace-all,
+  .btn-group-options {
     flex: 1 1 @option-button-width;
   }
 
-  .btn-group-find.btn-group {
-    flex: 1 1 @button-width;
-  }
-  .btn-group-options.btn-group {
-    flex: 1 1 @option-button-width;
-
+  .btn-group-options {
     .btn {
       .option-button();
       flex: 1 1 25%;
@@ -143,13 +136,13 @@ atom-workspace.find-visible {
         font-size: 20px;
         padding-top: 3px;
       }
-
       &.option-whole-word {
         font-size: 13px;
       }
     }
   }
 
+  // results count
   .find-meta-container {
     position: absolute;
     top: 1px;
@@ -159,7 +152,6 @@ atom-workspace.find-visible {
     font-size: .9em;
     line-height: @component-line-height;
     pointer-events: none;
-
     .result-counter {
       margin-right: @component-padding;
     }
@@ -168,13 +160,14 @@ atom-workspace.find-visible {
 
 // Project find and replace
 .project-find {
+  @project-input-width: 260px;
   @project-button-width: 100px;
 
   .input-block-item {
     flex: 1 1 @project-button-width;
   }
   .input-block-item--flex {
-    flex: 100 1 260px;
+    flex: 100 1 @project-input-width;
   }
 
   .loading,
@@ -184,19 +177,15 @@ atom-workspace.find-visible {
     display: none;
   }
 
-  .btn-group.btn-group-options {
+  .btn-group-options {
     width: @project-button-width;
     .btn {
       .option-button();
-      width: 50%;
     }
   }
 
-  .btn-group.btn-group-replace-all {
+  .btn-group-replace-all {
     width: @project-button-width;
-    .btn {
-      width: 100%;
-    }
   }
 }
 

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -41,12 +41,15 @@ atom-workspace.find-visible {
 // Both project and buffer FNR styles
 .find-and-replace,
 .project-find {
-  min-width: 320px; // fit find input + result counter
+  @min-width: 100px;           // min width before it starts scrolling
+
   -webkit-user-select: none;
   padding: @component-padding/2;
+  overflow-x: scroll;
 
   .header {
     padding: @component-padding/4 @component-padding/2;
+    min-width: @min-width;
   }
   .header-item {
     margin: @component-padding/4 0;
@@ -56,6 +59,7 @@ atom-workspace.find-visible {
     display: flex;
     flex-wrap: wrap;
     width: 100%;
+    min-width: @min-width;
   }
   .input-block-item {
     display: flex;
@@ -140,6 +144,10 @@ atom-workspace.find-visible {
         font-size: 13px;
       }
     }
+  }
+
+  .find-container atom-text-editor {
+    padding-right: 64px; // leave some room for the results count
   }
 
   // results count


### PR DESCRIPTION
This is a continuation of PR #359.

If the width gets too narrow, the mini editors wrap to a new row and the buttons stretch full width. Not that likely people use it that narrow, but still looks less broken.

Before:

![screen shot 2015-03-06 at 9 54 02 am](https://cloud.githubusercontent.com/assets/378023/6518209/20512d70-c3e7-11e4-8db2-e3475ad7a47b.png)

After:

![far](https://cloud.githubusercontent.com/assets/378023/6518212/2684a2da-c3e7-11e4-9cfd-2f60c37ccb9e.gif)
