### PR TITLE
Add regexp replacement highlighting

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -428,8 +428,11 @@ class FindView extends View
     if @model.getFindOptions().useRegex
       grammar = atom.grammars.grammarForScopeName('source.js.regexp')
       @findEditor.getModel().setGrammar(grammar)
+      replacement_grammar = atom.grammars.grammarForScopeName('source.js.regexp.replacement')
+      @replaceEditor.getModel().setGrammar(replacement_grammar)
     else
       @findEditor.getModel().setGrammar(atom.grammars.nullGrammar)
+      @replaceEditor.getModel().setGrammar(atom.grammars.nullGrammar)
 
   updateOptionsLabel: ->
     label = []

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -426,10 +426,8 @@ class FindView extends View
 
   updateSyntaxHighlighting: ->
     if @model.getFindOptions().useRegex
-      grammar = atom.grammars.grammarForScopeName('source.js.regexp')
-      @findEditor.getModel().setGrammar(grammar)
-      replacement_grammar = atom.grammars.grammarForScopeName('source.js.regexp.replacement')
-      @replaceEditor.getModel().setGrammar(replacement_grammar)
+      @findEditor.getModel().setGrammar(atom.grammars.grammarForScopeName('source.js.regexp'))
+      @replaceEditor.getModel().setGrammar(atom.grammars.grammarForScopeName('source.js.regexp.replacement'))
     else
       @findEditor.getModel().setGrammar(atom.grammars.nullGrammar)
       @replaceEditor.getModel().setGrammar(atom.grammars.nullGrammar)

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -334,8 +334,11 @@ class ProjectFindView extends View
     if @model.getFindOptions().useRegex
       grammar = atom.grammars.grammarForScopeName('source.js.regexp')
       @findEditor.getModel().setGrammar(grammar)
+      replacement_grammar = atom.grammars.grammarForScopeName('source.js.regexp.replacement')
+      @replaceEditor.getModel().setGrammar(replacement_grammar)
     else
       @findEditor.getModel().setGrammar(atom.grammars.nullGrammar)
+      @replaceEditor.getModel().setGrammar(atom.grammars.nullGrammar)
 
   updateOptionsLabel: ->
     label = []

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -332,10 +332,8 @@ class ProjectFindView extends View
 
   updateSyntaxHighlighting: ->
     if @model.getFindOptions().useRegex
-      grammar = atom.grammars.grammarForScopeName('source.js.regexp')
-      @findEditor.getModel().setGrammar(grammar)
-      replacement_grammar = atom.grammars.grammarForScopeName('source.js.regexp.replacement')
-      @replaceEditor.getModel().setGrammar(replacement_grammar)
+      @findEditor.getModel().setGrammar(atom.grammars.grammarForScopeName('source.js.regexp'))
+      @replaceEditor.getModel().setGrammar(atom.grammars.grammarForScopeName('source.js.regexp.replacement'))
     else
       @findEditor.getModel().setGrammar(atom.grammars.nullGrammar)
       @replaceEditor.getModel().setGrammar(atom.grammars.nullGrammar)

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -1290,6 +1290,7 @@ describe 'FindView', ->
       runs ->
         expect(findView.model.getFindOptions().useRegex).toBe true
         expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp'
+        expect(findView.replaceEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp.replacement'
 
     describe "when panel is active", ->
       beforeEach ->
@@ -1299,14 +1300,17 @@ describe 'FindView', ->
       it "does not use regexp grammar when in non-regex mode", ->
         expect(findView.model.getFindOptions().useRegex).not.toBe true
         expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
+        expect(findView.replaceEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
 
       it "uses regexp grammar when in regex mode and clears the regexp grammar when regex is disabled", ->
         atom.commands.dispatch(findView.findEditor.element, 'find-and-replace:toggle-regex-option')
 
         expect(findView.model.getFindOptions().useRegex).toBe true
         expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp'
+        expect(findView.replaceEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp.replacement'
 
         atom.commands.dispatch(findView.findEditor.element, 'find-and-replace:toggle-regex-option')
 
         expect(findView.model.getFindOptions().useRegex).not.toBe true
         expect(findView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
+        expect(findView.replaceEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -1376,6 +1376,7 @@ describe 'ProjectFindView', ->
       runs ->
         expect(projectFindView.model.getFindOptions().useRegex).toBe true
         expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp'
+        expect(projectFindView.replaceEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp.replacement'
 
     describe "when panel is active", ->
       beforeEach ->
@@ -1385,14 +1386,17 @@ describe 'ProjectFindView', ->
       it "does not use regexp grammar when in non-regex mode", ->
         expect(projectFindView.model.getFindOptions().useRegex).not.toBe true
         expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
+        expect(projectFindView.replaceEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
 
       it "uses regexp grammar when in regex mode and clears the regexp grammar when regex is disabled", ->
         atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
 
         expect(projectFindView.model.getFindOptions().useRegex).toBe true
         expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp'
+        expect(projectFindView.replaceEditor.getModel().getGrammar().scopeName).toBe 'source.js.regexp.replacement'
 
         atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
 
         expect(projectFindView.model.getFindOptions().useRegex).not.toBe true
         expect(projectFindView.findEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'
+        expect(projectFindView.replaceEditor.getModel().getGrammar().scopeName).toBe 'text.plain.null-grammar'

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -264,7 +264,7 @@ atom-workspace.find-visible {
   }
 }
 
-.find-container atom-text-editor::shadow {
+.find-container atom-text-editor::shadow, .replace-container atom-text-editor::shadow {
   // Styles for regular expression highlighting
   .regexp {
     .escape {
@@ -282,6 +282,10 @@ atom-workspace.find-visible {
     .keyword, .punctuation {
       color: @text-color-error;
       font-weight: normal;
+    }
+
+    .replacement.variable {
+      color: @text-color-warning;
     }
   }
 }


### PR DESCRIPTION
This pull request adds syntax-highlighting for regular expression replacement strings, first mentioned in #458 as a companion to syntax-highlighting for the regular expression search strings themselves.

Note that this is dependent on a new [source.js.regexp.replacement grammar](https://github.com/adamfranco/language-javascript/blob/regexp_replacement_grammar/grammars/regular%20expression%20replacement%20%28javascript%29.cson) provided in [adamfranco/language-javascript/regexp_replacement_grammar](https://github.com/adamfranco/language-javascript/tree/regexp_replacement_grammar). I'll link to the pull request for that code once it has been submitted.