### PR TITLE
Improve keyboard movement in project results pane

### DIFF
--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -118,7 +118,10 @@ class ResultsView extends ScrollView
     selectedView = @find('.selected').view()
     return @selectFirstResult() unless selectedView
 
-    itemHeight = selectedView.outerHeight()
+    if selectedView.hasClass('path')
+      itemHeight = selectedView.find('.path-details').outerHeight()
+    else
+      itemHeight = selectedView.outerHeight()
     pageHeight = @innerHeight()
     resultsPerPage = Math.round(pageHeight / itemHeight)
     pageHeight = resultsPerPage * itemHeight # so it's divisible by the number of items
@@ -137,7 +140,10 @@ class ResultsView extends ScrollView
     selectedView = @find('.selected').view()
     return @selectFirstResult() unless selectedView
 
-    itemHeight = selectedView.outerHeight()
+    if selectedView.hasClass('path')
+      itemHeight = selectedView.find('.path-details').outerHeight()
+    else
+      itemHeight = selectedView.outerHeight()
     pageHeight = @innerHeight()
     resultsPerPage = Math.round(pageHeight / itemHeight)
     pageHeight = resultsPerPage * itemHeight # so it's divisible by the number of items
@@ -158,11 +164,7 @@ class ResultsView extends ScrollView
     selectedView = @find('.selected').view()
     return @selectFirstResult() unless selectedView
 
-    if selectedView.isExpanded
-      nextView = selectedView.find('.search-result:first')
-    else
-      nextView = selectedView.next()
-      nextView = selectedView.closest('.path').next() unless nextView?.length
+    nextView = @getNextVisible(selectedView)
 
     @selectResult(nextView)
     @scrollTo(nextView)
@@ -171,27 +173,28 @@ class ResultsView extends ScrollView
     selectedView = @find('.selected').view()
     return @selectFirstResult() unless selectedView
 
-    if selectedView.isExpanded
-      prevView = selectedView.find('.search-result:last')
-    else
-      prevView = selectedView.prev()
-      if not prevView?.length
-        prevParent = selectedView.closest('.path').prev()
-        prevView = prevParent.find('.search-result:last')
-      else if prevView.hasClass('path')
-        prevView = prevView.find('.search-result:last')
+    prevView = @getPreviousVisible(selectedView)
 
     @selectResult(prevView)
     @scrollTo(prevView)
+
+  getNextVisible: (element) ->
+    return unless element?.length
+    visibleItems = @find('li:visible')
+    itemIndex = visibleItems.index(element)
+    $(visibleItems[Math.min(itemIndex + 1, visibleItems.length - 1)])
+
+  getPreviousVisible: (element) ->
+    return unless element?.length
+    visibleItems = @find('li:visible')
+    itemIndex = visibleItems.index(element)
+    $(visibleItems[Math.max(itemIndex - 1, 0)])
 
   selectResult: (resultView) ->
     return unless resultView?.length
     @find('.selected').removeClass('selected')
 
-    isPath = resultView.hasClass('path')
-    if isPath and not resultView.hasClass('collapsed')
-      resultView = resultView.find('.search-result:first')
-    else if not isPath
+    unless resultView.hasClass('path')
       parentView = resultView.closest('.path')
       resultView = parentView if parentView.hasClass('collapsed')
 

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -36,6 +36,8 @@ class ResultsView extends ScrollView
         @selectPreviousResult()
       'core:move-left': => @collapseResult()
       'core:move-right': => @expandResult()
+      'core:move-to-top': =>
+        @selectFirstResult()
       'core:move-to-bottom': =>
         @renderResults(renderAll: true)
         @selectLastResult()
@@ -98,10 +100,26 @@ class ResultsView extends ScrollView
     @prop('scrollHeight') <= @height() + @pixelOverdraw or @prop('scrollHeight') <= @scrollBottom() + @pixelOverdraw
 
   selectFirstResult: ->
-    @find('.search-result:first').addClass('selected')
+    @find('.selected').removeClass('selected')
+
+    lastView = @find('.search-result:first')
+    parentView = lastView.closest('.path')
+    if parentView.hasClass('collapsed')
+      parentView.addClass('selected')
+    else
+      lastView.addClass('selected')
+
+    @scrollTop(0)
 
   selectLastResult: ->
