### PR TITLE
Focus the editor when window:focus-next-pane is triggered

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -46,6 +46,9 @@ module.exports =
     @replaceHistory = new History(replaceHistory)
     @pathsHistory = new History(pathsHistory)
 
+    @subscriptions.add atom.commands.add '.find-and-replace, .project-find', 'window:focus-next-pane', =>
+      atom.views.getView(atom.workspace).focus()
+
     @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:show', =>
       @createViews()
       @findPanel.hide()

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -123,6 +123,16 @@ describe 'FindView', ->
         atom.commands.dispatch workspaceElement, 'find-and-replace:toggle'
         expect(getFindAtomPanel()).not.toBeVisible()
 
+  describe "when the find-view is focused and window:focus-next-pane is triggered", ->
+    beforeEach ->
+      atom.commands.dispatch editorView, 'find-and-replace:show'
+      waitsForPromise -> activationPromise
+
+    it "attaches FindView to the root view", ->
+      expect(workspaceElement.querySelector('.find-and-replace')).toHaveFocus()
+      atom.commands.dispatch(findView.findEditor.element, 'window:focus-next-pane')
+      expect(workspaceElement.querySelector('.find-and-replace')).not.toHaveFocus()
+
   describe "when FindView's replace editor is visible", ->
     it "keeps the replace editor visible when find-and-replace:show is triggered", ->
       atom.commands.dispatch editorView, 'find-and-replace:show-replace'


### PR DESCRIPTION
Currently there is no way to focus the editor when focused in find panel, other than closing the find panel with escape. This PR binds `window:focus-next-pane` to focus the editor, so you can use the same keybinding you use to move focus between panes.

This coupled with https://github.com/atom/atom/pull/8220 should up the keybinding game when focused in the find panel. 
