### PR TITLE
Fix issue with interface breaking in small windows

### DIFF
--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -13,11 +13,11 @@ module.exports =
 class ProjectFindView extends View
   @content: ->
     @div tabIndex: -1, class: 'project-find padded', =>
-      @div class: 'block', =>
+      @div class: 'find-header block', =>
+        @span outlet: 'descriptionLabel', class: 'description'
         @span class: 'options-label pull-right', =>
           @span 'Finding with Options: '
           @span outlet: 'optionsLabel', class: 'options'
-        @span outlet: 'descriptionLabel', class: 'description'
 
       @div outlet: 'replacmentInfoBlock', class: 'block', =>
         @progress outlet: 'replacementProgress', class: 'inline-block'

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -59,6 +59,16 @@ atom-workspace.find-visible {
     }
   }
 
+  .find-header {
+    white-space: nowrap;
+
+    &:after {
+      display: block;
+      clear: both;
+      content: "";
+    }
+  }
+
   .find-container,
   .replace-container,
   .paths-container {


### PR DESCRIPTION
This fixes an issue and a related inconsistency in the display of the text at the top of the find panel, that occurs when the window is small enough that not all of the text fits.

There are other solutions (like letting the text overlap), but I think mine is not horribly intrusive, still readable, and fixes the issue at hand of the search box being broken by the floating text wrapping.

Before:
![screen shot 2015-04-01 at 7 03 13 pm](https://cloud.githubusercontent.com/assets/491376/6957471/449984b0-d8b0-11e4-81b6-f0a1416a1b54.png)
![screen shot 2015-04-01 at 7 03 01 pm](https://cloud.githubusercontent.com/assets/491376/6957475/49ae4fa8-d8b0-11e4-8082-01c45d066241.png)

After:
![screen shot 2015-04-01 at 8 49 54 pm](https://cloud.githubusercontent.com/assets/491376/6957508/b4674408-d8b0-11e4-95d0-ccf560162de6.png)
![screen shot 2015-04-01 at 8 50 05 pm](https://cloud.githubusercontent.com/assets/491376/6957510/b6cdf9f8-d8b0-11e4-9073-e630a5f36b37.png)
