### PR TITLE
Scroll to first result on type

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -283,7 +283,7 @@ class FindView extends View
       results = @markers.length
       resultsStr = if results then _.pluralize(results, 'result') else 'No results'
       @setInfoMessage("#{resultsStr} found for '#{@findModel.pattern}'")
-      if @findEditor.hasFocus() && results > 0
+      if @findEditor.hasFocus() and results > 0
         @findAndSelectResult(@selectFirstMarkerStartingFromCursor, {focusEditorAfter: false})
     else
       @clearMessage()
@@ -327,7 +327,7 @@ class FindView extends View
     markerIndex = @firstMarkerIndexAfterCursor(true)
     @selectMarkerAtIndex(markerIndex)
 
-  firstMarkerIndexAfterCursor: (indexIncluded = false)->
+  firstMarkerIndexAfterCursor: (indexIncluded = false) ->
     editor = @findModel.getEditor()
     return -1 unless editor
 

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -283,6 +283,8 @@ class FindView extends View
       results = @markers.length
       resultsStr = if results then _.pluralize(results, 'result') else 'No results'
       @setInfoMessage("#{resultsStr} found for '#{@findModel.pattern}'")
+      if @findEditor.hasFocus() && results > 0
+        @findAndSelectResult(@selectFirstMarkerStartingFromCursor, {focusEditorAfter: false})
     else
       @clearMessage()
 
@@ -321,7 +323,11 @@ class FindView extends View
     markerIndex = @firstMarkerIndexAfterCursor()
     @selectMarkerAtIndex(markerIndex)
 
-  firstMarkerIndexAfterCursor: ->
+  selectFirstMarkerStartingFromCursor: =>
+    markerIndex = @firstMarkerIndexAfterCursor(true)
+    @selectMarkerAtIndex(markerIndex)
+
+  firstMarkerIndexAfterCursor: (indexIncluded = false)->
     editor = @findModel.getEditor()
     return -1 unless editor
 
@@ -331,6 +337,7 @@ class FindView extends View
 
     for marker, index in @markers
       markerStartPosition = marker.bufferMarker.getStartPosition()
+      return index if markerStartPosition.isEqual(start) and indexIncluded
       return index if markerStartPosition.isGreaterThan(start)
     0
 

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -283,7 +283,7 @@ class FindView extends View
       results = @markers.length
       resultsStr = if results then _.pluralize(results, 'result') else 'No results'
       @setInfoMessage("#{resultsStr} found for '#{@findModel.pattern}'")
-      if @findEditor.hasFocus() and results > 0
+      if @findEditor.hasFocus() and results > 0 and atom.config.get('find-and-replace.scrollToResultOnType')
         @findAndSelectResult(@selectFirstMarkerStartingFromCursor, {focusEditorAfter: false})
     else
       @clearMessage()

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -283,7 +283,7 @@ class FindView extends View
       results = @markers.length
       resultsStr = if results then _.pluralize(results, 'result') else 'No results'
       @setInfoMessage("#{resultsStr} found for '#{@findModel.pattern}'")
-      if @findEditor.hasFocus() and results > 0 and atom.config.get('find-and-replace.scrollToResultOnType')
+      if @findEditor.hasFocus() and results > 0 and atom.config.get('find-and-replace.scrollToResultOnLiveSearch')
         @findAndSelectResult(@selectFirstMarkerStartingFromCursor, {focusEditorAfter: false})
     else
       @clearMessage()

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -17,6 +17,9 @@ module.exports =
     openProjectFindResultsInRightPane:
       type: 'boolean'
       default: false
+    scrollToResultOnType:
+      type: 'boolean'
+      default: false
 
   activate: ({@viewState, @projectViewState, @resultsModelState, @modelState, findHistory, replaceHistory, pathsHistory}={}) ->
     atom.workspace.addOpener (filePath) ->

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -17,7 +17,7 @@ module.exports =
     openProjectFindResultsInRightPane:
       type: 'boolean'
       default: false
-    scrollToResultOnType:
+    scrollToResultOnLiveSearch:
       type: 'boolean'
       default: false
 

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -829,17 +829,25 @@ describe 'FindView', ->
       beforeEach ->
         findView.findEditor.focus()
 
-      it "scrolls to the first match depending on the settings", ->
-        editor.moveToTop()
+      it "scrolls to the first match if the settings scrollToResultOnLiveSearch is true", ->
         atom.config.set('find-and-replace.scrollToResultOnLiveSearch', true)
-        findView.findEditor.setText 'sort'
-        advance()
-        expect(editor.getSelectedBufferRange()).toEqual [[0, 9], [0, 13]]
-        expect(findView.findEditor).toHaveFocus()
+        editor.setHeight(3)
         editor.moveToTop()
-        atom.config.set('find-and-replace.scrollToResultOnLiveSearch', false)
-        findView.findEditor.setText 'concat'
+        originalScrollPosition = editor.getScrollTop()
+        findView.findEditor.setText 'Array'
         advance()
+        expect(editor.getScrollTop()).not.toEqual originalScrollPosition
+        expect(editor.getSelectedBufferRange()).toEqual [[11, 14], [11, 19]]
+        expect(findView.findEditor).toHaveFocus()
+
+      it "doesn't scroll to the first match if the settings scrollToResultOnLiveSearch is false", ->
+        atom.config.set('find-and-replace.scrollToResultOnLiveSearch', false)
+        editor.setHeight(3)
+        editor.moveToTop()
+        originalScrollPosition = editor.getScrollTop()
+        findView.findEditor.setText 'Array'
+        advance()
+        expect(editor.getScrollTop()).toEqual originalScrollPosition
         expect(editor.getSelectedBufferRange()).toEqual []
         expect(findView.findEditor).toHaveFocus()
 

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -829,6 +829,20 @@ describe 'FindView', ->
       beforeEach ->
         findView.findEditor.focus()
 
+      it "scrolls to the first match depending on the settings", ->
+        editor.moveToTop()
+        atom.config.set('find-and-replace.scrollToResultOnLiveSearch', true)
+        findView.findEditor.setText 'sort'
+        advance()
+        expect(editor.getSelectedBufferRange()).toEqual [[0, 9], [0, 13]]
+        expect(findView.findEditor).toHaveFocus()
+        editor.moveToTop()
+        atom.config.set('find-and-replace.scrollToResultOnLiveSearch', false)
+        findView.findEditor.setText 'concat'
+        advance()
+        expect(editor.getSelectedBufferRange()).toEqual []
+        expect(findView.findEditor).toHaveFocus()
+
       it "updates the search results", ->
         expect(findView.descriptionLabel.text()).toContain "6 results"
 


### PR DESCRIPTION
The idea of this pull request is to scroll the editor window on the result when you type, without having to press enter.
![screencast from 01-07-15 21-46-01](https://cloud.githubusercontent.com/assets/10697451/8464718/3773d014-203c-11e5-9f12-036c627e479e.gif)
