### PR TITLE
Add setting to disable livesearch

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -177,8 +177,15 @@ class FindView extends View
     @findPrevious(focusEditorAfter: atom.config.get('find-and-replace.focusEditorAfterSearch'))
 
   liveSearch: ->
-    pattern = @findEditor.getText()
-    @updateModel { pattern }
+    if atom.config.get('find-and-replace.liveSearch')
+      pattern = @findEditor.getText()
+      @updateModel { pattern }
+    else
+      pattern = @findEditor.getText()
+      editor = this
+      updateModel = () ->
+        editor.updateModel { pattern } if editor.findEditor.getText() == pattern
+      setTimeout(updateModel, 750)
 
   findAll: (options={focusEditorAfter: true}) =>
     @findAndSelectResult(@selectAllMarkers, options)

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -17,6 +17,10 @@ module.exports =
     openProjectFindResultsInRightPane:
       type: 'boolean'
       default: false
+    liveSearch:
+      type: 'boolean'
+      default: true
+
 
   activate: ({@viewState, @projectViewState, @resultsModelState, @modelState, findHistory, replaceHistory, pathsHistory}={}) ->
     atom.workspace.addOpener (filePath) =>


### PR DESCRIPTION
I added a setting for livesearch. When enabled (by default, it is enabled) the existing behavior for searching occurs.

When disabled, the search waits a small amount of time (750ms seemed reasonable in my tests), and checks to see if the user input any further search text. If so, the model is not updated. If no additional text was entered, the search results are highlighted.

A possible enhancement might be to detect if the user is editing a large file and automatically disabling live search for only that file.

Sorry if the code is not perfect, I have no previous coffeescript experience.
