### PR TITLE
Don’t throw exception when replacing with an empty find string

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -258,15 +258,15 @@ class FindView extends View
     @findHistory.store()
     @replaceHistory.store()
 
-    if @markers.length is 0
-      atom.beep()
-    else
+    if @markers?.length > 0
       unless currentMarker = @findModel.currentResultMarker
         markerIndex = @[nextIndexFn]()
         currentMarker = @markers[markerIndex]
 
       @findModel.replace([currentMarker], @replaceEditor.getText())
       @[nextOrPreviousFn](fieldToFocus: @replaceEditor)
+    else
+      atom.beep()
 
   replaceAll: =>
     @updateModel {pattern: @findEditor.getText()}

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -878,6 +878,12 @@ describe 'FindView', ->
         findView.findEditor.setText('items')
         findView.replaceEditor.setText('cats')
 
+    describe "when the find string is empty", ->
+      it "beeps", ->
+        findView.findEditor.setText('')
+        atom.commands.dispatch(findView.replaceEditor.element, 'core:confirm')
+        expect(atom.beep).toHaveBeenCalled()
+
     describe "when the replacement string contains an escaped char", ->
       describe "when the regex option is chosen", ->
         beforeEach ->


### PR DESCRIPTION
This fixes https://github.com/atom/find-and-replace/issues/402#issuecomment-118548573 and closes https://github.com/atom/find-and-replace/issues/402 (since the initial report was fixed in ed00ffb, I believe):

* 466c592 adds a [failing spec](https://travis-ci.org/atom/find-and-replace/builds/69598472) to demonstrate the problem
* a519074 [fixes the problem](https://travis-ci.org/atom/find-and-replace/builds/69598769) by checking that `@markers` is defined before calling `.length` on it.

cc @kevinsawicki @benogle for :eyes: 