### PR TITLE
Make project search pluggable via DefaultSearchDirectoryProvider.

### DIFF
--- a/lib/project/default-search-directory-provider.coffee
+++ b/lib/project/default-search-directory-provider.coffee
@@ -1,0 +1,51 @@
+module.exports =
+class DefaultSearchDirectoryProvider
+  # Public: Determines whether this provider supports search for a `Directory`.
+  #
+  # * `directory` {Directory} whose search needs might be supported by this provider.
+  #
+  # Returns a `boolean` indicating whether this provider can search this `Directory`.
+  canSearchDirectory: (directory) -> true
+
+  # Public: Performs a text search for files in the specified `Directory`, subject to the
+  # specified parameters.
+  #
+  # Results are streamed back to the caller via `recordSearchResult()` and `recordSearchError()`.
+  #
+  # * `directory` {Directory} that has been accepted by this provider's `canSearchDirectory()`
+  # predicate.
+  # * `regex` {RegExp} to search with. (Note this reflects the "Use Regex" and "Match Case" options
+  # exposed via the ProjectFindView UI.)
+  # * `recordNumPathsSearched` {Function} callback that should be invoked periodically with the number of
+  # paths searched.
+  # * `recordSearchResult` {Function} Should be called with each matching search result.
+  #   * `searchResult` {Object} with the following keys:
+  #     * `filePath` {String} absolute path to the matching file.
+  #     * `matches` {Array} with object elements with the following keys:
+  #       * `lineText` {String} The full text of the matching line (without a line terminator character).
+  #       * `lineTextOffset` {Number} (This always seems to be 0?)
+  #       * `matchText` {String} The text that matched the `regex` used for the search.
+  #       * `range` {Range} Identifies the matching region in the file. (Likely as an array of numeric arrays.)
+  # * `recordSearchError` {Function}
+  # * `options` {Object} with the following properties:
+  #   * `includePatterns` An {Array} of glob patterns (as strings) to search within. Note that this
+  #   array may be empty, indicating that all files should be searched.
+  #
+  #   Each item in the array is a file/directory pattern, e.g., `src` to search in the "src"
+  #   directory or `*.js` to search all JavaScript files. In practice, this often comes from the
+  #   comma-delimited list of patterns in the bottom text input of the ProjectFindView dialog.
+  #
+  # Returns a `Promise` that includes a `cancel()` method. If invoked before the `Proimse` is
+  # determined, it will reject the `Promise`.
+  search: (directory, regex, recordNumPathsSearched, recordSearchResult, recordSearchError, options) ->
+    scanOptions =
+      paths: options.includePatterns
+      onPathsSearched: recordNumPathsSearched
+      rootDirectories: [directory]
+    # Note that atom.workspace.scan takes care of searching open buffers that may have local
+    # modifications.
+    atom.workspace.scan regex, scanOptions, (result, error) ->
+      if result
+        recordSearchResult(result)
+      else
+        recordSearchError(error)

--- a/lib/project/result-view.coffee
+++ b/lib/project/result-view.coffee
@@ -7,6 +7,8 @@ path = require 'path'
 module.exports =
 class ResultView extends View
   @content: (model, filePath, result) ->
+    # Note that filePath might be a URI rather than a local path. In practice, path.basename() and
+    # atom.project.relativizePath() seem to handle such URIs all right.
     iconClass = if fs.isReadmePath(filePath) then 'icon-book' else 'icon-file-text'
     fileBasename = path.basename(filePath)
 

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -1,7 +1,7 @@
-Q = require 'q'
 _ = require 'underscore-plus'
 {Emitter} = require 'atom'
 escapeHelper = require '../escape-helper'
+DefaultSearchDirectoryProvider = require './default-search-directory-provider'
 
 class Result
   @create: (result) ->
@@ -16,6 +16,13 @@ class ResultsModel
     @emitter = new Emitter
     @useRegex = state.useRegex ? atom.config.get('find-and-replace.useRegex') ? false
     @caseSensitive = state.caseSensitive ? atom.config.get('find-and-replace.caseSensitive') ? false
+    @searchProviders = [new DefaultSearchDirectoryProvider()]
+    atom.packages.serviceHub.consume(
+      'find-and-replace.search-directory-provider',
+      '^0.1.0',
+      # New providers are added to the front of @searchProviders because
+      # DefaultSearchDirectoryProvider is a catch-all that will always claim to search a Directory.
+      (provider) => @searchProviders.unshift(provider))
 
     atom.workspace.observeTextEditors (editor) =>
       editor.onDidStopChanging => @onContentsModified(editor)
@@ -31,12 +38,15 @@ class ResultsModel
   onDidClearReplacementState: (callback) ->
     @emitter.on 'did-clear-replacement-state', callback
 
+  # * `callback` {Function} that receives the number of paths searched.
   onDidSearchPaths: (callback) ->
     @emitter.on 'did-search-paths', callback
 
   onDidErrorForPath: (callback) ->
     @emitter.on 'did-error-for-path', callback
 
+  # * `callback` {Function} that receives a Promise that resolves when
+  # the search is complete. If the search is cancelled, it will reject.
   onDidStartSearching: (callback) ->
     @emitter.on 'did-start-searching', callback
 
@@ -98,8 +108,9 @@ class ResultsModel
     @replacementErrors = null
     @emitter.emit 'did-clear-replacement-state', @getResultsSummary()
 
