### PR TITLE
Update project replace-all flow 

### DIFF
--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -231,13 +231,19 @@ class ProjectFindView extends View
   replaceAll: ->
     return atom.beep() unless @model.matchCount
 
-    @clearMessages()
     @showResultPane().then =>
-      pattern = @findEditor.getText()
+      pattern = @model.pattern
       replacementPattern = @replaceEditor.getText()
 
-      @clearMessages()
-      @model.replace(@getPaths(), replacementPattern, @model.getPaths())
+      message = "This will replace '#{pattern}' with '#{replacementPattern}' #{_.pluralize(@model.matchCount, 'time')} in #{_.pluralize(@model.pathCount, 'file')}"
+      buttonChosen = atom.confirm
+        message: 'Are you sure you want to replace all?'
+        detailedMessage: message
+        buttons: ['Ok', 'Cancel']
+
+      if buttonChosen is 0
+        @clearMessages()
+        @model.replace(@getPaths(), replacementPattern, @model.getPaths())
 
   getPaths: ->
     inputPath.trim() for inputPath in @pathsEditor.getText().trim().split(',') when inputPath

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -229,14 +229,15 @@ class ProjectFindView extends View
         @setErrorMessage(e.message)
 
   replaceAll: ->
+    return atom.beep() unless @model.matchCount
+
     @clearMessages()
     @showResultPane().then =>
       pattern = @findEditor.getText()
       replacementPattern = @replaceEditor.getText()
 
-      @model.search(pattern, @getPaths(), replacementPattern, onlyRunIfChanged: true).then =>
-        @clearMessages()
-        @model.replace(pattern, @getPaths(), replacementPattern, @model.getPaths())
+      @clearMessages()
+      @model.replace(@getPaths(), replacementPattern, @model.getPaths())
 
   getPaths: ->
     inputPath.trim() for inputPath in @pathsEditor.getText().trim().split(',') when inputPath

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -308,7 +308,7 @@ class ProjectFindView extends View
 
   updateReplaceAllButtonEnablement: (results) ->
     canReplace = results?.matchCount and results?.pattern is @findEditor.getText()
-    @replaceAllButton[0].disabled = !canReplace
+    @replaceAllButton[0].disabled = not canReplace
 
   updateOptionsLabel: ->
     label = []

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -41,7 +41,7 @@ class ProjectFindView extends View
           @subview 'replaceEditor', new TextEditorView(mini: true, placeholderText: 'Replace in project')
         @div class: 'input-block-item', =>
           @div class: 'btn-group btn-group-replace-all', =>
-            @button outlet: 'replaceAllButton', class: 'btn', 'Replace All'
+            @button outlet: 'replaceAllButton', class: 'btn', disabled: 'disabled', 'Replace All'
 
       @section class: 'input-block paths-container', =>
         @div class: 'input-block-item editor-container', =>
@@ -121,9 +121,17 @@ class ProjectFindView extends View
       'project-find:toggle-whole-word-option': => @toggleWholeWordOption()
       'project-find:replace-all': => @replaceAll()
 
-    @subscriptions.add @model.onDidClear => @clearMessages()
-    @subscriptions.add @model.onDidClearReplacementState (results) => @generateResultsMessage(results)
-    @subscriptions.add @model.onDidFinishSearching (results) => @generateResultsMessage(results)
+    updateInterfaceForResults = (results) =>
+      @generateResultsMessage(results)
+      @updateReplaceAllButtonEnablement(results)
+
+    resetInterface = =>
+      @clearMessages()
+      @updateReplaceAllButtonEnablement(null)
+
+    @subscriptions.add @model.onDidClear(resetInterface)
+    @subscriptions.add @model.onDidClearReplacementState(updateInterfaceForResults)
+    @subscriptions.add @model.onDidFinishSearching(updateInterfaceForResults)
 
     @on 'focus', (e) => @findEditor.focus()
     @regexOptionButton.click => @toggleRegexOption()
@@ -277,6 +285,9 @@ class ProjectFindView extends View
 
   setErrorMessage: (errorMessage) ->
     @descriptionLabel.html(errorMessage).addClass('text-error')
+
+  updateReplaceAllButtonEnablement: (results) ->
+    @replaceAllButton[0].disabled = !results?.matchCount
 
   updateOptionsLabel: ->
     label = []

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -122,7 +122,10 @@ class ProjectFindView extends View
       'project-find:replace-all': => @replaceAll()
 
     updateInterfaceForResults = (results) =>
