### PR TITLE
Add tooltip to whole word button

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -110,6 +110,10 @@ class FindView extends View
       title: "Only In Selection",
       keyBindingCommand: 'find-and-replace:toggle-selection-option',
       keyBindingTarget: @findEditor.element
+    subs.add atom.tooltips.add @wholeWordOptionButton,
+      title: "Whole Word",
+      keyBindingCommand: 'find-and-replace:toggle-whole-word-option',
+      keyBindingTarget: @findEditor.element
 
     subs.add atom.tooltips.add @nextButton,
       title: "Find Next",


### PR DESCRIPTION
There are currently tooltips for all buttons in the find view except the "whole word" option button. This PR adds the tooltip to that button to match the others in that view. 