### PR TITLE
Implement find-next/previous-selected functionality

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -11,6 +11,8 @@
 '.platform-darwin atom-text-editor':
   'cmd-g': 'find-and-replace:find-next'
   'cmd-G': 'find-and-replace:find-previous'
+  'cmd-f3': 'find-and-replace:find-next-selected'
+  'cmd-shift-f3': 'find-and-replace:find-previous-selected'
   'cmd-ctrl-g': 'find-and-replace:select-all'
   'cmd-d': 'find-and-replace:select-next'
   'cmd-e': 'find-and-replace:use-selection-as-find-pattern'
@@ -20,6 +22,8 @@
 '.platform-win32 atom-text-editor, .platform-linux atom-text-editor':
   'f3': 'find-and-replace:find-next'
   'shift-f3': 'find-and-replace:find-previous'
+  'ctrl-f3': 'find-and-replace:find-next-selected'
+  'ctrl-shift-f3': 'find-and-replace:find-previous-selected'
   'alt-f3': 'find-and-replace:select-all'
   'ctrl-d': 'find-and-replace:select-next'
   'ctrl-e': 'find-and-replace:use-selection-as-find-pattern'

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -142,6 +142,8 @@ class FindView extends View
     @subscriptions.add atom.commands.add 'atom-workspace',
       'find-and-replace:find-next': => @findNext(focusEditorAfter: true)
       'find-and-replace:find-previous': => @findPrevious(focusEditorAfter: true)
+      'find-and-replace:find-next-selected': @findNextSelected
+      'find-and-replace:find-previous-selected': @findPreviousSelected
       'find-and-replace:use-selection-as-find-pattern': @setSelectionAsFindPattern
 
   handleReplaceEvents: ->
@@ -330,8 +332,16 @@ class FindView extends View
   setSelectionAsFindPattern: =>
     editor = @findModel.getEditor()
     if editor?
-      pattern = editor.getSelectedText()
-      @updateModel {pattern}
+      pattern = editor.getSelectedText() or editor.getWordUnderCursor()
+      @updateModel {pattern} if pattern
+
+  findNextSelected: =>
+    @setSelectionAsFindPattern()
+    @findNext(focusEditorAfter: true)
+
+  findPreviousSelected: =>
+    @setSelectionAsFindPattern()
+    @findPrevious(focusEditorAfter: true)
 
   updateOptionsLabel: ->
     label = []

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -268,6 +268,6 @@ class ProjectFindView extends View
 
   setSelectionAsFindPattern: =>
     editor = atom.workspace.getActivePaneItem()
-    if editor?.getSelectedText?
-      pattern = editor.getSelectedText()
-      @findEditor.setText(pattern)
+    if editor?
+      pattern = editor.getSelectedText() or editor.getWordUnderCursor()
+      @findEditor.setText(pattern) if pattern

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
       "find-and-replace:toggle",
       "find-and-replace:find-next",
       "find-and-replace:find-previous",
+      "find-and-replace:find-next-selected",
+      "find-and-replace:find-previous-selected",
       "find-and-replace:use-selection-as-find-pattern",
       "find-and-replace:show-replace",
       "find-and-replace:replace-next",

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -484,20 +484,70 @@ describe 'FindView', ->
       editor.setSelectedBufferRange([[2, 34], [2, 39]])
       expect(findView.resultCounter.text()).toEqual('3 of 6')
 