-      @generateResultsMessage(results)
+      if results.matchCount is 0 and results.pattern is ''
+        @clearMessages()
+      else
+        @generateResultsMessage(results)
       @updateReplaceAllButtonEnablement(results)
 
     resetInterface = =>

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -133,8 +133,8 @@ class ResultsModel
         @inProgressSearchPromise = null
         @emitter.emit 'did-finish-searching', @getResultsSummary()
 
-  replace: (pattern, searchPaths, replacementPattern, replacementPaths) ->
-    regex = @getRegex(pattern)
+  replace: (searchPaths, replacementPattern, replacementPaths) ->
+    return unless @pattern and @regex?
 
     @updateReplacementPattern(replacementPattern)
     replacementPattern = escapeHelper.unescapeEscapeSequence(replacementPattern) if @useRegex
@@ -143,7 +143,7 @@ class ResultsModel
     @replacedPathCount = 0
     @replacementCount = 0
 
-    promise = atom.workspace.replace regex, replacementPattern, replacementPaths, (result, error) =>
+    promise = atom.workspace.replace @regex, replacementPattern, replacementPaths, (result, error) =>
       if result
         if result.replacements
           @replacedPathCount++
@@ -157,7 +157,7 @@ class ResultsModel
     @emitter.emit 'did-start-replacing', promise
     promise.then =>
       @emitter.emit 'did-finish-replacing', @getResultsSummary()
-      @search(pattern, searchPaths, replacementPattern, {keepReplacementState: true})
+      @search(@pattern, searchPaths, replacementPattern, {keepReplacementState: true})
 
   updateReplacementPattern: (replacementPattern) ->
     @replacementPattern = replacementPattern or null

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -929,6 +929,8 @@ describe 'ProjectFindView', ->
         atom.project.setPaths([projectPath])
         atom.commands.dispatch(workspaceElement, 'project-find:show')
 
+        spyOn(atom, 'confirm').andReturn 0
+
       describe "when the regex option is chosen", ->
         beforeEach ->
           atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
@@ -1002,6 +1004,9 @@ describe 'ProjectFindView', ->
           expect(projectFindView.replaceAllButton[0].disabled).toBe true
 
     describe "when the replace button is pressed", ->
+      beforeEach ->
+        spyOn(atom, 'confirm').andReturn 0
+
       it "runs the search, and replaces all the matches", ->
         projectFindView.findEditor.setText('items')
         atom.commands.dispatch(projectFindView[0], 'core:confirm')
@@ -1057,6 +1062,9 @@ describe 'ProjectFindView', ->
 
     describe "when the project-find:replace-all is triggered", ->
       describe "when no search has been run", ->
+        beforeEach ->
+          spyOn(atom, 'confirm').andReturn 0
+
         it "does nothing", ->
           projectFindView.findEditor.setText('items')
           projectFindView.replaceEditor.setText('sunshine')
@@ -1071,6 +1079,7 @@ describe 'ProjectFindView', ->
 
       describe "when a search with no results has been run", ->
         beforeEach ->
+          spyOn(atom, 'confirm').andReturn 0
           projectFindView.findEditor.setText('nopenotinthefile')
           atom.commands.dispatch(projectFindView[0], 'core:confirm')
 
@@ -1100,6 +1109,7 @@ describe 'ProjectFindView', ->
             searchPromise
 
         it "replaces the original search text with the replacement when the search text has changed since that last search", ->
+          spyOn(atom, 'confirm').andReturn 0
           spyOn(atom.workspace, 'scan').andCallThrough()
           spyOn(atom, 'beep')
 
@@ -1118,6 +1128,7 @@ describe 'ProjectFindView', ->
             expect(projectFindView.descriptionLabel.text()).toContain "Replaced items with ok 13 times in 2 files"
 
         it "replaces all the matches and updates the results view", ->
+          spyOn(atom, 'confirm').andReturn 0
           projectFindView.replaceEditor.setText('sunshine')
           atom.commands.dispatch(projectFindView[0], 'project-find:replace-all')
           expect(projectFindView.errorMessages).not.toBeVisible()
@@ -1142,8 +1153,22 @@ describe 'ProjectFindView', ->
             expect(sampleCoffeeContent.match(/items/g)).toBeFalsy()
             expect(sampleCoffeeContent.match(/sunshine/g)).toHaveLength 7
 
