### PR TITLE
Re-scan only changed region when buffer changes

### DIFF
--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -1,0 +1,193 @@
+_ = require 'underscore-plus'
+{Point, Emitter, CompositeDisposable, TextBuffer} = require 'atom'
+{Patch} = TextBuffer
+escapeHelper = require './escape-helper'
+
+SearchParams = [
+  'useRegex',
+  'pattern',
+  'caseSensitive',
+  'wholeWord',
+  'inCurrentSelection'
+]
+
+module.exports =
+class BufferSearch
+  @markerClass: 'find-result'
+
+  constructor: (searchParams={}) ->
+    @emitter = new Emitter
+    @patch = new Patch
+    @subscriptions = null
+    @markers = []
+    @editor = null
+    @setSearchParams(_.defaults({}, searchParams, {
+      pattern: "",
+      useRegex: atom.config.get('find-and-replace.useRegex') ? false
+      wholeWord: atom.config.get('find-and-replace.wholeWord') ? false
+      caseSensitive: atom.config.get('find-and-replace.caseSensitive') ? false
+      inCurrentSelection: atom.config.get('find-and-replace.inCurrentSelection') ? false
+    }))
+
+  onDidUpdate: (callback) ->
+    @emitter.on 'did-update', callback
+
+  onDidError: (callback) ->
+    @emitter.on 'did-error', callback
+
+  onDidChangeCurrentResult: (callback) ->
+    @emitter.on 'did-change-current-result', callback
+
+  setEditor: (@editor) ->
+    @subscriptions?.dispose()
+    if @editor?
+      @subscriptions = new CompositeDisposable
+      @subscriptions.add @editor.buffer.onDidChange(@bufferChanged.bind(this))
+      @subscriptions.add @editor.buffer.onDidStopChanging(@bufferStoppedChanging.bind(this))
+      @subscriptions.add @editor.onDidAddSelection(@setCurrentMarkerFromSelection.bind(this))
+      @subscriptions.add @editor.onDidChangeSelectionRange(@setCurrentMarkerFromSelection.bind(this))
+    @recreateMarkers()
+
+  getEditor: -> @editor
+
+  setSearchParams: (newParams={}) ->
+    changed = false
+    for key in SearchParams
+      if newParams[key]? and newParams[key] isnt this[key]
+        this[key] = newParams[key]
+        changed = true
+    @recreateMarkers() if changed
+
+  replace: (markers, replacementPattern) ->
+    return unless markers?.length > 0
+
+    @replacing = true
+    @editor.transact =>
+      for marker in markers
+        bufferRange = marker.getBufferRange()
+        replacementText = null
+        if @useRegex
+          replacementPattern = escapeHelper.unescapeEscapeSequence(replacementPattern)
+          textToReplace = @editor.getTextInBufferRange(bufferRange)
+          replacementText = textToReplace.replace(@getRegex(), replacementPattern)
+        @editor.setTextInBufferRange(bufferRange, replacementText ? replacementPattern)
+
+        marker.destroy()
+        @markers.splice(@markers.indexOf(marker), 1)
+    @replacing = false
+
+    @emitter.emit 'did-update', _.clone(@markers)
+
+  serialize: ->
+    {@useRegex, @inCurrentSelection, @caseSensitive, @wholeWord}
+
+  destroy: ->
+    @subscriptions?.dispose()
+
+  ###
+  Section: Private
+  ###
+
+  recreateMarkers: ->
+    @markers.forEach (marker) -> marker.destroy()
+    @markers.length = 0
+    @decorationsByMarkerId = {}
+    @emitter.emit "did-update", []
+    @createMarkers(0, Point.ZERO, Point.INFINITY)
+
+  createMarkers: (index, start, end) ->
+    if @pattern and @editor
+      if @inCurrentSelection
+        selectedRange = @editor.getSelectedBufferRange()
+        start = Point.max(start, selectedRange.start)
+        end = Point.min(end, selectedRange.end)
+
+      if regex = @getRegex()
+        @editor.scanInBufferRange regex, [start, end], ({range}) =>
+          @createMarker(index, range)
+          index++
+        @emitter.emit "did-update", @markers.slice()
+
+  bufferStoppedChanging: ->
+    return if @replacing
+    markerIndex = 0
+    changes = @patch.changes()
+    until (next = changes.next()).done
+      changeStart = next.value.position
+      changeEnd = next.value.position.traverse(next.value.newExtent)
+
+      while @markers[markerIndex]?.getBufferRange().end.isLessThan(changeStart)
+        markerIndex++
+
+      startPosition = @markers[markerIndex - 1]?.getBufferRange().end ? Point.ZERO
+      endPosition = @markers[markerIndex]?.getBufferRange().start ? Point.INFINITY
+      @createMarkers(markerIndex, startPosition, endPosition)
+    @patch.clear()
+
+  setCurrentMarkerFromSelection: ->
+    marker = null
+    marker = @findMarker(@editor.getSelectedBufferRange()) if @editor?
+
+    return if marker is @currentResultMarker
+
+    if @currentResultMarker?
+      @decorationsByMarkerId[@currentResultMarker.id]?.setProperties(type: 'highlight', class: @constructor.markerClass)
+      @currentResultMarker = null
+
+    if marker and not marker.isDestroyed()
+      @decorationsByMarkerId[marker.id]?.setProperties(type: 'highlight', class: 'current-result')
+      @currentResultMarker = marker
+
+    @emitter.emit 'did-change-current-result', @currentResultMarker
+
+  findMarker: (range) ->
+    if @markers?.length > 0
+      @editor.findMarkers(
+        class: @constructor.markerClass,
+        startPosition: range.start,
+        endPosition: range.end
+      )[0]
+
+  createMarker: (index, range) ->
+    marker = @editor.markBufferRange(range,
+      invalidate: 'inside'
+      class: @constructor.markerClass
+      persistent: false
+    )
+
+    marker.onDidChange ({isValid}) =>
+      unless isValid
+        marker.destroy()
+        @markers.splice(@markers.indexOf(marker), 1)
+        delete @decorationsByMarkerId[marker.id]
+
+    @markers.splice(index, 0, marker)
+    @decorationsByMarkerId[marker.id] = @editor.decorateMarker(marker,
+      type: 'highlight',
+      class: @constructor.markerClass
+    )
+
+  bufferChanged: ({oldRange, newRange, newText}) ->
+    @patch.splice(
+      oldRange.start,
+      oldRange.getExtent(),
+      newRange.getExtent(),
+      newText
+    )
+
+  getRegex: ->
+    flags = 'g'
+    flags += 'i' unless @caseSensitive
+
+    if @useRegex
+      expression = @pattern
+    else
+      expression = _.escapeRegExp(@pattern)
+
+    expression = "\\b#{expression}\\b" if @wholeWord
+
+    try
+      new RegExp(expression, flags)
+    catch e
+      @emitter.emit 'did-error', e
+      null

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -1,7 +1,6 @@
 _ = require 'underscore-plus'
 {$$$, View, TextEditorView} = require 'atom-space-pen-views'
 {CompositeDisposable} = require 'atom'
