### PR TITLE
Share settings between find-view and project-find-view

### DIFF
--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -52,7 +52,7 @@ class BufferSearch
         if @findOptions.useRegex
           replacementPattern = escapeHelper.unescapeEscapeSequence(replacementPattern)
           textToReplace = @editor.getTextInBufferRange(bufferRange)
-          replacementText = textToReplace.replace(@getRegex(), replacementPattern)
+          replacementText = textToReplace.replace(@getFindPatternRegex(), replacementPattern)
         @editor.setTextInBufferRange(bufferRange, replacementText ? replacementPattern)
 
         marker.destroy()
@@ -84,7 +84,7 @@ class BufferSearch
         start = Point.max(start, selectedRange.start)
         end = Point.min(end, selectedRange.end)
 
-      if regex = @getRegex()
+      if regex = @getFindPatternRegex()
         @editor.scanInBufferRange regex, Range(start, end), ({range}) =>
           newMarkers.push(@createMarker(range))
       else
@@ -200,19 +200,9 @@ class BufferSearch
       newText
     )
 
-  getRegex: ->
-    flags = 'g'
-    flags += 'i' unless @findOptions.caseSensitive
-
-    if @findOptions.useRegex
-      expression = @findOptions.findPattern
-    else
-      expression = _.escapeRegExp(@findOptions.findPattern)
-
-    expression = "\\b#{expression}\\b" if @findOptions.wholeWord
-
+  getFindPatternRegex: ->
     try
-      new RegExp(expression, flags)
+      @findOptions.getFindPatternRegex()
     catch e
       @emitter.emit 'did-error', e
       null

--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -16,7 +16,8 @@ class BufferSearch
 
     recreateMarkers = @recreateMarkers.bind(this)
     @findOptions.onDidChange (changedParams) =>
-      return unless changedParams? or changedParams.findPattern? or
+      return unless changedParams?
+      return unless changedParams.findPattern? or
         changedParams.useRegex? or
         changedParams.wholeWord? or
         changedParams.caseSensitive? or

--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -27,6 +27,9 @@ class FindOptions
   onDidChange: (callback) ->
     @emitter.on('did-change', callback)
 
+  onDidChangeReplacePattern: (callback) ->
+    @emitter.on('did-change-replacePattern', callback)
+
   serialize: ->
     result = {}
     for param in Params
@@ -34,12 +37,17 @@ class FindOptions
     result
 
   set: (newParams={}) ->
-    changed = false
+    changedParams = null
     for key in Params
       if newParams[key]? and newParams[key] isnt this[key]
+        changedParams ?= []
+        changedParams.push(key)
         this[key] = newParams[key]
-        changed = true
-    @emitter.emit('did-change') if changed
+
+    if changedParams?
+      for param in changedParams
+        @emitter.emit("did-change-#{param}")
+      @emitter.emit('did-change')
 
   toggleUseRegex: ->
     @useRegex = not @useRegex

--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -39,3 +39,19 @@ class FindOptions
         this[key] = newParams[key]
         changed = true
     @emitter.emit('did-change') if changed
+
+  toggleUseRegex: ->
+    @useRegex = not @useRegex
+    @emitter.emit('did-change')
+
+  toggleCaseSensitive: ->
+    @caseSensitive = not @caseSensitive
+    @emitter.emit('did-change')
+
+  toggleWholeWord: ->
+    @wholeWord = not @wholeWord
+    @emitter.emit('did-change')
+
+  toggleInCurrentSelection: ->
+    @inCurrentSelection = not @inCurrentSelection
+    @emitter.emit('did-change')

--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -40,14 +40,13 @@ class FindOptions
     changedParams = null
     for key in Params
       if newParams[key]? and newParams[key] isnt this[key]
-        changedParams ?= []
-        changedParams.push(key)
-        this[key] = newParams[key]
+        changedParams ?= {}
+        this[key] = changedParams[key] = newParams[key]
 
     if changedParams?
-      for param in changedParams
+      for param, val of changedParams
         @emitter.emit("did-change-#{param}")
-      @emitter.emit('did-change')
+      @emitter.emit('did-change', changedParams)
 
   toggleUseRegex: ->
     @useRegex = not @useRegex

--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -48,22 +48,6 @@ class FindOptions
         @emitter.emit("did-change-#{param}")
       @emitter.emit('did-change', changedParams)
 
-  toggleUseRegex: ->
-    @useRegex = not @useRegex
-    @emitter.emit('did-change')
-
-  toggleCaseSensitive: ->
-    @caseSensitive = not @caseSensitive
-    @emitter.emit('did-change')
-
-  toggleWholeWord: ->
-    @wholeWord = not @wholeWord
-    @emitter.emit('did-change')
-
-  toggleInCurrentSelection: ->
-    @inCurrentSelection = not @inCurrentSelection
-    @emitter.emit('did-change')
-
   getFindPatternRegex: ->
     flags = 'g'
     flags += 'i' unless @caseSensitive