+        describe "when the confirm box is cancelled", ->
+          beforeEach ->
+            spyOn(atom, 'confirm').andReturn 1
+
+          it "does not replace", ->
+            projectFindView.replaceEditor.setText('sunshine')
+            atom.commands.dispatch(projectFindView[0], 'project-find:replace-all')
+
+            waitsForPromise -> replacePromise
+
+            runs ->
+              expect(projectFindView.descriptionLabel.text()).toContain "13 results found"
+
     describe "when there is an error replacing", ->
       beforeEach ->
+        spyOn(atom, 'confirm').andReturn 0
         projectFindView.findEditor.setText('items')
         atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
         waitsForPromise -> searchPromise

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -992,6 +992,12 @@ describe 'ProjectFindView', ->
           projectFindView.findEditor.setText('nopenotinthefile')
           atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
 
+          projectFindView.findEditor.setText('itemss')
+          expect(projectFindView.replaceAllButton[0].disabled).toBe true
+
+          projectFindView.findEditor.setText('items')
+          expect(projectFindView.replaceAllButton[0].disabled).toBe false
+
         waitsForPromise ->
           searchPromise
 
@@ -1108,24 +1114,18 @@ describe 'ProjectFindView', ->
           waitsForPromise ->
             searchPromise
 
-        it "replaces the original search text with the replacement when the search text has changed since that last search", ->
+        it "messages the user when the search text has changed since that last search", ->
           spyOn(atom, 'confirm').andReturn 0
           spyOn(atom.workspace, 'scan').andCallThrough()
-          spyOn(atom, 'beep')
 
           projectFindView.findEditor.setText('sort')
           projectFindView.replaceEditor.setText('ok')
-          expect(projectFindView.resultsView).not.toBeVisible()
 
           atom.commands.dispatch(projectFindView[0], 'project-find:replace-all')
 
-          waitsForPromise ->
-            replacePromise
-
-          runs ->
-            expect(atom.workspace.scan).toHaveBeenCalled()
-            expect(atom.beep).not.toHaveBeenCalled()
-            expect(projectFindView.descriptionLabel.text()).toContain "Replaced items with ok 13 times in 2 files"
+          expect(atom.confirm).toHaveBeenCalled()
+          expect(replacePromise).toBeUndefined()
+          expect(atom.workspace.scan).not.toHaveBeenCalled()
 
         it "replaces all the matches and updates the results view", ->
           spyOn(atom, 'confirm').andReturn 0

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -1054,7 +1054,20 @@ describe 'ProjectFindView', ->
             expect(projectFindView.descriptionLabel.text()).toContain "13 results found in 2 files for items"
 
     describe "when the project-find:replace-all is triggered", ->
-      describe "when there are no results", ->
+      describe "when no search has been run", ->
+        it "does nothing", ->
+          projectFindView.findEditor.setText('items')
+          projectFindView.replaceEditor.setText('sunshine')
+
+          spyOn(atom, 'beep')
+          atom.commands.dispatch(projectFindView[0], 'project-find:replace-all')
+
+          expect(replacePromise).toBeUndefined()
+
+          expect(atom.beep).toHaveBeenCalled()
+          expect(projectFindView.descriptionLabel.text()).toContain "Find in Project"
+
+      describe "when a search with no results has been run", ->
         beforeEach ->
           projectFindView.findEditor.setText('nopenotinthefile')
           atom.commands.dispatch(projectFindView[0], 'core:confirm')
@@ -1076,20 +1089,7 @@ describe 'ProjectFindView', ->
           expect(atom.beep).toHaveBeenCalled()
           expect(projectFindView.descriptionLabel.text().replace(/(  )/g, ' ')).toContain "No results"
 
-      describe "when no search has been run", ->
-        it "does nothing", ->
-          projectFindView.findEditor.setText('items')
-          projectFindView.replaceEditor.setText('sunshine')
-
-          spyOn(atom, 'beep')
-          atom.commands.dispatch(projectFindView[0], 'project-find:replace-all')
-
-          expect(replacePromise).toBeUndefined()
-
-          expect(atom.beep).toHaveBeenCalled()
-          expect(projectFindView.descriptionLabel.text()).toContain "Find in Project"
-
-      describe "when a search has been run", ->
+      describe "when a search with results has been run", ->
         beforeEach ->
           projectFindView.findEditor.setText('items')
           atom.commands.dispatch(projectFindView[0], 'core:confirm')

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -933,39 +933,41 @@ describe 'ProjectFindView', ->
         beforeEach ->
           atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
 
-        it "finds the escape char", ->
           projectFindView.findEditor.setText('a')