-    @find('.search-result:last').addClass('selected')
+    @find('.selected').removeClass('selected')
+
+    lastView = @find('.search-result:last')
+    parentView = lastView.closest('.path')
+    if parentView.hasClass('collapsed')
+      @scrollTo(parentView.addClass('selected'))
+    else
+      @scrollTo(lastView.addClass('selected'))
 
   selectNextResult: ->
     selectedView = @find('.selected').view()

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -36,6 +36,9 @@ class ResultsView extends ScrollView
         @selectPreviousResult()
       'core:move-left': => @collapseResult()
       'core:move-right': => @expandResult()
+      'core:move-to-bottom': =>
+        @renderResults(renderAll: true)
+        @selectLastResult()
       'core:confirm': =>
         @find('.selected').view()?.confirm?()
         false
@@ -96,6 +99,9 @@ class ResultsView extends ScrollView
 
   selectFirstResult: ->
     @find('.search-result:first').addClass('selected')
+
+  selectLastResult: ->
+    @find('.search-result:last').addClass('selected')
 
   selectNextResult: ->
     selectedView = @find('.selected').view()

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -159,43 +159,33 @@ class ResultsView extends ScrollView
     return @selectFirstResult() unless selectedView
 
     if selectedView.isExpanded
-      nextView = selectedView.find('.search-result:first').view()
+      nextView = selectedView.find('.search-result:first')
     else
-      nextView = selectedView.next().view()
+      nextView = selectedView.next()
+      nextView = selectedView.closest('.path').next() unless nextView?.length
 
-      unless nextView?
-        nextParent = selectedView.closest('.path').next()
-        nextView = if (not nextParent.hasClass('collapsed')) then nextParent.find('.search-result:first').view() else nextParent.view()
-      else if nextView.isExpanded
-        nextView = nextView.find('.search-result:first').view()
-
-    # only select the next view if we found something
-    if nextView?
-      selectedView.removeClass('selected')
-      nextView.addClass('selected')
-      @scrollTo(nextView)
+    @selectResult(nextView)
+    @scrollTo(nextView)
 
   selectPreviousResult: ->
     selectedView = @find('.selected').view()
     return @selectFirstResult() unless selectedView
 
     if selectedView.isExpanded
-      prevView = selectedView.find('.search-result:last').view()
+      prevView = selectedView.find('.search-result:last')
     else
-      prevView = selectedView.prev().view()
-      unless prevView?
+      prevView = selectedView.prev()
+      if not prevView?.length
         prevParent = selectedView.closest('.path').prev()
-        prevView = if (not prevParent.hasClass('collapsed')) then prevParent.find('.search-result:last').view() else prevParent.view()
-      else if prevView.isExpanded
-        prevView = prevView.find('.search-result:last').view()
+        prevView = prevParent.find('.search-result:last')
+      else if prevView.hasClass('path')
+        prevView = prevView.find('.search-result:last')
 
-    # only select the prev view if we found something
-    if prevView?
-      selectedView.removeClass('selected')
-      prevView.addClass('selected')
-      @scrollTo(prevView)
+    @selectResult(prevView)
+    @scrollTo(prevView)
 
   selectResult: (resultView) ->
+    return unless resultView?.length
     @find('.selected').removeClass('selected')
 
     isPath = resultView.hasClass('path')
@@ -229,6 +219,7 @@ class ResultsView extends ScrollView
     @empty()
 
   scrollTo: (element) ->
+    return unless element?.length
     top = @scrollTop() + element.offset().top - @offset().top
     bottom = top + element.outerHeight()
 

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -683,14 +683,14 @@ describe 'ProjectFindView', ->
             resultsView.selectFirstResult()
             _.times 7, -> resultsView.selectNextResult()
 
-            expect(resultsView.find("li > ul:eq(1) > li:eq(0)")).toHaveClass 'selected'
+            expect(resultsView.find(".path:eq(1)")).toHaveClass 'selected'
 
             buffer.setText('there is one "items" in this file')
             advanceClock(buffer.stoppedChangingDelay)
 
             expect(resultsView.find("li > ul > li")).toHaveLength(8)
             expect(resultsPaneView.previewCount.text()).toBe "8 results found in 2 files for items"
-            expect(resultsView.find("li > ul:eq(1) > li:eq(0)")).toHaveClass 'selected'
+            expect(resultsView.find(".path:eq(1)")).toHaveClass 'selected'
 
             buffer.setText('no matches in this file')
             advanceClock(buffer.stoppedChangingDelay)

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -282,9 +282,6 @@ describe 'ResultsView', ->
       it "renders all results and selects the last item when core:move-to-bottom is triggered; selects the first item when core:move-to-top is triggered", ->
         expect(resultsView.find("li").length).toBeLessThan resultsView.getPathCount() + resultsView.getMatchCount()
 