--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -1,3 +1,4 @@
+_ = require 'underscore-plus'
 {Emitter} = require 'atom'
 
 Params = [
@@ -55,3 +56,16 @@ class FindOptions
   toggleInCurrentSelection: ->
     @inCurrentSelection = not @inCurrentSelection
     @emitter.emit('did-change')
+
+  getFindPatternRegex: ->
+    flags = 'g'
+    flags += 'i' unless @caseSensitive
+
+    if @useRegex
+      expression = @findPattern
+    else
+      expression = _.escapeRegExp(@findPattern)
+
+    expression = "\\b#{expression}\\b" if @wholeWord
+
+    new RegExp(expression, flags)

--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -1,0 +1,41 @@
+{Emitter} = require 'atom'
+
+Params = [
+  'findPattern'
+  'replacePattern'
+  'pathsPattern'
+  'useRegex'
+  'wholeWord'
+  'caseSensitive'
+  'inCurrentSelection'
+]
+
+module.exports =
+class FindOptions
+  constructor: (state={}) ->
+    @emitter = new Emitter
+
+    @findPattern = state.findPattern ? ''
+    @replacePattern = state.replacePattern ? ''
+    @pathsPattern = state.pathsPattern ? ''
+    @useRegex = state.useRegex ? atom.config.get('find-and-replace.useRegex') ? false
+    @caseSensitive = state.caseSensitive ? atom.config.get('find-and-replace.caseSensitive') ? false
+    @wholeWord = state.wholeWord ? atom.config.get('find-and-replace.wholeWord') ? false
+    @inCurrentSelection = state.inCurrentSelection ? atom.config.get('find-and-replace.inCurrentSelection') ? false
+
+  onDidChange: (callback) ->
+    @emitter.on('did-change', callback)
+
+  serialize: ->
+    result = {}
+    for param in Params
+      result[param] = this[param]
+    result
+
+  set: (newParams={}) ->
+    changed = false
+    for key in Params
+      if newParams[key]? and newParams[key] isnt this[key]
+        this[key] = newParams[key]
+        changed = true
+    @emitter.emit('did-change') if changed

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -222,7 +222,14 @@ class FindView extends View
   liveSearch: ->
     findPattern = @findEditor.getText()
     if findPattern.length is 0 or findPattern.length >= atom.config.get('find-and-replace.liveSearchMinimumCharacters')
-      @model.search(findPattern)
+      @search(findPattern)
+
+  search: (findPattern, options) ->
+    if arguments.length is 1 and typeof findPattern is 'object'
+      options = findPattern
+      findPattern = null
+    findPattern ?= @findEditor.getText()
+    @model.search(findPattern, options)
 
   findAll: (options={focusEditorAfter: true}) =>
     @findAndSelectResult(@selectAllMarkers, options)
@@ -234,7 +241,7 @@ class FindView extends View
     @findAndSelectResult(@selectFirstMarkerBeforeCursor, options)
 
   findAndSelectResult: (selectFunction, {focusEditorAfter, fieldToFocus}) =>
-    @model.search(@findEditor.getText())
+    @search()
     @findHistory.store()
 
     if @markers?.length > 0
@@ -256,7 +263,7 @@ class FindView extends View
     @replace('findPrevious', 'firstMarkerIndexBeforeCursor')
 
   replace: (nextOrPreviousFn, nextIndexFn) ->
-    @model.search(@findEditor.getText())
+    @search()
     @findHistory.store()
     @replaceHistory.store()
 
@@ -271,7 +278,7 @@ class FindView extends View
       atom.beep()
 
   replaceAll: =>
-    @model.search(@findEditor.getText())
+    @search()
     if @markers?.length
       @replaceHistory.store()
       @findHistory.store()
@@ -382,7 +389,7 @@ class FindView extends View
     if editor?
       findPattern = editor.getSelectedText() or editor.getWordUnderCursor()
       findPattern = Util.escapeRegex(findPattern) if @model.getFindOptions().useRegex
-      @model.search(findPattern) if findPattern
+      @search(findPattern) if findPattern
 
   findNextSelected: =>
     @setSelectionAsFindPattern()
@@ -420,19 +427,19 @@ class FindView extends View
       optionButton.removeClass 'selected'
 
   toggleRegexOption: =>
-    @model.search(@findEditor.getText(), useRegex: not @model.getFindOptions().useRegex)
+    @search(useRegex: not @model.getFindOptions().useRegex)
     @selectFirstMarkerAfterCursor()
 
   toggleCaseOption: =>
-    @model.search(@findEditor.getText(), caseSensitive: not @model.getFindOptions().caseSensitive)
+    @search(caseSensitive: not @model.getFindOptions().caseSensitive)
     @selectFirstMarkerAfterCursor()
 
   toggleSelectionOption: =>
-    @model.search(@findEditor.getText(), inCurrentSelection: not @model.getFindOptions().inCurrentSelection)
+    @search(inCurrentSelection: not @model.getFindOptions().inCurrentSelection)
     @selectFirstMarkerAfterCursor()
 
   toggleWholeWordOption: =>
-    @model.search(@findEditor.getText(), wholeWord: not @model.getFindOptions().wholeWord)
+    @search(@findEditor.getText(), wholeWord: not @model.getFindOptions().wholeWord)
     @selectFirstMarkerAfterCursor()
 
   updateReplaceEnablement: ->

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -282,7 +282,6 @@ class FindView extends View
       atom.beep()
 
   markersUpdated: (@markers) =>
-    console.log 'updated', markers
     @findError = null
     @updateOptionButtons()
     @updateResultCounter()

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -222,7 +222,7 @@ class FindView extends View
   liveSearch: ->
     findPattern = @findEditor.getText()
     if findPattern.length is 0 or findPattern.length >= atom.config.get('find-and-replace.liveSearchMinimumCharacters')
-      @updateModel {findPattern}
+      @model.search(findPattern)
 
   findAll: (options={focusEditorAfter: true}) =>
     @findAndSelectResult(@selectAllMarkers, options)
@@ -234,8 +234,7 @@ class FindView extends View
     @findAndSelectResult(@selectFirstMarkerBeforeCursor, options)
 
   findAndSelectResult: (selectFunction, {focusEditorAfter, fieldToFocus}) =>
-    findPattern = @findEditor.getText()
-    @updateModel {findPattern}
+    @model.search(@findEditor.getText())
     @findHistory.store()
 
     if @markers?.length > 0
@@ -257,8 +256,7 @@ class FindView extends View
     @replace('findPrevious', 'firstMarkerIndexBeforeCursor')
 
   replace: (nextOrPreviousFn, nextIndexFn) ->
-    findPattern = @findEditor.getText()
-    @updateModel {findPattern}
+    @model.search(@findEditor.getText())
     @findHistory.store()
     @replaceHistory.store()
 
@@ -273,7 +271,7 @@ class FindView extends View
       atom.beep()
 
   replaceAll: =>
-    @updateModel {findPattern: @findEditor.getText()}
+    @model.search(@findEditor.getText())
     if @markers?.length
       @replaceHistory.store()
       @findHistory.store()
@@ -300,9 +298,6 @@ class FindView extends View
 
   findError: (error) =>
     @setErrorMessage(error.message)
-
-  updateModel: (options) ->
-    @model.setFindOptions(options)
 
   updateResultCounter: =>
     if @model.currentResultMarker and (index = @markers.indexOf(@model.currentResultMarker)) > -1
@@ -387,7 +382,7 @@ class FindView extends View
     if editor?
       findPattern = editor.getSelectedText() or editor.getWordUnderCursor()
       findPattern = Util.escapeRegex(findPattern) if @model.getFindOptions().useRegex
-      @updateModel {findPattern} if findPattern
+      @model.search(findPattern) if findPattern
 
   findNextSelected: =>
     @setSelectionAsFindPattern()
@@ -425,19 +420,19 @@ class FindView extends View
       optionButton.removeClass 'selected'
 
   toggleRegexOption: =>
-    @updateModel {findPattern: @findEditor.getText(), useRegex: not @model.getFindOptions().useRegex}
+    @model.search(@findEditor.getText(), useRegex: not @model.getFindOptions().useRegex)
     @selectFirstMarkerAfterCursor()
 
   toggleCaseOption: =>
-    @updateModel {findPattern: @findEditor.getText(), caseSensitive: not @model.getFindOptions().caseSensitive}
+    @model.search(@findEditor.getText(), caseSensitive: not @model.getFindOptions().caseSensitive)
     @selectFirstMarkerAfterCursor()
 
   toggleSelectionOption: =>
-    @updateModel {findPattern: @findEditor.getText(), inCurrentSelection: not @model.getFindOptions().inCurrentSelection}
+    @model.search(@findEditor.getText(), inCurrentSelection: not @model.getFindOptions().inCurrentSelection)
     @selectFirstMarkerAfterCursor()
 
   toggleWholeWordOption: =>
-    @updateModel {findPattern: @findEditor.getText(), wholeWord: not @model.getFindOptions().wholeWord}
+    @model.search(@findEditor.getText(), wholeWord: not @model.getFindOptions().wholeWord)
     @selectFirstMarkerAfterCursor()
 
   updateReplaceEnablement: ->

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -80,11 +80,10 @@ class FindView extends View
     @findHistory = new HistoryCycler(@findEditor, findHistory)
     @replaceHistory = new HistoryCycler(@replaceEditor, replaceHistory)
     @handleEvents()
-    @updateOptionButtons()
-    @updateReplaceEnablement()
 
     @clearMessage()
-    @updateOptionsLabel()
+    @updateOptionViews()
+    @updateReplaceEnablement()
 
   destroy: ->
     @subscriptions?.dispose()
@@ -166,6 +165,7 @@ class FindView extends View
     @subscriptions.add @findModel.onDidUpdate @markersUpdated
     @subscriptions.add @findModel.onDidError @findError
     @subscriptions.add @findModel.onDidChangeCurrentResult @updateResultCounter
+    @subscriptions.add @findModel.getFindOptions().onDidChange @updateOptionViews
 
     @regexOptionButton.on 'click', @toggleRegexOption
     @caseOptionButton.on 'click', @toggleCaseOption
@@ -283,7 +283,6 @@ class FindView extends View
 
   markersUpdated: (@markers) =>
     @findError = null
-    @updateOptionButtons()
     @updateResultCounter()
     @updateReplaceEnablement()
 
@@ -398,6 +397,10 @@ class FindView extends View
     @setSelectionAsFindPattern()
     @findPrevious(focusEditorAfter: true)
 
+  updateOptionViews: =>
+    @updateOptionButtons()
+    @updateOptionsLabel()
+
   updateOptionsLabel: ->
     label = []
     label.push('Regex') if @findModel.getFindOptions().useRegex
@@ -409,25 +412,11 @@ class FindView extends View
     label.push('Whole Word') if @findModel.getFindOptions().wholeWord
     @optionsLabel.text(label.join(', '))
 
-  toggleRegexOption: =>
-    @updateModel {findPattern: @findEditor.getText(), useRegex: not @findModel.getFindOptions().useRegex}
-    @selectFirstMarkerAfterCursor()
-    @updateOptionsLabel()
-
-  toggleCaseOption: =>
-    @updateModel {findPattern: @findEditor.getText(), caseSensitive: not @findModel.getFindOptions().caseSensitive}
-    @selectFirstMarkerAfterCursor()
-    @updateOptionsLabel()
-
-  toggleSelectionOption: =>
-    @updateModel {findPattern: @findEditor.getText(), inCurrentSelection: not @findModel.getFindOptions().inCurrentSelection}
-    @selectFirstMarkerAfterCursor()
-    @updateOptionsLabel()
-
-  toggleWholeWordOption: =>
-    @updateModel {findPattern: @findEditor.getText(), wholeWord: not @findModel.getFindOptions().wholeWord}
-    @selectFirstMarkerAfterCursor()
-    @updateOptionsLabel()
+  updateOptionButtons: ->
+    @setOptionButtonState(@regexOptionButton, @findModel.getFindOptions().useRegex)
+    @setOptionButtonState(@caseOptionButton, @findModel.getFindOptions().caseSensitive)
+    @setOptionButtonState(@selectionOptionButton, @findModel.getFindOptions().inCurrentSelection)
+    @setOptionButtonState(@wholeWordOptionButton, @findModel.getFindOptions().wholeWord)
 
   setOptionButtonState: (optionButton, selected) ->
     if selected
@@ -435,11 +424,21 @@ class FindView extends View
     else
       optionButton.removeClass 'selected'
 
-  updateOptionButtons: ->
-    @setOptionButtonState(@regexOptionButton, @findModel.getFindOptions().useRegex)
-    @setOptionButtonState(@caseOptionButton, @findModel.getFindOptions().caseSensitive)
-    @setOptionButtonState(@selectionOptionButton, @findModel.getFindOptions().inCurrentSelection)
-    @setOptionButtonState(@wholeWordOptionButton, @findModel.getFindOptions().wholeWord)
+  toggleRegexOption: =>
+    @updateModel {findPattern: @findEditor.getText(), useRegex: not @findModel.getFindOptions().useRegex}
+    @selectFirstMarkerAfterCursor()
+
+  toggleCaseOption: =>
+    @updateModel {findPattern: @findEditor.getText(), caseSensitive: not @findModel.getFindOptions().caseSensitive}
+    @selectFirstMarkerAfterCursor()
+
+  toggleSelectionOption: =>
+    @updateModel {findPattern: @findEditor.getText(), inCurrentSelection: not @findModel.getFindOptions().inCurrentSelection}
+    @selectFirstMarkerAfterCursor()
+
+  toggleWholeWordOption: =>
+    @updateModel {findPattern: @findEditor.getText(), wholeWord: not @findModel.getFindOptions().wholeWord}
+    @selectFirstMarkerAfterCursor()
 
   updateReplaceEnablement: ->
     canReplace = @markers?.length > 0

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -29,7 +29,7 @@ module.exports =
       minimum: 0
       description: 'When you type in the buffer find box, you must type this many characters to automatically search'
 
-  activate: ({@viewState, @projectViewState, @resultsModelState, @modelState, findHistory, replaceHistory, pathsHistory}={}) ->
+  activate: ({@resultsModelState, @modelState, findHistory, replaceHistory, pathsHistory}={}) ->
     atom.workspace.addOpener (filePath) ->
       new ResultsPaneView() if filePath is ResultsPaneView.URI
 
@@ -179,9 +179,7 @@ module.exports =
     @subscriptions = null
 
   serialize: ->
-    viewState: @findView?.serialize() ? @viewState
     modelState: @findOptions?.serialize() ? @modelState
-    projectViewState: @projectFindView?.serialize() ? @projectViewState
     resultsModelState: @resultsModel?.serialize() ? @resultsModelState
     findHistory: @findHistory.serialize()
     replaceHistory: @replaceHistory.serialize()

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -34,19 +34,19 @@ module.exports =
       new ResultsPaneView() if filePath is ResultsPaneView.URI
 
     @subscriptions = new CompositeDisposable
+    @findHistory = new History(findHistory)
+    @replaceHistory = new History(replaceHistory)
+    @pathsHistory = new History(pathsHistory)
 
     @findOptions = new FindOptions(@modelState)
     @findModel = new BufferSearch(@findOptions)
+    @resultsModel = new ResultsModel(@findOptions)
+
     @subscriptions.add atom.workspace.observeActivePaneItem (paneItem) =>
       if paneItem?.getBuffer?()
         @findModel.setEditor(paneItem)
       else
         @findModel.setEditor(null)
-
-    @resultsModel = new ResultsModel(@resultsModelState)
-    @findHistory = new History(findHistory)
-    @replaceHistory = new History(replaceHistory)
-    @pathsHistory = new History(pathsHistory)
 
     @subscriptions.add atom.commands.add '.find-and-replace, .project-find', 'window:focus-next-pane', =>
       atom.views.getView(atom.workspace).focus()

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -29,7 +29,7 @@ module.exports =
       minimum: 0
       description: 'When you type in the buffer find box, you must type this many characters to automatically search'
 
-  activate: ({@resultsModelState, @modelState, findHistory, replaceHistory, pathsHistory}={}) ->
+  activate: ({@modelState, findHistory, replaceHistory, pathsHistory}={}) ->
     atom.workspace.addOpener (filePath) ->
       new ResultsPaneView() if filePath is ResultsPaneView.URI
 
@@ -180,7 +180,6 @@ module.exports =
 
   serialize: ->
     modelState: @findOptions?.serialize() ? @modelState
-    resultsModelState: @resultsModel?.serialize() ? @resultsModelState
     findHistory: @findHistory.serialize()
     replaceHistory: @replaceHistory.serialize()
     pathsHistory: @replaceHistory.serialize()

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -3,6 +3,7 @@
 
 SelectNext = require './select-next'
 {History} = require './history'
+FindOptions = require './find-options'
 BufferSearch = require './buffer-search'
 FindView = require './find-view'
 ProjectFindView = require './project-find-view'
@@ -34,7 +35,8 @@ module.exports =
 
     @subscriptions = new CompositeDisposable
 
-    @findModel = new BufferSearch(@modelState)
+    @findOptions = new FindOptions(@modelState)
+    @findModel = new BufferSearch(@findOptions)
     @subscriptions.add atom.workspace.observeActivePaneItem (paneItem) =>
       if paneItem?.getBuffer?()
         @findModel.setEditor(paneItem)
@@ -178,7 +180,7 @@ module.exports =
 
   serialize: ->
     viewState: @findView?.serialize() ? @viewState
-    modelState: @findModel?.serialize() ? @modelState
+    modelState: @findOptions?.serialize() ? @modelState
     projectViewState: @projectFindView?.serialize() ? @projectViewState
     resultsModelState: @resultsModel?.serialize() ? @resultsModelState
     findHistory: @findHistory.serialize()

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -138,7 +138,7 @@ module.exports =
     history = {@findHistory, @replaceHistory, @pathsHistory}
 
     @findView = new FindView(@findModel, history)
-    @projectFindView = new ProjectFindView(@findModel, @resultsModel, history)
+    @projectFindView = new ProjectFindView(@resultsModel, history)
 
     @findPanel = atom.workspace.addBottomPanel(item: @findView, visible: false, className: 'tool-panel panel-bottom')
     @projectFindPanel = atom.workspace.addBottomPanel(item: @projectFindView, visible: false, className: 'tool-panel panel-bottom')

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -29,7 +29,7 @@ module.exports =
       minimum: 0
       description: 'When you type in the buffer find box, you must type this many characters to automatically search'
 
-  activate: ({@modelState, findHistory, replaceHistory, pathsHistory}={}) ->
+  activate: ({findOptions, findHistory, replaceHistory, pathsHistory}={}) ->
     atom.workspace.addOpener (filePath) ->
       new ResultsPaneView() if filePath is ResultsPaneView.URI
 
@@ -38,7 +38,7 @@ module.exports =
     @replaceHistory = new History(replaceHistory)
     @pathsHistory = new History(pathsHistory)
 
-    @findOptions = new FindOptions(@modelState)
+    @findOptions = new FindOptions(findOptions)
     @findModel = new BufferSearch(@findOptions)
     @resultsModel = new ResultsModel(@findOptions)
 
@@ -179,7 +179,7 @@ module.exports =
     @subscriptions = null
 
   serialize: ->
-    modelState: @findOptions?.serialize() ? @modelState
+    findOptions: @findOptions.serialize()
     findHistory: @findHistory.serialize()
     replaceHistory: @replaceHistory.serialize()
     pathsHistory: @replaceHistory.serialize()

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -195,7 +195,8 @@ class ProjectFindView extends View
     @onlyRunIfChanged = true
     searchPromise
 
-  search: ({onlyRunIfActive, onlyRunIfChanged}={}) ->
+  search: (options={}) ->
+    {onlyRunIfActive, onlyRunIfChanged} = options
     return Promise.resolve() if onlyRunIfActive and not @model.active
 
     findPattern = @findEditor.getText()
@@ -205,7 +206,7 @@ class ProjectFindView extends View
     @clearMessages()
     @showResultPane().then =>
       try
-        @model.search(findPattern, pathsPattern, replacePattern, {onlyRunIfChanged})
+        @model.search(findPattern, pathsPattern, replacePattern, options)
       catch e
         @setErrorMessage(e.message)
 
@@ -319,13 +320,10 @@ class ProjectFindView extends View
       optionButton.removeClass 'selected'
 
   toggleRegexOption: ->
-    @model.getFindOptions().toggleUseRegex()
-    @search(onlyRunIfActive: true)
+    @search(onlyRunIfActive: true, useRegex: not @model.getFindOptions().toggleUseRegex())
 
   toggleCaseOption: ->
-    @model.getFindOptions().toggleCaseSensitive()
-    @search(onlyRunIfActive: true)
+    @search(onlyRunIfActive: true, caseSensitive: not @model.getFindOptions().toggleCaseSensitive())
 
   toggleWholeWordOption: ->
-    @model.getFindOptions().toggleWholeWord()
-    @search(onlyRunIfActive: true)
+    @search(onlyRunIfActive: true, wholeWord: not @model.getFindOptions().toggleWholeWord())

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -220,7 +220,6 @@ class ProjectFindView extends View
     return Promise.resolve() if onlyRunIfActive and not @model.active
 
     findPattern = @findEditor.getText()
-    # @findInBufferModel.setFindOptions({findPattern})
 
     @clearMessages()
     @showResultPane().then =>

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -196,6 +196,9 @@ class ProjectFindView extends View
     searchPromise
 
   search: (options={}) ->
+    # We always want to set the options passed in, even if we dont end up doing the search
+    @model.getFindOptions().set(options)
+
     {onlyRunIfActive, onlyRunIfChanged} = options
     return Promise.resolve() if onlyRunIfActive and not @model.active
 

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -320,10 +320,10 @@ class ProjectFindView extends View
       optionButton.removeClass 'selected'
 
   toggleRegexOption: ->
-    @search(onlyRunIfActive: true, useRegex: not @model.getFindOptions().toggleUseRegex())
+    @search(onlyRunIfActive: true, useRegex: not @model.getFindOptions().useRegex)
 
   toggleCaseOption: ->
-    @search(onlyRunIfActive: true, caseSensitive: not @model.getFindOptions().toggleCaseSensitive())
+    @search(onlyRunIfActive: true, caseSensitive: not @model.getFindOptions().caseSensitive)
 
   toggleWholeWordOption: ->
-    @search(onlyRunIfActive: true, wholeWord: not @model.getFindOptions().toggleWholeWord())
+    @search(onlyRunIfActive: true, wholeWord: not @model.getFindOptions().wholeWord)

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -46,7 +46,7 @@ class ProjectFindView extends View
         @div class: 'input-block-item editor-container', =>
           @subview 'pathsEditor', new TextEditorView(mini: true, placeholderText: 'File/directory pattern. eg. `src` to search in the "src" directory or `*.js` to search all javascript files.')
 
-  initialize: (@findInBufferModel, @model, {findHistory, replaceHistory, pathsHistory}) ->
+  initialize: (@model, {findHistory, replaceHistory, pathsHistory}) ->
     @subscriptions = new CompositeDisposable
     @handleEvents()
     @findHistory = new HistoryCycler(@findEditor, findHistory)

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -1,6 +1,5 @@
 fs = require 'fs-plus'
 path = require 'path'
-Q = require 'q'
 _ = require 'underscore-plus'
 {Disposable, CompositeDisposable} = require 'atom'
 {$, $$$, View, TextEditorView} = require 'atom-space-pen-views'
@@ -218,7 +217,7 @@ class ProjectFindView extends View
     searchPromise
 
   search: ({onlyRunIfActive, onlyRunIfChanged}={}) ->
-    return Q() if onlyRunIfActive and not @model.active
+    return Promise.resolve() if onlyRunIfActive and not @model.active
 
     findPattern = @findEditor.getText()
     # @findInBufferModel.setFindOptions({findPattern})

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -221,7 +221,7 @@ class ProjectFindView extends View
     return Q() if onlyRunIfActive and not @model.active
 
     pattern = @findEditor.getText()
-    @findInBufferModel.setSearchParams({pattern})
+    @findInBufferModel.setFindOptions({pattern})
 
     @clearMessages()
     @showResultPane().then =>

--- a/lib/project/match-view.coffee
+++ b/lib/project/match-view.coffee
@@ -28,13 +28,13 @@ class MatchView extends View
 
   attached: ->
     @subscriptions = new CompositeDisposable
-    @subscriptions.add @model.onDidChangeReplacementPattern @render
+    @subscriptions.add @model.getFindOptions().onDidChangeReplacePattern @render
 
   detached: -> @subscriptions.dispose()
 
   render: =>
-    if @model.replacementPattern and @model.regex and not @model.replacedPathCount?
-      replacementText = @match.matchText.replace(@model.regex, @model.replacementPattern)
+    if @model.getFindOptions().replacePattern and @model.regex and not @model.replacedPathCount?
+      replacementText = @match.matchText.replace(@model.regex, @model.getFindOptions().replacePattern)
       @replacementText.text(replacementText)
       @replacementText.show()
       @matchText.removeClass('highlight-info').addClass('highlight-error')

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -1,4 +1,3 @@
-Q = require 'q'
 _ = require 'underscore-plus'
 {Emitter} = require 'atom'
 escapeHelper = require '../escape-helper'
@@ -93,7 +92,8 @@ class ResultsModel
     @emitter.emit 'did-clear-replacement-state', @getResultsSummary()
 
   search: (findPattern, searchPaths, replacementPattern, {onlyRunIfChanged, keepReplacementState}={}) ->
-    return Q() if onlyRunIfChanged and findPattern? and searchPaths? and findPattern is @findOptions.findPattern and _.isEqual(searchPaths, @searchedPaths)
+    if onlyRunIfChanged and findPattern? and searchPaths? and findPattern is @findOptions.findPattern and _.isEqual(searchPaths, @searchedPaths)
+      return Promise.resolve()
 
     if keepReplacementState
       @clearSearchState()

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -88,7 +88,8 @@ class ResultsModel
     @replacementErrors = null
     @emitter.emit 'did-clear-replacement-state', @getResultsSummary()
 
-  search: (findPattern, pathsPattern, replacePattern, {onlyRunIfChanged, keepReplacementState}={}) ->
+  search: (findPattern, pathsPattern, replacePattern, options) ->
+    {onlyRunIfChanged, keepReplacementState} = options
     if onlyRunIfChanged and findPattern? and pathsPattern? and findPattern is @findOptions.findPattern and pathsPattern is @findOptions.pathsPattern
       return Promise.resolve()
 
@@ -97,7 +98,7 @@ class ResultsModel
     else
       @clear()
 
-    @findOptions.set({findPattern, replacePattern, pathsPattern})
+    @findOptions.set(_.extend({findPattern, replacePattern, pathsPattern}, options))
     @regex = @findOptions.getFindPatternRegex()
 
     @active = true

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -100,10 +100,12 @@ class ResultsModel
     else
       @clear()
 
-    @active = true
-    @regex = @getRegex(findPattern)
-    @searchedPaths = searchPaths
     @findOptions.set({findPattern})
+
+    @regex = @findOptions.getFindPatternRegex()
+
+    @active = true
+    @searchedPaths = searchPaths
 
     @updateReplacementPattern(replacementPattern)
 
@@ -214,19 +216,6 @@ class ResultsModel
       @paths = _.without(@paths, filePath)
       delete @results[filePath]
       @emitter.emit 'did-remove-result', {filePath}
-
-  getRegex: (pattern) ->
-    flags = 'g'
-    flags += 'i' unless @findOptions.caseSensitive
-
-    if @findOptions.useRegex
-      expression = pattern
-    else
-      expression = _.escapeRegExp(pattern)
-
-    expression = "\\b#{expression}\\b" if @findOptions.wholeWord
-
-    new RegExp(expression, flags)
 
   onContentsModified: (editor) =>
     return unless @active

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -88,7 +88,7 @@ class ResultsModel
     @replacementErrors = null
     @emitter.emit 'did-clear-replacement-state', @getResultsSummary()
 
-  search: (findPattern, pathsPattern, replacePattern, options) ->
+  search: (findPattern, pathsPattern, replacePattern, options={}) ->
     {onlyRunIfChanged, keepReplacementState} = options
     if onlyRunIfChanged and findPattern? and pathsPattern? and findPattern is @findOptions.findPattern and pathsPattern is @findOptions.pathsPattern
       return Promise.resolve()

--- a/lib/project/results-pane.coffee
+++ b/lib/project/results-pane.coffee
@@ -105,8 +105,9 @@ class ResultsPaneView extends ScrollView
       @showSearchedCountBlock = true
     , 500
 
-    deferred.done =>
-      @loadingMessage.hide()
+    hideLoadingMessage = => @loadingMessage.hide()
+
+    deferred.then(hideLoadingMessage).catch(hideLoadingMessage)
 
   onPathsSearched: (numberOfPathsSearched) =>
     if @showSearchedCountBlock

--- a/lib/project/util.coffee
+++ b/lib/project/util.coffee
@@ -14,14 +14,14 @@ module.exports =
     pattern = @escapeHtml(pattern)
     pattern.replace(/\n/g, '\\n').replace(/\t/g, '\\t')
 
-  getReplacementResultsMessage: ({pattern, replacementPattern, replacedPathCount, replacementCount}) ->
+  getReplacementResultsMessage: ({findPattern, replacePattern, replacedPathCount, replacementCount}) ->
     if replacedPathCount
-      "<span class=\"text-highlight\">Replaced <span class=\"highlight-error\">#{@sanitizePattern(pattern)}</span> with <span class=\"highlight-success\">#{@sanitizePattern(replacementPattern)}</span> #{_.pluralize(replacementCount, 'time')} in #{_.pluralize(replacedPathCount, 'file')}</span>"
+      "<span class=\"text-highlight\">Replaced <span class=\"highlight-error\">#{@sanitizePattern(findPattern)}</span> with <span class=\"highlight-success\">#{@sanitizePattern(replacePattern)}</span> #{_.pluralize(replacementCount, 'time')} in #{_.pluralize(replacedPathCount, 'file')}</span>"
     else
       "<span class=\"text-highlight\">Nothing replaced</span>"
 
-  getSearchResultsMessage: ({pattern, matchCount, pathCount, replacedPathCount}) ->
+  getSearchResultsMessage: ({findPattern, matchCount, pathCount, replacedPathCount}) ->
     if matchCount
-      "#{_.pluralize(matchCount, 'result')} found in #{_.pluralize(pathCount, 'file')} for <span class=\"highlight-info\">#{@sanitizePattern(pattern)}</span>"
+      "#{_.pluralize(matchCount, 'result')} found in #{_.pluralize(pathCount, 'file')} for <span class=\"highlight-info\">#{@sanitizePattern(findPattern)}</span>"
     else
-      "No #{if replacedPathCount? then 'more' else ''} results found for '#{@sanitizePattern(pattern)}'"
+      "No #{if replacedPathCount? then 'more' else ''} results found for '#{@sanitizePattern(findPattern)}'"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
     "fs-plus": "2.x",
-    "q": "^1.0.1",
     "temp": "0.8.1",
     "underscore-plus": "1.x"
   },

