### PR TITLE
Serialize / remember the open panel on reload

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -21,6 +21,16 @@ module.exports =
       description: 'When you type in the buffer find box, you must type this many characters to automatically search'
 
   activate: (@state) ->
+    {visiblePanel} = @state
+
+    if visiblePanel?
+      setImmediate =>
+        @createViews()
+        if visiblePanel is 'find'
+          @findPanel.show()
+        else if visiblePanel is 'project-find'
+          @projectFindPanel.show()
+
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.workspace.observeActivePaneItem (paneItem) =>
       @createModels()
@@ -148,9 +158,9 @@ module.exports =
     ResultsPaneView ?= require './project/results-pane'
     {HistoryCycler} = require './history'
 
-    findBuffer = new TextBuffer
-    replaceBuffer = new TextBuffer
-    pathsBuffer = new TextBuffer
+    findBuffer = new TextBuffer(@findOptions.findPattern or '')
+    replaceBuffer = new TextBuffer(@findOptions.replacePattern or '')
+    pathsBuffer = new TextBuffer(@findOptions.pathsPattern or '')
 
     findHistoryCycler = new HistoryCycler(findBuffer, @findHistory)
     replaceHistoryCycler = new HistoryCycler(replaceBuffer, @replaceHistory)
@@ -200,7 +210,17 @@ module.exports =
     @subscriptions = null
 
   serialize: ->
-    findOptions: @findOptions.serialize()
-    findHistory: @findHistory.serialize()
-    replaceHistory: @replaceHistory.serialize()
-    pathsHistory: @replaceHistory.serialize()
+    visiblePanel = if @findPanel.isVisible()
+      'find'
+    else if @projectFindPanel.isVisible()
+      'project-find'
+    else
+      null
+
+    {
+      findOptions: @findOptions.serialize()
+      findHistory: @findHistory.serialize()
+      replaceHistory: @replaceHistory.serialize()
+      pathsHistory: @replaceHistory.serialize()
+      visiblePanel: visiblePanel
+    }

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -158,15 +158,15 @@ module.exports =
     ResultsPaneView ?= require './project/results-pane'
     {HistoryCycler} = require './history'
 
-    findBuffer = new TextBuffer(@findOptions.findPattern or '')
-    replaceBuffer = new TextBuffer(@findOptions.replacePattern or '')
-    pathsBuffer = new TextBuffer(@findOptions.pathsPattern or '')
+    @findBuffer = new TextBuffer(@findOptions.findPattern or '')
+    @replaceBuffer = new TextBuffer(@findOptions.replacePattern or '')
+    @pathsBuffer = new TextBuffer(@findOptions.pathsPattern or '')
 
-    findHistoryCycler = new HistoryCycler(findBuffer, @findHistory)
-    replaceHistoryCycler = new HistoryCycler(replaceBuffer, @replaceHistory)
-    pathsHistoryCycler = new HistoryCycler(pathsBuffer, @pathsHistory)
+    findHistoryCycler = new HistoryCycler(@findBuffer, @findHistory)
+    replaceHistoryCycler = new HistoryCycler(@replaceBuffer, @replaceHistory)
+    pathsHistoryCycler = new HistoryCycler(@pathsBuffer, @pathsHistory)
 
-    options = {findBuffer, replaceBuffer, pathsBuffer, findHistoryCycler, replaceHistoryCycler, pathsHistoryCycler}
+    options = {@findBuffer, @replaceBuffer, @pathsBuffer, findHistoryCycler, replaceHistoryCycler, pathsHistoryCycler}
 
     @findView = new FindView(@findModel, options)
     @projectFindView = new ProjectFindView(@resultsModel, options)
@@ -210,6 +210,12 @@ module.exports =
     @subscriptions = null
 
   serialize: ->
+    if @findBuffer?
+      @findOptions.set
+        findPattern: @findBuffer.getText()
+        replacePattern: @replaceBuffer.getText()
+        pathsPattern: @pathsBuffer.getText()
+
     visiblePanel = if @findPanel.isVisible()
       'find'
     else if @projectFindPanel.isVisible()

--- a/package.json
+++ b/package.json
@@ -4,25 +4,6 @@
   "description": "Find and replace within buffers and across the project.",
   "version": "0.177.0",
   "license": "MIT",
-  "activationCommands": {
-    "atom-workspace": [
-      "project-find:show",
-      "project-find:toggle",
-      "project-find:show-in-current-directory",
-      "find-and-replace:show",
-      "find-and-replace:toggle",
-      "find-and-replace:find-next",
-      "find-and-replace:find-previous",
-      "find-and-replace:find-next-selected",
-      "find-and-replace:find-previous-selected",
-      "find-and-replace:use-selection-as-find-pattern",
-      "find-and-replace:show-replace",
-      "find-and-replace:replace-next",
-      "find-and-replace:replace-all",
-      "find-and-replace:select-next",
-      "find-and-replace:select-all"
-    ]
-  },
   "repository": "https://github.com/atom/find-and-replace",
   "engines": {
     "atom": "*"


### PR DESCRIPTION
For forever we have not been properly serializing the find and replace panels. It wouldnt remember if you had a panel open, and it wouldnt remember the text you had in any of the boxes. This PR allows the correct panel to open up on an atom window reload / restart.

Note: 
- I removed the activation commands. `activate()` is run all the time. I've tried to keep it fast. On my machine it takes 13ms to activate.

_Here's a seizure inducing gif_
![fnr-serialize](https://cloud.githubusercontent.com/assets/69169/9186481/0d0472e0-3f7a-11e5-9404-02430f8201da.gif)

This is a WIP. I would like people to try this out if possible and see if it's helpful or annoying. cc @atom/feedback 

TODO
- [x] Make it work
- [ ] Come to consensus on whether we should or shouldnt do this
- [ ] Fix Specs, add a spec or two

Closes #393 
Closes #426
