### PR TITLE
Escape search on use-selection-as-find-pattern and Regex enabled #455

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -197,8 +197,7 @@ class FindView extends View
   focusFindEditor: =>
     selectedText = atom.workspace.getActiveTextEditor()?.getSelectedText?()
     if selectedText and selectedText.indexOf('\n') < 0
-      if @findModel.useRegex
-        selectedText = Util.escapeRegex(selectedText)
+      selectedText = Util.escapeRegex(selectedText) if @findModel.useRegex
       @findEditor.setText(selectedText)
     @findEditor.focus()
     @findEditor.getModel().selectAll()
@@ -382,8 +381,7 @@ class FindView extends View
     editor = @findModel.getEditor()
     if editor?
       pattern = editor.getSelectedText() or editor.getWordUnderCursor()
-      if @findModel.useRegex
-        pattern = Util.escapeRegex(pattern)
+      pattern = Util.escapeRegex(pattern) if @findModel.useRegex
       @updateModel {pattern} if pattern
 
   findNextSelected: =>

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -379,6 +379,9 @@ class FindView extends View
     editor = @findModel.getEditor()
     if editor?
       pattern = editor.getSelectedText() or editor.getWordUnderCursor()
+      if @findModel.useRegex
+        pattern = pattern.replace /[.?*+^$[\]\\(){}|-]/g, (match) ->
+          "\\" + match
       @updateModel {pattern} if pattern
 
   findNextSelected: =>

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -2,6 +2,7 @@ _ = require 'underscore-plus'
 {$$$, View, TextEditorView} = require 'atom-space-pen-views'
 {CompositeDisposable} = require 'atom'
 {HistoryCycler} = require './history'
+Util = require './project/util'
 
 module.exports =
 class FindView extends View
@@ -196,6 +197,8 @@ class FindView extends View
   focusFindEditor: =>
     selectedText = atom.workspace.getActiveTextEditor()?.getSelectedText?()
     if selectedText and selectedText.indexOf('\n') < 0
+      if @findModel.useRegex
+        selectedText = Util.escapeRegex(selectedText)
       @findEditor.setText(selectedText)
     @findEditor.focus()
     @findEditor.getModel().selectAll()
@@ -380,8 +383,7 @@ class FindView extends View
     if editor?
       pattern = editor.getSelectedText() or editor.getWordUnderCursor()
       if @findModel.useRegex
-        pattern = pattern.replace /[.?*+^$[\]\\(){}|-]/g, (match) ->
-          "\\" + match
+        pattern = Util.escapeRegex(pattern)
       @updateModel {pattern} if pattern
 
   findNextSelected: =>

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -186,8 +186,7 @@ class ProjectFindView extends View
   focusFindElement: ->
     selectedText = atom.workspace.getActiveTextEditor()?.getSelectedText?()
     if selectedText and selectedText.indexOf('\n') < 0
-      if @model.useRegex
-        selectedText = Util.escapeRegex(selectedText)
+      selectedText = Util.escapeRegex(selectedText) if @model.useRegex
       @findEditor.setText(selectedText)
     @findEditor.focus()
     @findEditor.getModel().selectAll()
@@ -293,6 +292,5 @@ class ProjectFindView extends View
     editor = atom.workspace.getActivePaneItem()
     if editor?
       pattern = editor.getSelectedText() or editor.getWordUnderCursor()
-      if @model.useRegex
-        pattern = Util.escapeRegex(pattern)
+      pattern = Util.escapeRegex(pattern) if @model.useRegex
       @findEditor.setText(pattern) if pattern

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -185,7 +185,10 @@ class ProjectFindView extends View
 
   focusFindElement: ->
     selectedText = atom.workspace.getActiveTextEditor()?.getSelectedText?()
-    @findEditor.setText(selectedText) if selectedText and selectedText.indexOf('\n') < 0
+    if selectedText and selectedText.indexOf('\n') < 0
+      if @model.useRegex
+        selectedText = Util.escapeRegex(selectedText)
+      @findEditor.setText(selectedText)
     @findEditor.focus()
     @findEditor.getModel().selectAll()
 
