### PR TITLE
Project View Search Button

### DIFF
--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -35,7 +35,7 @@ class ProjectFindView extends View
       buffer: pathsBuffer
       placeholderText: 'File/directory pattern. eg. `src` to search in the "src" directory or `*.js` to search all javascript files.'
 
-    @div tabIndex: -1, class: 'project-find padded', =>
+    @div tabIndex: -1, class: 'find-and-replace', =>
       @header class: 'header', =>
         @span outlet: 'descriptionLabel', class: 'header-item description'
         @span class: 'header-item options-label pull-right', =>
@@ -52,7 +52,7 @@ class ProjectFindView extends View
         @div class: 'input-block-item', =>
           @div class: 'btn-group btn-group-find', =>
             @button outlet: 'findAllButton', class: 'btn', 'Find'
-        @div class: 'input-block-item', =>
+
           @div class: 'btn-group btn-toggle btn-group-options', =>
             @button outlet: 'regexOptionButton', class: 'btn option-regex', =>
               @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-regex" /></svg>'

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -52,7 +52,6 @@ class ProjectFindView extends View
         @div class: 'input-block-item', =>
           @div class: 'btn-group btn-group-find', =>
             @button outlet: 'findAllButton', class: 'btn', 'Find'
-
           @div class: 'btn-group btn-toggle btn-group-options', =>
             @button outlet: 'regexOptionButton', class: 'btn option-regex', =>
               @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-regex" /></svg>'

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -53,8 +53,6 @@ class ProjectFindView extends View
           @div class: 'btn-group btn-group-find', =>
             @button outlet: 'findAllButton', class: 'btn', 'Find'
 
-
-
         @div class: 'input-block-item', =>
           @div class: 'btn-group btn-toggle btn-group-options', =>
             @button outlet: 'regexOptionButton', class: 'btn option-regex', =>

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -374,4 +374,4 @@ class ProjectFindView extends View
     @search(onlyRunIfActive: true, caseSensitive: not @model.getFindOptions().caseSensitive)
 
   toggleWholeWordOption: ->
-    @search(onlyRunIfActive: true, wholeWord: not @model.getFindOptions().wholeWord)
+    @search(onlyRunIfActive: true, wholeWord: not @model.getFindOptions().wholeWord) 

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -35,7 +35,7 @@ class ProjectFindView extends View
       buffer: pathsBuffer
       placeholderText: 'File/directory pattern. eg. `src` to search in the "src" directory or `*.js` to search all javascript files.'
 
-    @div tabIndex: -1, class: 'find-and-replace', =>
+    @div tabIndex: -1, class: 'project-find padded', =>
       @header class: 'header', =>
         @span outlet: 'descriptionLabel', class: 'header-item description'
         @span class: 'header-item options-label pull-right', =>

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -52,7 +52,6 @@ class ProjectFindView extends View
         @div class: 'input-block-item', =>
           @div class: 'btn-group btn-group-find', =>
             @button outlet: 'findAllButton', class: 'btn', 'Find'
-
         @div class: 'input-block-item', =>
           @div class: 'btn-group btn-toggle btn-group-options', =>
             @button outlet: 'regexOptionButton', class: 'btn option-regex', =>
@@ -233,7 +232,6 @@ class ProjectFindView extends View
     searchPromise = @search({@onlyRunIfChanged})
     @onlyRunIfChanged = true
     searchPromise
-
 
   search: (options={}) ->
     # We always want to set the options passed in, even if we dont end up doing the search

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -50,6 +50,12 @@ class ProjectFindView extends View
         @div class: 'input-block-item input-block-item--flex editor-container', =>
           @subview 'findEditor', new TextEditorView(editor: findEditor)
         @div class: 'input-block-item', =>
+          @div class: 'btn-group btn-group-find', =>
+            @button outlet: 'findAllButton', class: 'btn', 'Find'
+
+
+
+        @div class: 'input-block-item', =>
           @div class: 'btn-group btn-toggle btn-group-options', =>
             @button outlet: 'regexOptionButton', class: 'btn option-regex', =>
               @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-regex" /></svg>'
@@ -115,6 +121,11 @@ class ProjectFindView extends View
       keyBindingCommand: 'project-find:replace-all',
       keyBindingTarget: @replaceEditor.element
 
+    subs.add atom.tooltips.add @findAllButton,
+      title: "Find All",
+      keyBindingCommand: 'find-and-replace:search',
+      keyBindingTarget: @findEditor.element
+
   didHide: ->
     @hideAllTooltips()
     workspaceElement = atom.views.getView(atom.workspace)
@@ -166,6 +177,7 @@ class ProjectFindView extends View
     @caseOptionButton.click => @toggleCaseOption()
     @wholeWordOptionButton.click => @toggleWholeWordOption()
     @replaceAllButton.on 'click', => @replaceAll()
+    @findAllButton.on 'click', => @search()
 
     focusCallback = => @onlyRunIfChanged = false
     $(window).on 'focus', focusCallback
@@ -223,6 +235,7 @@ class ProjectFindView extends View
     searchPromise = @search({@onlyRunIfChanged})
     @onlyRunIfChanged = true
     searchPromise
+
 
   search: (options={}) ->
     # We always want to set the options passed in, even if we dont end up doing the search

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -374,4 +374,4 @@ class ProjectFindView extends View
     @search(onlyRunIfActive: true, caseSensitive: not @model.getFindOptions().caseSensitive)
 
   toggleWholeWordOption: ->
-    @search(onlyRunIfActive: true, wholeWord: not @model.getFindOptions().wholeWord) 
+    @search(onlyRunIfActive: true, wholeWord: not @model.getFindOptions().wholeWord)

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -171,13 +171,17 @@ atom-workspace.find-visible {
 // Project find and replace
 .project-find {
   @project-input-width: 260px;
-  @project-button-width: 120px;
+  @project-block-width: 220px;
 
   .input-block-item {
-    flex: 1 1 @project-button-width;
+    flex: 1 1 @project-block-width;
   }
   .input-block-item--flex {
     flex: 100 1 @project-input-width;
+  }
+
+  .btn-group-find {
+    flex: .6;
   }
 
   .loading,
@@ -185,14 +189,6 @@ atom-workspace.find-visible {
   .error-messages,
   .filter-container {
     display: none;
-  }
-
-  .btn-group-options {
-    width: @project-button-width;
-  }
-
-  .btn-group-replace-all {
-    width: @project-button-width;
   }
 }
 


### PR DESCRIPTION
This is to create a 'Find' button so that users are able to press Find instead of having to press enter.
This is to improve user friendiness, instead of having to guess enter = find.

This is my first dabble in coffee, code review appreciated. 

Please see https://github.com/atom/find-and-replace/issues/297

Cheers,


----

Added by @simurai

Before:

![screen shot 2015-09-22 at 10 48 29 pm](https://cloud.githubusercontent.com/assets/378023/10020124/308bc7a8-617c-11e5-884f-ad3ad42246a1.png)

After:

![screen shot 2015-09-22 at 10 46 07 pm](https://cloud.githubusercontent.com/assets/378023/10020138/3c4a3296-617c-11e5-8616-f6cf970dd783.png)

Once this gets merged, also merge One dark/light PRs https://github.com/atom/one-dark-ui/issues/91 + https://github.com/atom/one-light-ui/issues/35.