### PR TITLE
Prevent duplicate "Project Find Results" panels

### DIFF
--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -237,8 +237,8 @@ class ProjectFindView extends View
       @findEditor.getModel().selectAll()
 
   showResultPane: ->
-    options = null
-    options = {split: 'right'} if atom.config.get('find-and-replace.openProjectFindResultsInRightPane')
+    options = {searchAllPanes: true}
+    options.split = 'right' if atom.config.get('find-and-replace.openProjectFindResultsInRightPane')
     atom.workspace.open(ResultsPaneView.URI, options)
 
   onFinishedReplacing: (results) ->

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -1142,3 +1142,37 @@ describe 'ProjectFindView', ->
       expect(projectFindView.findEditor).not.toHaveClass('is-focused')
       expect(projectFindView.replaceEditor).toHaveClass('is-focused')
       expect(projectFindView.pathsEditor).not.toHaveClass('is-focused')
+
+  describe "panel opening", ->
+    describe "when a panel is already open", ->
+      beforeEach ->
+        atom.config.set('find-and-replace.openProjectFindResultsInRightPane', true)
+
+        waitsForPromise ->
+          atom.workspace.open('sample.js')
+
+        runs ->
+          editor = atom.workspace.getActiveTextEditor()
+          editorView = atom.views.getView(editor)
+          atom.commands.dispatch(workspaceElement, 'project-find:show')
+
+        waitsForPromise ->
+          activationPromise
+
+        runs ->
+          projectFindView.findEditor.setText('items')
+          atom.commands.dispatch(projectFindView[0], 'core:confirm')
+
+        waitsForPromise ->
+          searchPromise
+
+      it "doesn't open another panel even if the active pane is vertically split", ->
+        atom.commands.dispatch(editorView, 'pane:split-down')
+        projectFindView.findEditor.setText('items')
+        atom.commands.dispatch(projectFindView[0], 'core:confirm')
+
+        waitsForPromise ->
+          searchPromise
+
+        runs ->
+          expect(workspaceElement.querySelectorAll('.preview-pane').length).toBe(1)


### PR DESCRIPTION
Prevent duplicate "Project Find Results" panels. Closes #378