-        expect(resultsView.prop('scrollTop')).toBe 0
-        expect(resultsView.prop('scrollHeight')).toBeGreaterThan resultsView.height()
-        previousScrollHeight = resultsView.prop('scrollHeight')
         atom.commands.dispatch resultsView.element, 'core:move-to-bottom'
         expect(resultsView.find("li").length).toBe resultsView.getPathCount() + resultsView.getMatchCount()
         expect(resultsView.find("li:eq(1)")).not.toHaveClass 'selected'

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -276,8 +276,11 @@ describe 'ResultsView', ->
         waitsForPromise ->
           searchPromise
 
+        runs ->
+          resultsView = getResultsView()
+
+
       it "renders all results and selects the last item when core:move-to-bottom is triggered; selects the first item when core:move-to-top is triggered", ->
-        resultsView = getResultsView()
         expect(resultsView.find("li").length).toBeLessThan resultsView.getPathCount() + resultsView.getMatchCount()
 
         expect(resultsView.prop('scrollTop')).toBe 0
@@ -294,8 +297,6 @@ describe 'ResultsView', ->
         expect(resultsView.prop('scrollTop')).toBe 0
 
       it "selects the path when when core:move-to-bottom is triggered and last item is collapsed", ->
-        resultsView = getResultsView()
-
         atom.commands.dispatch resultsView.element, 'core:move-to-bottom'
         atom.commands.dispatch resultsView.element, 'core:move-left'
         atom.commands.dispatch resultsView.element, 'core:move-to-bottom'
@@ -303,8 +304,6 @@ describe 'ResultsView', ->
         expect(resultsView.find("li:last").closest('.path')).toHaveClass 'selected'
 
       it "selects the path when when core:move-to-bottom is triggered and last item is collapsed", ->
-        resultsView = getResultsView()
-
         atom.commands.dispatch resultsView.element, 'core:move-to-top'
         atom.commands.dispatch resultsView.element, 'core:move-left'
         atom.commands.dispatch resultsView.element, 'core:move-to-top'

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -267,6 +267,63 @@ describe 'ResultsView', ->
 
         expect(resultsView.find(".path-details").length).toBe 3
 
+    describe "core:page-up and core:page-down", ->
+      beforeEach ->
+        workspaceElement.style.height = '300px'
+        projectFindView.findEditor.setText(' ')
+        projectFindView.confirm()
+
+        waitsForPromise ->
+          searchPromise
+
+        runs ->
+          resultsView = getResultsView()
+          expect(resultsView.prop('scrollTop')).toBe 0
+          expect(resultsView.prop('scrollHeight')).toBeGreaterThan resultsView.height()
+
+      it "selects the first result on the next page when core:page-down is triggered", ->
+        itemHeight = resultsView.find('.selected').outerHeight()
+        pageHeight = Math.round(resultsView.innerHeight() / itemHeight) * itemHeight
+        expect(resultsView.find("li").length).toBeLessThan resultsView.getPathCount() + resultsView.getMatchCount()
+
+        atom.commands.dispatch resultsView.element, 'core:page-down'
+        expect(resultsView.find("li:eq(1)")).not.toHaveClass 'selected'
+        expect(resultsView.find("li:eq(5)")).toHaveClass 'selected'
+        expect(resultsView.prop('scrollTop')).toBe pageHeight
+
+        atom.commands.dispatch resultsView.element, 'core:page-down'
+        expect(resultsView.find("li:eq(5)")).not.toHaveClass 'selected'
+        expect(resultsView.find("li:eq(9)")).toHaveClass 'selected'
+        expect(resultsView.prop('scrollTop')).toBe pageHeight * 2
+
+        _.times 60, ->
+          atom.commands.dispatch resultsView.element, 'core:page-down'
+
+        expect(resultsView.find("li:last")).toHaveClass 'selected'
+
+      it "selects the first result on the next page when core:page-up is triggered", ->
+        atom.commands.dispatch resultsView.element, 'core:move-to-bottom'
+        expect(resultsView.find("li:last")).toHaveClass 'selected'
+
+        itemHeight = resultsView.find('.selected').outerHeight()
+        pageHeight = Math.round(resultsView.innerHeight() / itemHeight) * itemHeight
+        initialScrollTop = resultsView.scrollTop()
+
+        atom.commands.dispatch resultsView.element, 'core:page-up'
+        expect(resultsView.find("li:last")).not.toHaveClass 'selected'
+        expect(resultsView.find("li:eq(215)")).toHaveClass 'selected'
+        expect(resultsView.prop('scrollTop')).toBe initialScrollTop - pageHeight
+
+        atom.commands.dispatch resultsView.element, 'core:page-up'
+        expect(resultsView.find("li:eq(215)")).not.toHaveClass 'selected'
+        expect(resultsView.find("li:eq(210)")).toHaveClass 'selected'
+        expect(resultsView.prop('scrollTop')).toBe initialScrollTop - pageHeight * 2
+
+        _.times 60, ->
+          atom.commands.dispatch resultsView.element, 'core:page-up'
+
+        expect(resultsView.find("li:eq(1)")).toHaveClass 'selected'
+
     describe "core:move-to-top and core:move-to-bottom", ->
       beforeEach ->
         workspaceElement.style.height = '200px'

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -268,7 +268,7 @@ describe 'ResultsView', ->
         expect(resultsView.find(".path-details").length).toBe 3
 
     it "renders all results when core:move-to-bottom is triggered", ->