@@ -290,4 +293,6 @@ class ProjectFindView extends View
     editor = atom.workspace.getActivePaneItem()
     if editor?
       pattern = editor.getSelectedText() or editor.getWordUnderCursor()
+      if @model.useRegex
+        pattern = Util.escapeRegex(pattern)
       @findEditor.setText(pattern) if pattern

--- a/lib/project/util.coffee
+++ b/lib/project/util.coffee
@@ -6,6 +6,10 @@ module.exports =
     @escapeNode.innerText = str
     @escapeNode.innerHTML
 
+  escapeRegex: (str) =>
+    str.replace /[.?*+^$[\]\\(){}|-]/g, (match) ->
+      "\\" + match
+
   sanitizePattern: (pattern) ->
     pattern = @escapeHtml(pattern)
     pattern.replace(/\n/g, '\\n').replace(/\t/g, '\\t')

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -100,6 +100,17 @@ describe 'FindView', ->
         expect(findView.regexOptionButton).toHaveClass 'selected'
         expect(findView.selectionOptionButton).toHaveClass 'selected'
 
+    it "places selected text into the find editor and escapes it when Regex is enabled", ->
+      atom.config.set('find-and-replace.useRegex', true)
+      editor.setSelectedBufferRange([[6, 6], [6, 65]])
+      atom.commands.dispatch editorView, 'find-and-replace:show'
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        expect(findView.findEditor.getText()).toBe 'current < pivot \\? left\\.push\\(current\\) : right\\.push\\(current\\);'
+
   describe "when find-and-replace:toggle is triggered", ->
     it "toggles the visibility of the FindView", ->
       atom.commands.dispatch workspaceElement, 'find-and-replace:toggle'

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -519,6 +519,12 @@ describe 'FindView', ->
         atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
         expect(findView.findEditor.getText()).toBe 'sort'
 
+      it "places selected text into the find editor and escapes it when Regex is enabled", ->
+        atom.commands.dispatch(findView.findEditor.element, 'find-and-replace:toggle-regex-option')
+        editor.setSelectedBufferRange([[6, 6], [6, 65]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
+        expect(findView.findEditor.getText()).toBe 'current < pivot \\? left\\.push\\(current\\) : right\\.push\\(current\\);'
+
     describe "when find-and-replace:find-next-selected is triggered", ->
       it "places the selected text into the find editor and finds the next occurrence", ->
         editor.setSelectedBufferRange([[0, 9], [0, 13]])

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -89,6 +89,12 @@ describe 'ProjectFindView', ->
         expect(getAtomPanel()).toBeVisible()
         expect(projectFindView.findEditor.getText()).toBe('length')
 
+      it "places selected text into the find editor and escapes it when Regex is enabled", ->
+        atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
+        editor.setSelectedBufferRange([[6, 6], [6, 65]])
+        atom.commands.dispatch(workspaceElement, 'project-find:show')
+        expect(projectFindView.findEditor.getText()).toBe 'current < pivot \\? left\\.push\\(current\\) : right\\.push\\(current\\);'
+
     describe "when the ProjectFindView is already attached", ->
       beforeEach ->
         atom.commands.dispatch(workspaceElement, 'project-find:show')
@@ -770,6 +776,12 @@ describe 'ProjectFindView', ->
         editor.setSelectedBufferRange([[1, 1], [1, 1]])
         atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
         expect(projectFindView.findEditor.getText()).toBe 'function'
+
+      it "places selected text into the find editor and escapes it when Regex is enabled", ->
+        atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
+        editor.setSelectedBufferRange([[6, 6], [6, 65]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
+        expect(projectFindView.findEditor.getText()).toBe 'current < pivot \\? left\\.push\\(current\\) : right\\.push\\(current\\);'
 
     describe "when there is an error searching", ->
       it "displays the errors in the results pane", ->


### PR DESCRIPTION
Currently, if the Regex option is enabled and the use-selection-as-find-pattern command is triggered on a string like `function foo($bar) {`, then the find-window's search string won't actually match the selection since the characters in the string don't make for a valid regular expression.

If the Regex option is selected, then the selection string should be escaped so that it is a valid regular expression.

This patch escapes the search string when the regex option is enabled, allowing the resulting pattern to match the selection.

Closes #455 