+  # Returns a `Promise` that resolves when the search is complete.
   search: (pattern, searchPaths, replacementPattern, {onlyRunIfChanged, keepReplacementState}={}) ->
-    return Q() if onlyRunIfChanged and pattern? and searchPaths? and pattern is @pattern and _.isEqual(searchPaths, @searchedPaths)
+    return Promise.resolve() if onlyRunIfChanged and pattern? and searchPaths? and pattern is @pattern and _.isEqual(searchPaths, @searchedPaths)
 
     if keepReplacementState
       @clearSearchState()
@@ -113,24 +124,64 @@ class ResultsModel
 
     @updateReplacementPattern(replacementPattern)
 
-    onPathsSearched = (numberOfPathsSearched) =>
-      @emitter.emit 'did-search-paths', numberOfPathsSearched
-
-    @inProgressSearchPromise = atom.workspace.scan @regex, {paths: searchPaths, onPathsSearched}, (result, error) =>
-      if result
-        @setResult(result.filePath, Result.create(result))
+    # Find a search provider for every Directory in the project.
+    providersAndDirectories = []
+    for directory in atom.project.getDirectories()
+      providerForDirectory = null
+      for provider in @searchProviders
+        if provider.canSearchDirectory(directory)
+          providerForDirectory = provider
+          break
+      if providerForDirectory
+        providersAndDirectories.push({provider, directory})
       else
-        @searchErrors ?= []
-        @searchErrors.push(error)
-        @emitter.emit 'did-error-for-path', error
+        throw Error("Could not find search provider for #{directory.getPath()}")
 
+    # Now that we are sure every Directory has a provider, construct the search options.
+    recordSearchResult = (result) =>
+      @setResult(result.filePath, Result.create(result))
+    recordSearchError = (error) =>
+      @searchErrors ?= []
+      @searchErrors.push(error)
+      @emitter.emit 'did-error-for-path', error
+    options = {includePatterns: searchPaths}
+
+    # Maintain a map of providers to the number of search results. When notified of a new count,
+    # replace the entry in the map and update the total.
+    totalNumberOfPathsSearched = 0
+    numberOfPathsSearchedForProvider = new Map()
+    onPathsSearched = (provider, numberOfPathsSearched) =>
+      oldValue = numberOfPathsSearchedForProvider.get(provider)
+      if oldValue
+        totalNumberOfPathsSearched -= oldValue
+      numberOfPathsSearchedForProvider.set(provider, numberOfPathsSearched)
+      totalNumberOfPathsSearched += numberOfPathsSearched
+      @emitter.emit 'did-search-paths', totalNumberOfPathsSearched
+
+    # Kick off all of the searches and unify them into one Promise.
+    searches = []
+    for entry in providersAndDirectories
+      {provider, directory} = entry
+      recordNumPathsSearched = onPathsSearched.bind(undefined, provider)
+      searches.push(provider.search(
+        directory,
+        @regex,
+        recordNumPathsSearched,
+        recordSearchResult,
+        recordSearchError,
+        options))
+    allSearches = Promise.all(searches)
+    @inProgressSearchPromise = allSearches
     @emitter.emit 'did-start-searching', @inProgressSearchPromise
-    @inProgressSearchPromise.then (message) =>
-      if message is 'cancelled'
-        @emitter.emit 'did-cancel-searching'
-      else
-        @inProgressSearchPromise = null
-        @emitter.emit 'did-finish-searching', @getResultsSummary()
+
+    # Retain the current search and make sure it is cancelable.
+    allSearches.cancel = =>
+      promise.cancel() for promise in allSearches
+      @emitter.emit 'did-cancel-searching'
+
+    allSearches.then =>
+      @inProgressSearchPromise = null
+      @emitter.emit 'did-finish-searching', @getResultsSummary()
 
   replace: (pattern, searchPaths, replacementPattern, replacementPaths) ->
     regex = @getRegex(pattern)

--- a/lib/project/results-pane.coffee
+++ b/lib/project/results-pane.coffee
@@ -87,7 +87,7 @@ class ResultsPaneView extends ScrollView
   clearErrors: ->
     @errorList.html('').hide()
 
-  onSearch: (deferred) =>
+  onSearch: (promise) =>
     @loadingMessage.show()
 
     @previewCount.text('Searching...')
@@ -105,8 +105,8 @@ class ResultsPaneView extends ScrollView
       @showSearchedCountBlock = true
     , 500
 
-    deferred.done =>
-      @loadingMessage.hide()
+    onSuccessOrFailure = => @loadingMessage.hide()
+    promise.then(onSuccessOrFailure, onSuccessOrFailure)
 
   onPathsSearched: (numberOfPathsSearched) =>
     if @showSearchedCountBlock


### PR DESCRIPTION
This refactors `ResultsModel` so that when its `search()` method is
invoked, it finds the appropriate `SearchDirectoryProvider` for each
`Directory` in `atom.project.getDirectories()`. It invokes the `search()`
method for each provider and aggregates the results as they are streamed in.

Currently, there is only one implementation of `SearchDirectoryProvider`:
`DefaultSearchDirectoryProvider`. It uses the existing logic from
`ResultsModel` to implement `search()`, which is basically a call to
`atom.workspace.scan()` with an appropriate callback.

The next step is to make `find-and-replace` a consumer of `SearchDirectoryProvider`
objects so that remote directories can be supported. New providers will be added
to the front of the `ResultsModel::searchProviders` array so that they are considered
before the `DefaultSearchDirectoryProvider`. Note that the same technique is used
with `Project::directoryProviders`.