-FindModel = require './find-model'
 {HistoryCycler} = require './history'
 
 module.exports =
@@ -294,7 +293,7 @@ class FindView extends View
     @setErrorMessage(error.message)
 
   updateModel: (options) ->
-    @findModel.update(options)
+    @findModel.setSearchParams(options)
 
   updateResultCounter: =>
     if @findModel.currentResultMarker and (index = @markers.indexOf(@findModel.currentResultMarker)) > -1

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -3,7 +3,7 @@
 
 SelectNext = require './select-next'
 {History} = require './history'
-FindModel = require './find-model'
+BufferSearch = require './buffer-search'
 FindView = require './find-view'
 ProjectFindView = require './project-find-view'
 ResultsModel = require './project/results-model'
@@ -23,7 +23,14 @@ module.exports =
       new ResultsPaneView() if filePath is ResultsPaneView.URI
 
     @subscriptions = new CompositeDisposable
-    @findModel = new FindModel(@modelState)
+
+    @findModel = new BufferSearch(@modelState)
+    @subscriptions.add atom.workspace.observeActivePaneItem (paneItem) =>
+      if paneItem?.getBuffer?()
+        @findModel.setEditor(paneItem)
+      else
+        @findModel.setEditor(null)
+
     @resultsModel = new ResultsModel(@resultsModelState)
     @findHistory = new History(findHistory)
     @replaceHistory = new History(replaceHistory)
