### PR TITLE
Regex syntax highlighting

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -296,6 +296,12 @@ class FindView extends View
 
   updateModel: (options) ->
     @findModel.setSearchParams(options)
+    # Set syntax highlighting if using regular expressions
+    if @findModel.useRegex
+      grammar = atom.grammars.grammarForScopeName('source.regexp.python')
+      @findEditor.getModel().setGrammar(grammar)
+    else
+      @findEditor.getModel().setGrammar(atom.grammars.nullGrammar)
 
   updateResultCounter: =>
     if @findModel.currentResultMarker and (index = @markers.indexOf(@findModel.currentResultMarker)) > -1

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -300,7 +300,7 @@ class FindView extends View
     @findModel.setSearchParams(options)
     # Set syntax highlighting if using regular expressions
     if @findModel.useRegex
-      grammar = atom.grammars.grammarForScopeName('source.regexp.python')
+      grammar = atom.grammars.grammarForScopeName('source.js.regexp')
       @findEditor.getModel().setGrammar(grammar)
     else
       @findEditor.getModel().setGrammar(atom.grammars.nullGrammar)

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -61,6 +61,7 @@ class ProjectFindView extends View
 
     @clearMessages()
     @updateOptionsLabel()
+    @updateModel()
 
   destroy: ->
     @subscriptions?.dispose()
@@ -158,18 +159,21 @@ class ProjectFindView extends View
     @model.toggleUseRegex()
     if @model.useRegex then @regexOptionButton.addClass('selected') else @regexOptionButton.removeClass('selected')
     @updateOptionsLabel()
+    @updateModel()
     @search(onlyRunIfActive: true)
 
   toggleCaseOption: ->
     @model.toggleCaseSensitive()
     if @model.caseSensitive then @caseOptionButton.addClass('selected') else @caseOptionButton.removeClass('selected')
     @updateOptionsLabel()
+    @updateModel()
     @search(onlyRunIfActive: true)
 
   toggleWholeWordOption: ->
     @model.toggleWholeWord()
     if @model.wholeWord then @wholeWordOptionButton.addClass('selected') else @wholeWordOptionButton.removeClass('selected')
     @updateOptionsLabel()
+    @updateModel()
     @search(onlyRunIfActive: true)
 
   focusNextElement: (direction) ->
@@ -275,6 +279,14 @@ class ProjectFindView extends View
 
   setErrorMessage: (errorMessage) ->
     @descriptionLabel.html(errorMessage).addClass('text-error')
+
+  updateModel: ->
+    # Set syntax highlighting if using regular expressions
+    if @model.useRegex
+      grammar = atom.grammars.grammarForScopeName('source.regexp.python')
+      @findEditor.getModel().setGrammar(grammar)
+    else
+      @findEditor.getModel().setGrammar(atom.grammars.nullGrammar)
 
   updateOptionsLabel: ->
     label = []

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -1243,3 +1243,26 @@ describe 'FindView', ->
       atom.commands.dispatch findView.replaceEditor.element, 'find-and-replace:focus-next'
       expect(findView.findEditor).toHaveClass('is-focused')
       expect(findView.replaceEditor).not.toHaveClass('is-focused')
+
+  describe "when language-javascript is also active", ->
+    beforeEach ->
+      waitsForPromise ->
+        atom.packages.activatePackage("language-javascript")
+
+      atom.commands.dispatch editorView, 'find-and-replace:show'
+      waitsForPromise -> activationPromise
+
+    it "does not use regexp grammar when in non-regex mode", ->
+      expect(findView.model.getFindOptions().useRegex).not.toBe true
+      expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
+
+    it "uses regexp grammar when in regex mode and clears the regexp grammar when regex is disabled", ->
+      atom.commands.dispatch(findView.findEditor.element, 'find-and-replace:toggle-regex-option')
+
+      expect(findView.model.getFindOptions().useRegex).toBe true
+      expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp'
+
+      atom.commands.dispatch(findView.findEditor.element, 'find-and-replace:toggle-regex-option')
+
+      expect(findView.model.getFindOptions().useRegex).not.toBe true
+      expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -1244,25 +1244,37 @@ describe 'FindView', ->
       expect(findView.findEditor).toHaveClass('is-focused')
       expect(findView.replaceEditor).not.toHaveClass('is-focused')
 
