### PR TITLE
Create option for disabling the behavior of skipping non-word matches when a word is selected on select next command

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -22,6 +22,11 @@ module.exports =
       default: false
       title: 'Scroll To Result On Live Search (incremental find in buffer)'
       description: 'When you type in the buffer find box, the closest match will be selected and made visible in the editor.'
+    skipNonWordMatches:
+      type: 'boolean'
+      default: true
+      title: 'When a Word is Selected, Skip Non-Word Matches (Select Next)'
+      description: 'If the selected text is a whole word, only whole words will match when using select next feature.'
 
   activate: ({@viewState, @projectViewState, @resultsModelState, @modelState, findHistory, replaceHistory, pathsHistory}={}) ->
     atom.workspace.addOpener (filePath) ->

--- a/lib/select-next.coffee
+++ b/lib/select-next.coffee
@@ -82,10 +82,11 @@ class SelectNext
     selection = @editor.getLastSelection()
     text = _.escapeRegExp(selection.getText())
 
-    @wordSelected ?= @isWordSelected(selection)
-    if @wordSelected
-      nonWordCharacters = atom.config.get('editor.nonWordCharacters')
-      text = "(^|[ \t#{_.escapeRegExp(nonWordCharacters)}]+)#{text}(?=$|[\\s#{_.escapeRegExp(nonWordCharacters)}]+)"
+    if atom.config.get('find-and-replace.skipNonWordMatches')
+      @wordSelected ?= @isWordSelected(selection)
+      if @wordSelected
+        nonWordCharacters = atom.config.get('editor.nonWordCharacters')
+        text = "(^|[ \t#{_.escapeRegExp(nonWordCharacters)}]+)#{text}(?=$|[\\s#{_.escapeRegExp(nonWordCharacters)}]+)"
 
     @editor.scanInBufferRange new RegExp(text, 'g'), range, (result) ->
       if prefix = result.match[1]

--- a/spec/select-next-spec.coffee
+++ b/spec/select-next-spec.coffee
@@ -28,8 +28,10 @@ describe "SelectNext", ->
         atom.commands.dispatch editorElement, 'find-and-replace:select-next'
         expect(editor.getSelectedBufferRanges()).toEqual [[[1, 2], [1, 5]]]
 
-    describe "when a word is selected", ->
+    describe "when a word is selected and skipNonWordMatches is true", ->
       it "selects the next occurrence of the selected word skipping any non-word matches", ->
+        atom.config.set('find-and-replace.skipNonWordMatches', true)
+
         editor.setText """
           for
           information
@@ -72,6 +74,91 @@ describe "SelectNext", ->
         atom.commands.dispatch editorElement, 'find-and-replace:select-next'
         expect(editor.getSelectedBufferRanges()).toEqual [
           [[0, 0], [0, 7]]
+        ]
+
+    describe "when a word is selected and skipNonWordMatches is false", ->
+      it "selects the next occurrence of the selected text", ->
+        atom.config.set('find-and-replace.skipNonWordMatches', false)
+
+        editor.setText """
+          for
+          information
+          format
+          another for
+          fork
+          a 3rd for is here
+        """
+
+        editor.setSelectedBufferRange([[0, 0], [0, 3]])
+
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[0, 0], [0, 3]]
+          [[1, 2], [1, 5]]
+        ]
+
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[0, 0], [0, 3]]
+          [[1, 2], [1, 5]]
+          [[2, 0], [2, 3]]
+        ]
+
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[0, 0], [0, 3]]
+          [[1, 2], [1, 5]]
+          [[2, 0], [2, 3]]
+          [[3, 8], [3, 11]]
+        ]
+
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[0, 0], [0, 3]]
+          [[1, 2], [1, 5]]
+          [[2, 0], [2, 3]]
+          [[3, 8], [3, 11]]
+          [[4, 0], [4, 3]]
+        ]
+
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[0, 0], [0, 3]]
+          [[1, 2], [1, 5]]
+          [[2, 0], [2, 3]]
+          [[3, 8], [3, 11]]
+          [[4, 0], [4, 3]]
+          [[5, 6], [5, 9]]
+        ]
+
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[0, 0], [0, 3]]
+          [[1, 2], [1, 5]]
+          [[2, 0], [2, 3]]
+          [[3, 8], [3, 11]]
+          [[4, 0], [4, 3]]
+          [[5, 6], [5, 9]]
+        ]
+
+        editor.setText "Testing reallyTesting"
+        editor.setCursorBufferPosition([0, 0])
+
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[0, 0], [0, 7]]
+        ]
+
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[0, 0], [0, 7]]
+          [[0, 14], [0, 21]]
+        ]
+
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[0, 0], [0, 7]]
+          [[0, 14], [0, 21]]
         ]
 
     describe "when part of a word is selected", ->


### PR DESCRIPTION
Fix #340.

#356 removes completely this behavior, but I see that there are some people that want to keep it the way it is.

With that being said, I decided to create an option (that defaults to the current behavior) that allows the user to enable and disable it, as you can see in the following video:

![skipNonWordMatches Behavior](http://imagizer.imageshack.us/a/img901/3486/Pg4gAF.gif)