+          atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
+          waitsForPromise -> searchPromise
+
+        it "finds the escape char", ->
           projectFindView.replaceEditor.setText('\\t')
           atom.commands.dispatch(projectFindView[0], 'project-find:replace-all')
 
-          waitsForPromise ->
-            replacePromise
+          waitsForPromise -> replacePromise
 
           runs ->
             fileContent = fs.readFileSync(filePath, 'utf8')
             expect(fileContent).toBe("\t\nb\n\t")
 
         it "doesn't insert a escaped char if there are multiple backslashs in front of the char", ->
-          projectFindView.findEditor.setText('a')
           projectFindView.replaceEditor.setText('\\\\t')
           atom.commands.dispatch(projectFindView[0], 'project-find:replace-all')
 
-          waitsForPromise ->
-            replacePromise
+          waitsForPromise -> replacePromise
 
           runs ->
             fileContent = fs.readFileSync(filePath, 'utf8')
             expect(fileContent).toBe("\\t\nb\n\\t")
 
-
       describe "when regex option is not set", ->
-        it "finds the escape char", ->
+        beforeEach ->
           projectFindView.findEditor.setText('a')
+          atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
+          waitsForPromise -> searchPromise
+
+        it "finds the escape char", ->
           projectFindView.replaceEditor.setText('\\t')
           atom.commands.dispatch(projectFindView[0], 'project-find:replace-all')
 
-          waitsForPromise ->
-            replacePromise
+          waitsForPromise -> replacePromise
 
           runs ->
             fileContent = fs.readFileSync(filePath, 'utf8')
@@ -1141,9 +1143,13 @@ describe 'ProjectFindView', ->
             expect(sampleCoffeeContent.match(/sunshine/g)).toHaveLength 7
 
     describe "when there is an error replacing", ->
+      beforeEach ->
+        projectFindView.findEditor.setText('items')
+        atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
+        waitsForPromise -> searchPromise
+
       it "displays the errors in the results pane", ->
         [callback, deferred, called, resultsPaneView, errorList] = []
-        projectFindView.findEditor.setText('items')
         projectFindView.replaceEditor.setText('sunshine')
 
         spyOn(atom.workspace, 'replace').andCallFake (regex, replacement, paths, fn) ->

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -971,6 +971,34 @@ describe 'ProjectFindView', ->
             fileContent = fs.readFileSync(filePath, 'utf8')
             expect(fileContent).toBe("\\t\nb\n\\t")
 
+    describe "replace all button enablement", ->
+      it "is disabled initially", ->
+        expect(projectFindView.replaceAllButton[0].disabled).toBe true
+
+      it "is enabled when a search has results and disabled when there are no results", ->
+        projectFindView.findEditor.setText('items')
+        atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
+
+        waitsForPromise ->
+          searchPromise
+
+        runs ->
+          expect(projectFindView.replaceAllButton[0].disabled).toBe false
+
+          projectFindView.findEditor.setText('nopenotinthefile')
+          atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
+
+        waitsForPromise ->
+          searchPromise
+
+        runs ->
+          expect(projectFindView.replaceAllButton[0].disabled).toBe true
+
+          projectFindView.findEditor.setText('')
+          atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
+
+          expect(projectFindView.replaceAllButton[0].disabled).toBe true
+
     describe "when the replace button is pressed", ->
       it "runs the search, and replaces all the matches", ->
         projectFindView.findEditor.setText('items')


### PR DESCRIPTION
This is a tuneup for https://github.com/atom/find-and-replace/issues/331. People are hosing their working state and it sucks. Replace all was a little too eager. This PR changes a few things

First, you must have run a search with results to enable the replace all functionality. Before a search or after a search with no results, the replace-all function is disabled, and the command will 'beep':

![disasbled](https://cloud.githubusercontent.com/assets/69169/9050047/1e077e60-39fe-11e5-8684-eb643320f981.jpg)

The second thing is a confirm box on replace all:

![screen shot 2015-08-03 at 4 33 09 pm](https://cloud.githubusercontent.com/assets/69169/9050050/2b7bbb2e-39fe-11e5-9b2a-42f1de8c0c13.png)

And the third is that it will not replace unless the search pattern is the same as the results pattern. Previously, if you searched for `welcome`, changed the find box to `something`, then ran a replace all, it would first search for `something`, then do the replace all on `something`. Now you must explicitly search for the string before you can replace it:

![fnr-replace-all](https://cloud.githubusercontent.com/assets/69169/9051033/2854f7e2-3a0a-11e5-8216-4b0ba5a0feda.gif)

Hopefully these checks will make things more reliable for folks.