### PR TITLE
Sort project find results

### DIFF
--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -1,6 +1,7 @@
 _ = require 'underscore-plus'
 {Emitter} = require 'atom'
 escapeHelper = require '../escape-helper'
+binarySearch = require 'binarysearch'
 
 class Result
   @create: (result) ->
@@ -192,16 +193,17 @@ class ResultsModel
       @removeResult(filePath)
 
   addResult: (filePath, result) ->
+    filePathInsertedIndex = null
     if @results[filePath]
       @matchCount -= @results[filePath].matches.length
     else
       @pathCount++
-      @paths.push(filePath)
+      filePathInsertedIndex = binarySearch.insert(@paths, filePath, stringCompare)
 
     @matchCount += result.matches.length
 
     @results[filePath] = result
-    @emitter.emit 'did-add-result', {filePath, result}
+    @emitter.emit 'did-add-result', {filePath, result, filePathInsertedIndex}
 
   removeResult: (filePath) ->
     if @results[filePath]
@@ -226,3 +228,5 @@ class ResultsModel
 
   pathsArrayFromPathsPattern: (pathsPattern) ->
     (inputPath.trim() for inputPath in pathsPattern.trim().split(',') when inputPath)
+
+stringCompare = (a, b) -> a.localeCompare(b)

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -52,14 +52,24 @@ class ResultsView extends ScrollView
   hasResults: ->
     @model.getResultCount() > 0
 
-  addResult: ({filePath, result}) =>
+  addResult: ({filePath, result, filePathInsertedIndex}) =>
     resultView = @getResultView(filePath)
+    return resultView.renderResult(result) if resultView
 
-    if resultView
-      resultView.renderResult(result)
-    else
-      @renderResults()
-      @selectFirstResult() if @getPathCount() is 1
+    if filePathInsertedIndex? and (filePathInsertedIndex < @lastRenderedResultIndex or @shouldRenderMoreResults())
+      children = @children()
+      resultView = new ResultView(@model, filePath, result)
+
+      if children.length is 0 or filePathInsertedIndex is children.length
+        @append(resultView)
+      else if filePathInsertedIndex is 0
+        @prepend(resultView)
+      else
+        @element.insertBefore(resultView.element, children[filePathInsertedIndex])
+
+      @lastRenderedResultIndex++
+
+    @selectFirstResult() if @getPathCount() is 1
 
   removeResult: ({filePath}) =>
     resultView = @getResultView(filePath)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.1.0",
+    "binarysearch": "^0.2.4",
     "fs-plus": "2.x",
     "temp": "0.8.1",
     "underscore-plus": "1.x"


### PR DESCRIPTION
Inspired by @muan's #320, this adds sorting to the project find results. I'm sorting them as they come into the model, rather than the view as in #320.

Closes #64 
Closes #320 