-    it "places the selected text into the find editor when find-and-replace:set-find-pattern is triggered", ->
-      editor.setSelectedBufferRange([[1,6],[1,10]])
-      atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
+    describe "when find-and-replace:use-selection-as-find-pattern is triggered", ->
+      it "places the selected text into the find editor", ->
+        editor.setSelectedBufferRange([[1,6],[1,10]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
 
-      expect(findView.findEditor.getText()).toBe 'sort'
-      expect(editor.getSelectedBufferRange()).toEqual [[1,6],[1,10]]
+        expect(findView.findEditor.getText()).toBe 'sort'
+        expect(editor.getSelectedBufferRange()).toEqual [[1,6],[1,10]]
 
-      atom.commands.dispatch workspaceElement, 'find-and-replace:find-next'
-      expect(editor.getSelectedBufferRange()).toEqual [[8,11],[8,15]]
+        atom.commands.dispatch workspaceElement, 'find-and-replace:find-next'
+        expect(editor.getSelectedBufferRange()).toEqual [[8,11],[8,15]]
 
-      atom.workspace.destroyActivePane()
-      atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
-      expect(findView.findEditor.getText()).toBe 'sort'
-      expect(editor.getSelectedBufferRange()).toEqual [[8,11],[8,15]]
+        atom.workspace.destroyActivePane()
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
+        expect(findView.findEditor.getText()).toBe 'sort'
+        expect(editor.getSelectedBufferRange()).toEqual [[8,11],[8,15]]
+
+      it "places the word under the cursor into the find editor", ->
+        editor.setSelectedBufferRange([[1,8],[1,8]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
+
+        expect(findView.findEditor.getText()).toBe 'sort'
+        expect(editor.getSelectedBufferRange()).toEqual [[1,8],[1,8]]
+
+        atom.commands.dispatch workspaceElement, 'find-and-replace:find-next'
+        expect(editor.getSelectedBufferRange()).toEqual [[8,11],[8,15]]
+
+      it "places the previously selected text into the find editor if no selection", ->
+        editor.setSelectedBufferRange([[1,6],[1,10]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
+        expect(findView.findEditor.getText()).toBe 'sort'
+
+        editor.setSelectedBufferRange([[1,1],[1,1]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
+        expect(findView.findEditor.getText()).toBe 'sort'
+
+    describe "when find-and-replace:find-next-selected is triggered", ->
+      it "places the selected text into the find editor and finds the next occurrence", ->
+        editor.setSelectedBufferRange([[0,9],[0,13]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:find-next-selected'
+
+        expect(findView.findEditor.getText()).toBe 'sort'
+        expect(editor.getSelectedBufferRange()).toEqual [[1,6],[1,10]]
+
+      it "places the word under the cursor into the find editor and finds the next occurrence", ->
+        editor.setSelectedBufferRange([[1,8],[1,8]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:find-next-selected'
+
+        expect(findView.findEditor.getText()).toBe 'sort'
+        expect(editor.getSelectedBufferRange()).toEqual [[8,11],[8,15]]
+
+    describe "when find-and-replace:find-previous-selected is triggered", ->
+      it "places the selected text into the find editor and finds the previous occurrence ", ->
+        editor.setSelectedBufferRange([[0,9],[0,13]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:find-previous-selected'
+
+        expect(findView.findEditor.getText()).toBe 'sort'
+        expect(editor.getSelectedBufferRange()).toEqual [[11,9],[11,13]]
+
+      it "places the word under the cursor into the find editor and finds the previous occurrence", ->
+        editor.setSelectedBufferRange([[8,13],[8,13]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:find-previous-selected'
+
+        expect(findView.findEditor.getText()).toBe 'sort'
+        expect(editor.getSelectedBufferRange()).toEqual [[1,6],[1,10]]
 
     it "does not highlight the found text when the find view is hidden", ->
       atom.commands.dispatch(findView.findEditor.element, 'core:cancel')

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -703,7 +703,7 @@ describe 'ProjectFindView', ->
         atom.commands.dispatch(projectFindView.replaceEditor[0], 'core:move-down')
         expect(projectFindView.replaceEditor.getText()).toEqual ''
 
-    describe "when find-and-replace:set-find-pattern is triggered", ->
+    describe "when find-and-replace:use-selection-as-find-pattern is triggered", ->
       it "places the selected text into the find editor", ->
         editor.setSelectedBufferRange([[1,6],[1,10]])
         atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
@@ -713,14 +713,23 @@ describe 'ProjectFindView', ->
         atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
         expect(projectFindView.findEditor.getText()).toBe 'function'
 
-      it "places the previously selected text into the find editor if no selection", ->
+      it "places the word under the cursor into the find editor", ->
+        editor.setSelectedBufferRange([[1,8],[1,8]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
+        expect(projectFindView.findEditor.getText()).toBe 'sort'
+
+        editor.setSelectedBufferRange([[1,15],[1,15]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
+        expect(projectFindView.findEditor.getText()).toBe 'function'
+
+      it "places the previously selected text into the find editor if no selection and no word under cursor", ->
         editor.setSelectedBufferRange([[1,13],[1,21]])
         atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
         expect(projectFindView.findEditor.getText()).toBe 'function'
 
-        editor.setSelectedBufferRange([[1,30],[1,30]])
+        editor.setSelectedBufferRange([[1,1],[1,1]])
         atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
-        expect(projectFindView.findEditor.getText()).toBe ''
+        expect(projectFindView.findEditor.getText()).toBe 'function'
 
     describe "when there is an error searching", ->
       it "displays the errors in the results pane", ->


### PR DESCRIPTION
Add ability to search for the next and previous occurrence of the
current selection or the word containing the cursor in the absence
of a selection. This behaviour, and associated keybindings, is
identical to that of Sublime Text and Visual Studio, among others.

This change also makes the use-selection-as-find-pattern
command use the word containing the cursor in the absence of a
selection instead of simply clearing the existing search pattern, so
that the behaviour is consistent (and code can be reused internally).

This change implements the enhancement described in issue #210.