-      workspaceElement.style.height = '300px'
+      workspaceElement.style.height = '200px'
       projectFindView.findEditor.setText('so')
       projectFindView.confirm()
 
@@ -277,11 +277,13 @@ describe 'ResultsView', ->
 
       runs ->
         resultsView = getResultsView()
+        expect(resultsView.find("li").length).toBeLessThan resultsView.getPathCount() + resultsView.getMatchCount()
 
         expect(resultsView.prop('scrollHeight')).toBeGreaterThan resultsView.height()
         previousScrollHeight = resultsView.prop('scrollHeight')
         atom.commands.dispatch resultsView.element, 'core:move-to-bottom'
         expect(resultsView.find("li").length).toBe resultsView.getPathCount() + resultsView.getMatchCount()
+        expect(resultsView.find("li:last")).toHaveClass 'selected'
 
   describe "opening results", ->
     openHandler = null

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -279,7 +279,6 @@ describe 'ResultsView', ->
         runs ->
           resultsView = getResultsView()
 
-
       it "renders all results and selects the last item when core:move-to-bottom is triggered; selects the first item when core:move-to-top is triggered", ->
         expect(resultsView.find("li").length).toBeLessThan resultsView.getPathCount() + resultsView.getMatchCount()
 

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -645,6 +645,19 @@ describe 'ResultsView', ->
       atom.commands.dispatch resultsView.element, 'core:copy'
       expect(atom.clipboard.read()).toBe '    return items if items.length <= 1'
 
+  # Keep. Useful for debugging.
+  logSelectedIndex = ->
+    paths = resultsView.find('.path')
+    selectedView = resultsView.find('.selected')
+
+    if selectedView.hasClass('path')
+      console.log 'PATH', paths.index(selectedView)
+    else
+      for pathElement, pathIndex in paths
+        index = $(pathElement).find('.search-result').index(selectedView)
+        console.log pathIndex, index if index > -1
+        break
+
 buildMouseEvent = (type, properties...) ->
   properties = _.extend({bubbles: true, cancelable: true}, properties...)
   properties.detail ?= 1

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -267,23 +267,49 @@ describe 'ResultsView', ->
 
         expect(resultsView.find(".path-details").length).toBe 3
 
-    it "renders all results when core:move-to-bottom is triggered", ->
-      workspaceElement.style.height = '200px'
-      projectFindView.findEditor.setText('so')
-      projectFindView.confirm()
+    describe "core:move-to-top and core:move-to-bottom", ->
+      beforeEach ->
+        workspaceElement.style.height = '200px'
+        projectFindView.findEditor.setText('so')
+        projectFindView.confirm()
 
-      waitsForPromise ->
-        searchPromise
+        waitsForPromise ->
+          searchPromise
 
-      runs ->
+      it "renders all results and selects the last item when core:move-to-bottom is triggered; selects the first item when core:move-to-top is triggered", ->
         resultsView = getResultsView()
         expect(resultsView.find("li").length).toBeLessThan resultsView.getPathCount() + resultsView.getMatchCount()
 
