### PR TITLE
Add a `liveSearchMinimumCharacters` setting

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -220,7 +220,8 @@ class FindView extends View
 
   liveSearch: ->
     pattern = @findEditor.getText()
-    @updateModel {pattern}
+    if pattern.length is 0 or pattern.length >= atom.config.get('find-and-replace.liveSearchMinimumCharacters')
+      @updateModel {pattern}
 
   findAll: (options={focusEditorAfter: true}) =>
     @findAndSelectResult(@selectAllMarkers, options)

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -20,7 +20,7 @@ module.exports =
     scrollToResultOnLiveSearch:
       type: 'boolean'
       default: false
-      title: 'Scroll To Result On Live Search (incremental find in buffer)'
+      title: 'Scroll To Result On Live-Search (incremental find in buffer)'
       description: 'When you type in the buffer find box, the closest match will be selected and made visible in the editor.'
     liveSearchMinimumCharacters:
       type: 'integer'

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -22,6 +22,11 @@ module.exports =
       default: false
       title: 'Scroll To Result On Live Search (incremental find in buffer)'
       description: 'When you type in the buffer find box, the closest match will be selected and made visible in the editor.'
+    liveSearchMinimumCharacters:
+      type: 'integer'
+      default: 3
+      minimum: 0
+      description: 'When you type in the buffer find box, you must type this many characters to automatically search'
 
   activate: ({@viewState, @projectViewState, @resultsModelState, @modelState, findHistory, replaceHistory, pathsHistory}={}) ->
     atom.workspace.addOpener (filePath) ->

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -889,6 +889,40 @@ describe 'FindView', ->
         expect(findView.descriptionLabel.text()).toContain "6 results"
         expect(findView).toHaveFocus()
 
+      it "respects the `liveSearchMinimumCharacters` setting", ->
+        expect(findView.descriptionLabel.text()).toContain "6 results"
+        atom.config.set('find-and-replace.liveSearchMinimumCharacters', 3)
+
+        findView.findEditor.setText 'why do I need these 2 lines? The editor does not trigger contents-modified without them'
+        advance()
+
+        findView.findEditor.setText ''
+        advance()
+        expect(findView.descriptionLabel.text()).toContain "Find in Current Buffer"
+        expect(findView).toHaveFocus()
+
+        findView.findEditor.setText 'ite'
+        advance()
+        expect(findView.descriptionLabel.text()).toContain "6 results"
+        expect(findView).toHaveFocus()
+
+        findView.findEditor.setText 'i'
+        advance()
+        expect(findView.descriptionLabel.text()).toContain "6 results"
+        expect(findView).toHaveFocus()
+
+        findView.findEditor.setText ''
+        advance()
+        expect(findView.descriptionLabel.text()).toContain "Find in Current Buffer"
+        expect(findView).toHaveFocus()
+
+        atom.config.set('find-and-replace.liveSearchMinimumCharacters', 0)
+
+        findView.findEditor.setText 'i'
+        advance()
+        expect(findView.descriptionLabel.text()).toContain "20 results"
+        expect(findView).toHaveFocus()
+
     describe "when another find is called", ->
       previousMarkers = null
 


### PR DESCRIPTION
This is intended to assuage the editor freezing when live (auto) searching in buffer until we get to really truly fixing #145. I've set the default minimum character length to 3.

Closes #174 
Closes #440 
Closes #368 
Closes #153 