### PR TITLE
createViews in activate

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -37,13 +37,11 @@ module.exports =
     @pathsHistory = new History(pathsHistory)
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:show', =>
-      @createViews()
       @findPanel.hide()
       @projectFindPanel.show()
       @projectFindView.focusFindElement()
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:toggle', =>
-      @createViews()
       @findPanel.hide()
 
       if @projectFindPanel.isVisible()
@@ -52,7 +50,6 @@ module.exports =
         @projectFindPanel.show()
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:show-in-current-directory', ({target}) =>
-      @createViews()
       @findPanel.hide()
       @projectFindPanel.show()
       @projectFindView.findInCurrentlySelectedDirectory(target)
@@ -60,13 +57,11 @@ module.exports =
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:use-selection-as-find-pattern', =>
       return if @projectFindPanel?.isVisible() or @findPanel?.isVisible()
 
-      @createViews()
       @projectFindPanel.hide()
       @findPanel.show()
       @findView.focusFindEditor()
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:toggle', =>
-      @createViews()
       @projectFindPanel.hide()
 
       if @findPanel.isVisible()
@@ -76,13 +71,11 @@ module.exports =
         @findView.focusFindEditor()
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:show', =>
-      @createViews()
       @projectFindPanel.hide()
       @findPanel.show()
       @findView.focusFindEditor()
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:show-replace', =>
-      @createViews()
       @projectFindPanel?.hide()
       @findPanel.show()
       @findView.focusReplaceEditor()
@@ -116,6 +109,7 @@ module.exports =
         selectNextObjectForEditorElement(this).undoLastSelection()
       'find-and-replace:select-skip': (event) ->
         selectNextObjectForEditorElement(this).skipCurrentSelection()
+    @createViews()
 
   createViews: ->
     return if @findView?


### PR DESCRIPTION
The find-view has to exist, to be abel to use `find-and-replace:find-next-selected`, `find-and-replace:find-previous-selected` and `find-and-replace:use-selection-as-find-pattern` commands. This was not the case before this fix.