+        expect(resultsView.prop('scrollTop')).toBe 0
         expect(resultsView.prop('scrollHeight')).toBeGreaterThan resultsView.height()
         previousScrollHeight = resultsView.prop('scrollHeight')
         atom.commands.dispatch resultsView.element, 'core:move-to-bottom'
         expect(resultsView.find("li").length).toBe resultsView.getPathCount() + resultsView.getMatchCount()
+        expect(resultsView.find("li:eq(1)")).not.toHaveClass 'selected'
         expect(resultsView.find("li:last")).toHaveClass 'selected'
+        expect(resultsView.prop('scrollTop')).not.toBe 0
+
+        atom.commands.dispatch resultsView.element, 'core:move-to-top'
+        expect(resultsView.find("li:eq(1)")).toHaveClass 'selected'
+        expect(resultsView.prop('scrollTop')).toBe 0
+
+      it "selects the path when when core:move-to-bottom is triggered and last item is collapsed", ->
+        resultsView = getResultsView()
+
+        atom.commands.dispatch resultsView.element, 'core:move-to-bottom'
+        atom.commands.dispatch resultsView.element, 'core:move-left'
+        atom.commands.dispatch resultsView.element, 'core:move-to-bottom'
+
+        expect(resultsView.find("li:last").closest('.path')).toHaveClass 'selected'
+
+      it "selects the path when when core:move-to-bottom is triggered and last item is collapsed", ->
+        resultsView = getResultsView()
+
+        atom.commands.dispatch resultsView.element, 'core:move-to-top'
+        atom.commands.dispatch resultsView.element, 'core:move-left'
+        atom.commands.dispatch resultsView.element, 'core:move-to-top'
+
+        expect(resultsView.find("li:first").closest('.path')).toHaveClass 'selected'
 
   describe "opening results", ->
     openHandler = null

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -286,15 +286,25 @@ describe 'ResultsView', ->
         pageHeight = Math.round(resultsView.innerHeight() / itemHeight) * itemHeight
         expect(resultsView.find("li").length).toBeLessThan resultsView.getPathCount() + resultsView.getMatchCount()
 
-        atom.commands.dispatch resultsView.element, 'core:page-down'
-        expect(resultsView.find("li:eq(1)")).not.toHaveClass 'selected'
-        expect(resultsView.find("li:eq(5)")).toHaveClass 'selected'
-        expect(resultsView.prop('scrollTop')).toBe pageHeight
+        resultLis = resultsView.find("li")
+        getSelectedIndex = ->
+          resultLis.index(resultsView.find('.selected'))
 
+        initialIndex = getSelectedIndex()
         atom.commands.dispatch resultsView.element, 'core:page-down'
-        expect(resultsView.find("li:eq(5)")).not.toHaveClass 'selected'
-        expect(resultsView.find("li:eq(9)")).toHaveClass 'selected'
+        newIndex = getSelectedIndex()
+        expect(resultsView.find("li:eq(#{initialIndex})")).not.toHaveClass 'selected'
+        expect(resultsView.find("li:eq(#{newIndex})")).toHaveClass 'selected'
+        expect(resultsView.prop('scrollTop')).toBe pageHeight
+        expect(newIndex).toBeGreaterThan initialIndex
+
+        initialIndex = getSelectedIndex()
+        atom.commands.dispatch resultsView.element, 'core:page-down'
+        newIndex = getSelectedIndex()
+        expect(resultsView.find("li:eq(#{initialIndex})")).not.toHaveClass 'selected'
+        expect(resultsView.find("li:eq(#{newIndex})")).toHaveClass 'selected'
         expect(resultsView.prop('scrollTop')).toBe pageHeight * 2
+        expect(newIndex).toBeGreaterThan initialIndex
 
         _.times 60, ->
           atom.commands.dispatch resultsView.element, 'core:page-down'


### PR DESCRIPTION
This turned into kind of a rabbit hole. My intent was to fix move-to-bottom and add move-to-top. 

Changes:

* Fixes `core:move-to-bottom` to actually work
* Adds `core:move-to-top` support
* Adds `core:page-down` support
* Adds `core:page-up` support
* Allow selecting paths even when they are not collapsed
* Fixes movement when files have been updated. Updating a file so it no longer has matches for the search string removes old results from the `ResultsView` by hiding the `ResultView` element for the path. Previously, it would attempt to select these invisible elements, which would make the selection 'stick' in the removed element location when arrowing through the results.