--- a/spec/buffer-search-spec.coffee
+++ b/spec/buffer-search-spec.coffee
@@ -1,5 +1,6 @@
 {TextEditor} = require 'atom'
 BufferSearch = require '../lib/buffer-search'
+FindOptions = require '../lib/find-options'
 
 describe "BufferSearch", ->
   [search, editor, markersListener, currentResultListener] = []
@@ -20,7 +21,8 @@ describe "BufferSearch", ->
       -----------
     """
 
-    search = new BufferSearch
+    findOptions = new FindOptions
+    search = new BufferSearch(findOptions)
 
     markersListener = jasmine.createSpy('markersListener')
     search.onDidUpdate(markersListener)
@@ -31,8 +33,8 @@ describe "BufferSearch", ->
     search.setEditor(editor)
     markersListener.reset()
 
-    search.setSearchParams(
-      pattern: "a+"
+    search.setFindOptions(
+      findPattern: "a+"
       caseSensitive: false
       useRegex: true
       wholeWord: false

--- a/spec/buffer-search-spec.coffee
+++ b/spec/buffer-search-spec.coffee
@@ -3,7 +3,7 @@ BufferSearch = require '../lib/buffer-search'
 FindOptions = require '../lib/find-options'
 
 describe "BufferSearch", ->
-  [search, editor, markersListener, currentResultListener] = []
+  [model, editor, markersListener, currentResultListener] = []
 
   beforeEach ->
     editor = new TextEditor
@@ -22,26 +22,24 @@ describe "BufferSearch", ->
     """
 
     findOptions = new FindOptions
