### PR TITLE
MatchView core:confirm only opens on left when openOnRight is true

### DIFF
--- a/lib/project/match-view.coffee
+++ b/lib/project/match-view.coffee
@@ -43,7 +43,10 @@ class MatchView extends View
       @matchText.removeClass('highlight-error').addClass('highlight-info')
 
   confirm: ->
-    atom.workspace.open(@filePath, split: 'left').then (editor) =>
+    openInRightPane = atom.config.get('find-and-replace.openProjectFindResultsInRightPane')
+    options = {}
+    options = {split: 'left'} if openInRightPane
+    atom.workspace.open(@filePath, options).then (editor) =>
       editor.setSelectedBufferRange(@match.range, autoscroll: true)
 
   copy: ->


### PR DESCRIPTION
Previously, it always tried to open the item in the left pane. Now, it only opens in the left pane when `openProjectFindResultsInRightPane` is true.

Closes #484 