@@ -142,7 +149,7 @@ module.exports =
     @findPanel = null
     @findView?.destroy()
     @findView = null
-
+    @findModel?.destroy()
     @findModel = null
 
     @projectFindPanel?.destroy()

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -190,7 +190,7 @@ class ProjectFindView extends View
     return Q() if onlyRunIfActive and not @model.active
 
     pattern = @findEditor.getText()
-    @findInBufferModel.update {pattern}
+    @findInBufferModel.setSearchParams({pattern})
 
     @clearMessages()
     @showResultPane().then =>

--- a/spec/buffer-search-spec.coffee
+++ b/spec/buffer-search-spec.coffee
@@ -1,0 +1,160 @@
+{TextEditor} = require 'atom'
+BufferSearch = require '../lib/buffer-search'
+
+describe "BufferSearch", ->
+  [search, editor, markersListener] = []
+
+  beforeEach ->
+    editor = new TextEditor
+
+    editor.setText """
+      -----------
+      aaa bbb ccc
+      ddd aaa bbb
+      ccc ddd aaa
+      -----------
+      aaa bbb ccc
+      ddd aaa bbb
+      ccc ddd aaa
+      -----------
+    """
+
+    search = new BufferSearch
+
+    markersListener = jasmine.createSpy('markersListener')
+    search.onDidUpdate(markersListener)
+
+    search.setEditor(editor)
+    search.setSearchParams(
+      pattern: "a+"
+      caseSensitive: false
+      useRegex: true
+      wholeWord: false
+    )
+
+  afterEach ->
+    search.destroy()
+    editor.destroy()
+
+  expectResultsUpdated = (expectEvent, ranges) ->
+    highlightedRanges = editor
+      .getDecorations(type: 'highlight', class: 'find-result')
+      .map (decoration) -> decoration.getMarker().getBufferRange()
+      .sort (a, b) -> a.compare(b)
+      .map (range) -> range.serialize()
+    expect(highlightedRanges).toEqual(ranges)
+
+    if expectEvent
+      emittedMarkerRanges = markersListener
+        .mostRecentCall.args[0]
+        .map (marker) -> marker.getBufferRange().serialize()
+      expect(emittedMarkerRanges).toEqual(ranges)
+
+  it "highlights all the occurrences of the search regexp", ->
+    expectResultsUpdated false, [
+      [[1, 0], [1, 3]]
+      [[2, 4], [2, 7]]
+      [[3, 8], [3, 11]]
+      [[5, 0], [5, 3]]
+      [[6, 4], [6, 7]]
+      [[7, 8], [7, 11]]
+    ]
+
+  describe "when the buffer changes", ->
+    describe "when changes occur in the middle of the buffer", ->
+      it "removes any invalidated search results and recreates markers in the changed regions", ->
+        editor.setCursorBufferPosition([2, 5])
+        editor.addCursorAtBufferPosition([6, 5])
+        editor.insertText(".")
+        editor.insertText(".")
+
+        expectResultsUpdated false, [
+          [[1, 0], [1, 3]]
+          [[3, 8], [3, 11]]
+          [[5, 0], [5, 3]]
+          [[7, 8], [7, 11]]
+        ]
+
+        spyOn(editor, 'scanInBufferRange').andCallThrough()
+        advanceClock(editor.buffer.stoppedChangingDelay)
+
+        expectResultsUpdated true, [
+          [[1, 0], [1, 3]]
+          [[2, 4], [2, 5]]
+          [[2, 7], [2, 9]]
+          [[3, 8], [3, 11]]
+          [[5, 0], [5, 3]]
+          [[6, 4], [6, 5]]
+          [[6, 7], [6, 9]]
+          [[7, 8], [7, 11]]
+        ]
+
+        scannedRanges = (args[1] for args in editor.scanInBufferRange.argsForCall)
+        expect(scannedRanges).toEqual [
+          [[1, 3], [3, 8]]
+          [[5, 3], [7, 8]]
+        ]
+
+    describe "when changes occur within the first search result", ->
+      it "rescans the buffer from the beginning to the first valid marker", ->
+        editor.setCursorBufferPosition([1, 2])
+        editor.insertText(".")
+        editor.insertText(".")
+
+        expectResultsUpdated false, [
+          [[2, 4], [2, 7]]
+          [[3, 8], [3, 11]]
+          [[5, 0], [5, 3]]
+          [[6, 4], [6, 7]]
+          [[7, 8], [7, 11]]
+        ]
+
+        spyOn(editor, 'scanInBufferRange').andCallThrough()
+        advanceClock(editor.buffer.stoppedChangingDelay)
+
+        expectResultsUpdated true, [
+          [[1, 0], [1, 2]]
+          [[1, 4], [1, 5]]
+          [[2, 4], [2, 7]]
+          [[3, 8], [3, 11]]
+          [[5, 0], [5, 3]]
+          [[6, 4], [6, 7]]
+          [[7, 8], [7, 11]]
+        ]
+
+        scannedRanges = (args[1] for args in editor.scanInBufferRange.argsForCall)
+        expect(scannedRanges).toEqual [
+          [[0, 0], [2, 4]]
+        ]
+
+    describe "when changes occur within the last search result", ->
+      it "rescans the buffer from the last valid marker to the end", ->
+        editor.setCursorBufferPosition([7, 9])
+        editor.insertText(".")
+        editor.insertText(".")
+
+        expectResultsUpdated false, [
+          [[1, 0], [1, 3]]
+          [[2, 4], [2, 7]]
+          [[3, 8], [3, 11]]
+          [[5, 0], [5, 3]]
+          [[6, 4], [6, 7]]
+        ]
+
+        spyOn(editor, 'scanInBufferRange').andCallThrough()
+        advanceClock(editor.buffer.stoppedChangingDelay)
+
+        expectResultsUpdated true, [
+          [[1, 0], [1, 3]]
+          [[2, 4], [2, 7]]
+          [[3, 8], [3, 11]]
+          [[5, 0], [5, 3]]
+          [[6, 4], [6, 7]]
+          [[7, 8], [7, 9]]
+          [[7, 11], [7, 13]]
+        ]
+
+        scannedRanges = (args[1] for args in editor.scanInBufferRange.argsForCall)
+        expect(scannedRanges).toEqual [
+          [[6, 7], [Infinity, Infinity]]
+        ]


### PR DESCRIPTION
:warning: Depends on Atom features that won't be released until 0.202 :warning:

## Problem

Currently, whenever a buffer stops changing, we re-scan the entire buffer for strings matching our search. This can take a long time and can delay the UI responding to typing.

Here's a flame graph taken while typing in the middle of jQuery 2.0.3 (88,000) lines while searching for the string `e` (20769 results). Rescanning took **681 ms**.

![before](https://cloud.githubusercontent.com/assets/326587/7762096/31dca8b0-ffe4-11e4-87d4-21fb31055c15.png)

## After

This new approach is to keep track of the buffer changes that occur between scans, and only rescan the changed regions.

Here's a flame graph for the same operation as above. Rescanning took **8 ms**.

![after](https://cloud.githubusercontent.com/assets/326587/7762116/7cceb1a6-ffe4-11e4-89c2-83d3cfbee3e4.png)

This uses a new (and for the time being, undocumented) feature of `text-buffer`: the `Patch` class that allows text changes to be aggregated and grouped (see https://github.com/atom/text-buffer/pull/62).