### PR TITLE
Fix accidental reassignment of path var

### DIFF
--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -210,7 +210,7 @@ class ProjectFindView extends View
         @model.replace(pattern, @getPaths(), replacementPattern, @model.getPaths())
 
   getPaths: ->
-    path.trim() for path in @pathsEditor.getText().trim().split(',') when path
+    inputPath.trim() for inputPath in @pathsEditor.getText().trim().split(',') when inputPath
 
   directoryPathForElement: (element) ->
     elementPath = element?.dataset.path ? element?.querySelector('[data-path]')?.dataset.path


### PR DESCRIPTION
Fixes a bug that caused exception to be thrown if you used the `Search in Directory` context menu command from the tree-view after already performing a project search. 