-    search = new BufferSearch(findOptions)
+    model = new BufferSearch(findOptions)
 
     markersListener = jasmine.createSpy('markersListener')
-    search.onDidUpdate(markersListener)
+    model.onDidUpdate(markersListener)
 
     currentResultListener = jasmine.createSpy('currentResultListener')
-    search.onDidChangeCurrentResult(currentResultListener)
+    model.onDidChangeCurrentResult(currentResultListener)
 
-    search.setEditor(editor)
+    model.setEditor(editor)
     markersListener.reset()
 
-    search.setFindOptions(
-      findPattern: "a+"
+    model.search "a+",
       caseSensitive: false
       useRegex: true
       wholeWord: false
-    )
 
   afterEach ->
-    search.destroy()
+    model.destroy()
     editor.destroy()
 
   getHighlightedRanges = ->
@@ -382,7 +380,7 @@ describe "BufferSearch", ->
       expect(currentResultListener).toHaveBeenCalledWith(markers[1])
       currentResultListener.reset()
 
-      search.replace([markers[1]], "new-text")
+      model.replace([markers[1]], "new-text")
 
       expect(editor.getText()).toBe """
         -----------

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -819,12 +819,12 @@ describe 'ProjectFindView', ->
           expect(errorList.find("li:eq(1)").text()).toBe 'Broken'
 
     describe "buffer search sharing of the find pattern", ->
-      getResultDecorations = (clazz) ->
+      getResultDecorations = (className) ->
         markerIdForDecorations = editor.decorationsForScreenRowRange(0, editor.getLineCount())
         resultDecorations = []
         for markerId, decorations of markerIdForDecorations
           for decoration in decorations
-            resultDecorations.push decoration if decoration.getProperties().class is clazz
+            resultDecorations.push decoration if decoration.getProperties().class is className
         resultDecorations
 
       it 'highlights the search results in the selected file', ->

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -645,7 +645,7 @@ describe 'ProjectFindView', ->
             searchPromise
 
           runs ->
-            expect(atom.workspace.scan.argsForCall[0][1]['paths']).toEqual ['*.js']
+            expect(atom.workspace.scan.argsForCall[0][1].paths).toEqual ['*.js']
 
         it "updates the results list when a buffer changes", ->
           atom.commands.dispatch(projectFindView[0], 'core:confirm')

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -816,7 +816,7 @@ describe 'ProjectFindView', ->
           expect(errorList.find("li:eq(0)").text()).toBe 'Nope'
           expect(errorList.find("li:eq(1)").text()).toBe 'Broken'
 
-    describe "buffer search sharing of the find pattern", ->
+    describe "buffer search sharing of the find options", ->
       getResultDecorations = (className) ->
         markerIdForDecorations = editor.decorationsForScreenRowRange(0, editor.getLineCount())
         resultDecorations = []
@@ -829,7 +829,7 @@ describe 'ProjectFindView', ->
         # Process here is to
         # * open samplejs
         # * run a search that has sample js results
-        # * that should place the pattern in the buffer find and replace
+        # * that should place the pattern in the buffer find
         # * focus sample.js by clicking on a sample.js result
         # * when the file has been activated, it's results for the project search should be highlighted
 
@@ -841,7 +841,7 @@ describe 'ProjectFindView', ->
           expect(getResultDecorations('find-result')).toHaveLength 0
 
         runs ->
-          projectFindView.findEditor.setText('items')
+          projectFindView.findEditor.setText('item')
           atom.commands.dispatch(projectFindView[0], 'core:confirm')
 
         waitsForPromise ->
@@ -860,9 +860,7 @@ describe 'ProjectFindView', ->
           atom.commands.dispatch(resultsView[0], 'core:confirm')
 
         waits 0 # not sure why this is async
-
         runs ->
-
           # sample.js has 6 results
           expect(getResultDecorations('find-result')).toHaveLength 5
           expect(getResultDecorations('current-result')).toHaveLength 1
@@ -873,6 +871,18 @@ describe 'ProjectFindView', ->
           # now we can find next
           atom.commands.dispatch atom.views.getView(editor), 'find-and-replace:find-next'
           expect(editor.getSelectedBufferRange()).not.toEqual initialSelectedRange
+
+          # Now we toggle the whole-word option to make sure it is updated in the buffer find
+          atom.commands.dispatch(projectFindView[0], 'project-find:toggle-whole-word-option')
+
+        waits 0
+        runs ->
+          # sample.js has 0 results for whole word `item`
+          expect(getResultDecorations('find-result')).toHaveLength 0
+          expect(workspaceElement).toHaveClass 'find-visible'
+
+          # Now we toggle the whole-word option to make sure it is updated in the buffer find
+          atom.commands.dispatch(projectFindView[0], 'project-find:toggle-whole-word-option')
 
   describe "replacing", ->
     [testDir, sampleJs, sampleCoffee, replacePromise] = []

--- a/spec/results-model-spec.coffee
+++ b/spec/results-model-spec.coffee
@@ -30,7 +30,7 @@ describe 'ResultsModel', ->
       runs ->
         resultsModel.onDidAddResult resultAddedSpy
         resultsModel.onDidRemoveResult resultRemovedSpy
-        searchPromise = resultsModel.search('items', ['*.js'], '')
+        searchPromise = resultsModel.search('items', '*.js', '')
 
       waitsForPromise ->
         searchPromise
@@ -94,7 +94,7 @@ describe 'ResultsModel', ->
       runs ->
         resultsModel.onDidAddResult resultAddedSpy
         resultsModel.onDidRemoveResult resultRemovedSpy
-        searchPromise = resultsModel.search('items', ['*.js'], '')
+        searchPromise = resultsModel.search('items', '*.js', '')
 
       waitsForPromise ->
         searchPromise
@@ -114,7 +114,7 @@ describe 'ResultsModel', ->
 
     it "populates the model with all the results, and updates in response to changes in the buffer", ->
       runs ->
-        searchPromise = resultsModel.search('items', ['*.js'], '')
+        searchPromise = resultsModel.search('items', '*.js', '')
 
         expect(resultsModel.inProgressSearchPromise).toBeTruthy()
         resultsModel.clear()
@@ -128,8 +128,8 @@ describe 'ResultsModel', ->
 
     it "populates the model with all the results, and updates in response to changes in the buffer", ->
       runs ->
-        searchPromise = resultsModel.search('items', ['*.js'], '')
-        searchPromise = resultsModel.search('sort', ['*.js'], '')
+        searchPromise = resultsModel.search('items', '*.js', '')
+        searchPromise = resultsModel.search('sort', '*.js', '')
 
       waitsForPromise ->
         searchPromise

--- a/spec/results-model-spec.coffee
+++ b/spec/results-model-spec.coffee
@@ -1,6 +1,7 @@
 path = require 'path'
 
 ResultsModel = require '../lib/project/results-model'
+FindOptions = require '../lib/find-options'
 
 # Default to 30 second promises
 waitsForPromise = (fn) -> window.waitsForPromise timeout: 30000, fn
@@ -16,7 +17,8 @@ describe 'ResultsModel', ->
 
     runs ->
       editor = atom.workspace.getActiveTextEditor()
-      resultsModel = new ResultsModel()
+      findOptions = new FindOptions
+      resultsModel = new ResultsModel(findOptions)
 
   describe "searching for a pattern", ->
     beforeEach ->


### PR DESCRIPTION
This introduces a `FindOptions` object containing the current state of the options like `useRegex`, and the pattern values. Both models share this `FindOptions` object. 

This also has refactoring to make both views use their models and the `FindOptions` in a consistent way. Hopefully the code is a lot more straightforward.

This is what it looks like (toggling in project find, affecting buffer find):

![shared-options](https://cloud.githubusercontent.com/assets/69169/9126505/a108a558-3c62-11e5-8749-ed1e4e1a907e.gif)

Closes #431 
Closes #432