### PR TITLE
Only show scrollbar when there is overflow

### DIFF
--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -45,7 +45,7 @@ atom-workspace.find-visible {
 
   -webkit-user-select: none;
   padding: @component-padding/2;
-  overflow-x: scroll;
+  overflow-x: auto;
 
   .header {
     padding: @component-padding/4 @component-padding/2;


### PR DESCRIPTION
There seems to be an always present scrollbar at the bottom of the panel, you can see it here on two different themes (atom-dark-ui and outlander-ui):

![before-1](https://cloud.githubusercontent.com/assets/2635560/7466372/8419e7a6-f296-11e4-98bb-c4465e8f4fef.png)
![before-2](https://cloud.githubusercontent.com/assets/2635560/7466371/8419bb6e-f296-11e4-8358-9867c8053851.png)

Its still there on other themes like one-dark, however it is hard to see since the `::--webkit
-scrollbar-track` has the same background-color as it's container. Here is what it looks like with this change: 

![after-1](https://cloud.githubusercontent.com/assets/2635560/7466377/9078a942-f296-11e4-95ec-62977ff77d9c.png)
![after-2](https://cloud.githubusercontent.com/assets/2635560/7466378/9079093c-f296-11e4-9429-3627284b62a5.png)

The scrollbar still appears when the content reaches the `@min-width: 200px`, so that part will still work. 

This is all assuming that we don't want to want to always show the scrollbar track. If `overflow-x` was set to `scroll` intentionally for this reason, than I suppose this change can be disregarded. However, I would say that it looks much better this way. 

Thanks, and let me know if I missed anything!

Note: Reproduced/Tested on OSX (10.10.3) and Linux (Arch + Gnome 3.16).