-  describe "when language-javascript is also active", ->
+  describe "when language-javascript is active", ->
     beforeEach ->
       waitsForPromise ->
         atom.packages.activatePackage("language-javascript")
 
+    it "uses the regexp grammar when regex-mode is loaded from configuration", ->
+      atom.config.set('find-and-replace.useRegex', true)
       atom.commands.dispatch editorView, 'find-and-replace:show'
-      waitsForPromise -> activationPromise
+      waitsForPromise ->
+        activationPromise
+      
+      runs ->
+        expect(findView.model.getFindOptions().useRegex).toBe true
+        expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp'
 
-    it "does not use regexp grammar when in non-regex mode", ->
-      expect(findView.model.getFindOptions().useRegex).not.toBe true
-      expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
+    describe "when panel is active", ->
+      beforeEach ->
+        atom.commands.dispatch editorView, 'find-and-replace:show'
+        waitsForPromise -> activationPromise
 
-    it "uses regexp grammar when in regex mode and clears the regexp grammar when regex is disabled", ->
-      atom.commands.dispatch(findView.findEditor.element, 'find-and-replace:toggle-regex-option')
+      it "does not use regexp grammar when in non-regex mode", ->
+        expect(findView.model.getFindOptions().useRegex).not.toBe true
+        expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
 
-      expect(findView.model.getFindOptions().useRegex).toBe true
-      expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp'
+      it "uses regexp grammar when in regex mode and clears the regexp grammar when regex is disabled", ->
+        atom.commands.dispatch(findView.findEditor.element, 'find-and-replace:toggle-regex-option')
 
-      atom.commands.dispatch(findView.findEditor.element, 'find-and-replace:toggle-regex-option')
+        expect(findView.model.getFindOptions().useRegex).toBe true
+        expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp'
 
-      expect(findView.model.getFindOptions().useRegex).not.toBe true
-      expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
+        atom.commands.dispatch(findView.findEditor.element, 'find-and-replace:toggle-regex-option')
+
+        expect(findView.model.getFindOptions().useRegex).not.toBe true
+        expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -1291,3 +1291,26 @@ describe 'ProjectFindView', ->
 
         runs ->
           expect(workspaceElement.querySelectorAll('.preview-pane').length).toBe(1)
+
+  describe "when language-javascript is also active", ->
+    beforeEach ->
+      waitsForPromise ->
+        atom.packages.activatePackage("language-javascript")
+
+      atom.commands.dispatch(workspaceElement, 'project-find:show')
+      waitsForPromise -> activationPromise
+
+    it "does not use regexp grammar when in non-regex mode", ->
+      expect(projectFindView.model.getFindOptions().useRegex).not.toBe true
+      expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
+
+    it "uses regexp grammar when in regex mode and clears the regexp grammar when regex is disabled", ->
+      atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
+
+      expect(projectFindView.model.getFindOptions().useRegex).toBe true
+      expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp'
+
+      atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
+
+      expect(projectFindView.model.getFindOptions().useRegex).not.toBe true
+      expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -1292,25 +1292,37 @@ describe 'ProjectFindView', ->
         runs ->
           expect(workspaceElement.querySelectorAll('.preview-pane').length).toBe(1)
 
-  describe "when language-javascript is also active", ->
+  describe "when language-javascript is active", ->
     beforeEach ->
       waitsForPromise ->
         atom.packages.activatePackage("language-javascript")
 
+    it "uses the regexp grammar when regex-mode is loaded from configuration", ->
+      atom.config.set('find-and-replace.useRegex', true)
       atom.commands.dispatch(workspaceElement, 'project-find:show')
-      waitsForPromise -> activationPromise
+      waitsForPromise ->
+        activationPromise
 
-    it "does not use regexp grammar when in non-regex mode", ->
-      expect(projectFindView.model.getFindOptions().useRegex).not.toBe true
-      expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
+      runs ->
+        expect(projectFindView.model.getFindOptions().useRegex).toBe true
+        expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp'
 
-    it "uses regexp grammar when in regex mode and clears the regexp grammar when regex is disabled", ->
-      atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
+    describe "when panel is active", ->
+      beforeEach ->
+        atom.commands.dispatch(workspaceElement, 'project-find:show')
+        waitsForPromise -> activationPromise
 
