### PR TITLE
Force search results outlines to be in front of other highlights

### DIFF
--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -9,12 +9,14 @@ atom-text-editor::shadow {
     border-radius: @component-border-radius;
     border: 1px solid @syntax-result-marker-color;
     box-sizing: border-box;
+    z-index: 0;
   }
 
   .current-result .region {
     border-radius: @component-border-radius;
     border: 1px solid @syntax-result-marker-color-selected;
     box-sizing: border-box;
+    z-index: 0;
   }
 
   .find-result,


### PR DESCRIPTION
Fixes #406.

![return](https://cloud.githubusercontent.com/assets/482957/9221966/756211e2-40ee-11e5-9f27-bbfa452b18f6.gif)

/cc: @benogle @izuzak 