### PR TITLE
Add whole word option for project find

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -52,11 +52,13 @@
   'cmd-enter': 'project-find:confirm'
   'cmd-alt-/': 'project-find:toggle-regex-option'
   'cmd-alt-c': 'project-find:toggle-case-option'
+  'cmd-alt-w': 'project-find:toggle-whole-word-option'
 
 '.platform-win32 .project-find, .platform-linux .project-find':
   'ctrl-enter': 'project-find:confirm'
   'ctrl-alt-/': 'project-find:toggle-regex-option'
   'ctrl-alt-c': 'project-find:toggle-case-option'
+  'ctrl-alt-w': 'project-find:toggle-whole-word-option'
 
 '.find-and-replace, .project-find, .project-find .results-view':
   'tab': 'find-and-replace:focus-next'

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -33,6 +33,8 @@ class ProjectFindView extends View
               @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-regex" /></svg>'
             @button outlet: 'caseOptionButton', class: 'btn option-case-sensitive', =>
               @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-case" /></svg>'
+            @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', =>
+              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-word" /></svg>'
 
       @section class: 'input-block replace-container', =>
         @div class: 'input-block-item input-block-item--flex editor-container', =>
@@ -55,6 +57,7 @@ class ProjectFindView extends View
 
     @regexOptionButton.addClass('selected') if @model.useRegex
     @caseOptionButton.addClass('selected') if @model.caseSensitive
+    @wholeWordOptionButton.addClass('selected') if @model.wholeWord
 
     @clearMessages()
     @updateOptionsLabel()
@@ -80,6 +83,11 @@ class ProjectFindView extends View
     subs.add atom.tooltips.add @caseOptionButton,
       title: "Match Case",
       keyBindingCommand: 'project-find:toggle-case-option',
+      keyBindingTarget: @findEditor.element
+
+    subs.add atom.tooltips.add @wholeWordOptionButton,
+      title: "Whole Word",
+      keyBindingCommand: 'project-find:toggle-whole-word-option',
       keyBindingTarget: @findEditor.element
 
     subs.add atom.tooltips.add @replaceAllButton,
@@ -110,6 +118,7 @@ class ProjectFindView extends View
       'project-find:confirm': => @confirm()
       'project-find:toggle-regex-option': => @toggleRegexOption()
       'project-find:toggle-case-option': => @toggleCaseOption()
+      'project-find:toggle-whole-word-option': => @toggleWholeWordOption()
       'project-find:replace-all': => @replaceAll()
 
     @subscriptions.add @model.onDidClear => @clearMessages()
@@ -119,6 +128,7 @@ class ProjectFindView extends View
     @on 'focus', (e) => @findEditor.focus()
     @regexOptionButton.click => @toggleRegexOption()
     @caseOptionButton.click => @toggleCaseOption()
+    @wholeWordOptionButton.click => @toggleWholeWordOption()
     @replaceAllButton.on 'click', => @replaceAll()
 
     focusCallback = => @onlyRunIfChanged = false
@@ -153,6 +163,12 @@ class ProjectFindView extends View
   toggleCaseOption: ->
     @model.toggleCaseSensitive()
     if @model.caseSensitive then @caseOptionButton.addClass('selected') else @caseOptionButton.removeClass('selected')
+    @updateOptionsLabel()
+    @search(onlyRunIfActive: true)
+
+  toggleWholeWordOption: ->
+    @model.toggleWholeWord()
+    if @model.wholeWord then @wholeWordOptionButton.addClass('selected') else @wholeWordOptionButton.removeClass('selected')
     @updateOptionsLabel()
     @search(onlyRunIfActive: true)
 
@@ -267,6 +283,7 @@ class ProjectFindView extends View
       label.push('Case Sensitive')
     else
       label.push('Case Insensitive')
+    label.push('Whole Word') if @model.wholeWord
     @optionsLabel.text(label.join(', '))
 
   setSelectionAsFindPattern: =>

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -16,6 +16,7 @@ class ResultsModel
     @emitter = new Emitter
     @useRegex = state.useRegex ? atom.config.get('find-and-replace.useRegex') ? false
     @caseSensitive = state.caseSensitive ? atom.config.get('find-and-replace.caseSensitive') ? false
+    @wholeWord = state.wholeWord ? atom.config.get('find-and-replace.wholeWord') ? false
 
     atom.workspace.observeTextEditors (editor) =>
       editor.onDidStopChanging => @onContentsModified(editor)
@@ -68,7 +69,7 @@ class ResultsModel
     @emitter.on 'did-remove-result', callback
 
   serialize: ->
-    {@useRegex, @caseSensitive}
+    {@useRegex, @caseSensitive, @wholeWord}
 
   clear: ->
     @clearSearchState()
@@ -173,6 +174,9 @@ class ResultsModel
   toggleCaseSensitive: ->
     @caseSensitive = not @caseSensitive
 
+  toggleWholeWord: ->
+    @wholeWord = not @wholeWord
+
   getResultsSummary: ->
     pattern = @pattern or ''
     {
@@ -233,9 +237,13 @@ class ResultsModel
     flags += 'i' unless @caseSensitive
 
     if @useRegex
-      new RegExp(pattern, flags)
+      expression = pattern
     else
-      new RegExp(_.escapeRegExp(pattern), flags)
+      expression = _.escapeRegExp(pattern)
+
+    expression = "\\b#{expression}\\b" if @wholeWord
+
+    new RegExp(expression, flags)
 
   onContentsModified: (editor) =>
     return unless @active

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -169,7 +169,7 @@ atom-workspace.find-visible {
 // Project find and replace
 .project-find {
   @project-input-width: 260px;
-  @project-button-width: 100px;
+  @project-button-width: 120px;
 
   .input-block-item {
     flex: 1 1 @project-button-width;


### PR DESCRIPTION
This PR closes https://github.com/atom/find-and-replace/issues/339 .

![whole-word](https://cloud.githubusercontent.com/assets/1128248/8512021/d321193e-2331-11e5-8070-de11c848f0dc.png)
![whole-word-tooltip](https://cloud.githubusercontent.com/assets/1128248/8512033/8206d948-2332-11e5-8cdf-9e713011954d.png)

Tests were heavily inspired by the "case sensitivity" tests.


Looking forward to your feedback.