-      expect(projectFindView.model.getFindOptions().useRegex).toBe true
-      expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp'
+      it "does not use regexp grammar when in non-regex mode", ->
+        expect(projectFindView.model.getFindOptions().useRegex).not.toBe true
+        expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
 
-      atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
+      it "uses regexp grammar when in regex mode and clears the regexp grammar when regex is disabled", ->
+        atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
 
-      expect(projectFindView.model.getFindOptions().useRegex).not.toBe true
-      expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
+        expect(projectFindView.model.getFindOptions().useRegex).toBe true
+        expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp'
+
+        atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
+
+        expect(projectFindView.model.getFindOptions().useRegex).not.toBe true
+        expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -114,25 +114,6 @@ atom-workspace.find-visible {
     }
   }
 
-  .find-container atom-text-editor::shadow {
-    // Styles for regular expression highlighting
-    .regexp {
-      .escape {
-        color: rgb(51, 51, 255);
-      }
-      .range, .character-class {
-        color: rgb(0, 200, 0);
-      }
-      .set {
-        color: inherit;
-      }
-      .keyword, .punctuation {
-        color: rgb(255, 51, 51);
-        font-weight: normal;
-      }
-    }
-  }
-
 }
 
 // Buffer find and replace

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -261,3 +261,25 @@ atom-workspace.find-visible {
     }
   }
 }
+
+.find-container atom-text-editor::shadow {
+  // Styles for regular expression highlighting
+  .regexp {
+    .escape {
+      color: @text-color-info;
+    }
+    .range, .character-class, .wildcard {
+      color: @text-color-success;
+    }
+    .wildcard {
+      font-weight: bold;
+    }
+    .set {
+      color: inherit;
+    }
+    .keyword, .punctuation {
+      color: @text-color-error;
+      font-weight: normal;
+    }
+  }
+}

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -114,6 +114,22 @@ atom-workspace.find-visible {
     }
   }
 
+  .find-container atom-text-editor::shadow {
+    // Styles for regular expression highlighting
+    .regexp {
+      .escape {
+        color: rgb(51, 51, 255);
+      }
+      .range, .character-class {
+        color: rgb(0, 200, 0);
+      }
+      .keyword, .punctuation {
+        color: rgb(255, 51, 51);
+        font-weight: normal;
+      }
+    }
+  }
+
 }
 
 // Buffer find and replace
@@ -148,22 +164,6 @@ atom-workspace.find-visible {
 
   .find-container atom-text-editor {
     padding-right: 64px; // leave some room for the results count
-  }
-
-  .find-container atom-text-editor::shadow {
-    // Styles for regular expression highlighting
-    .regexp {
-      .escape {
-        color: rgb(51, 51, 255);
-      }
-      .range, .character-class {
-        color: rgb(0, 200, 0);
-      }
-      .keyword, .punctuation {
-        color: rgb(255, 51, 51);
-        font-weight: normal;
-      }
-    }
   }
 
   // results count

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -123,6 +123,9 @@ atom-workspace.find-visible {
       .range, .character-class {
         color: rgb(0, 200, 0);
       }
+      .set {
+        color: inherit;
+      }
       .keyword, .punctuation {
         color: rgb(255, 51, 51);
         font-weight: normal;

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -157,7 +157,7 @@ atom-workspace.find-visible {
         color: rgb(51, 51, 255);
       }
       .range, .character-class {
-        color: rgb(51, 150, 51);
+        color: rgb(0, 200, 0);
       }
       .keyword, .punctuation {
         color: rgb(255, 51, 51);

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -150,6 +150,22 @@ atom-workspace.find-visible {
     padding-right: 64px; // leave some room for the results count
   }
 
+  .find-container atom-text-editor::shadow {
+    // Styles for regular expression highlighting
+    .regexp {
+      .escape {
+        color: rgb(51, 51, 255);
+      }
+      .range, .character-class {
+        color: rgb(51, 150, 51);
+      }
+      .keyword, .punctuation {
+        color: rgb(255, 51, 51);
+        font-weight: normal;
+      }
+    }
+  }
+
   // results count
   .find-meta-container {
     position: absolute;


### PR DESCRIPTION
This PR implements syntax highlighting for regular expression searches and will fix #458.

Highlighting works in both the buffer-find and project find dialogs and defaults to text colors that are required by all themes. Themes can override the styling to tweak colors as they desire.