### PR TITLE
Add an option to close the find panel after search

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -18,6 +18,9 @@ module.exports =
     openProjectFindResultsInRightPane:
       type: 'boolean'
       default: false
+    closeFindPanelAfterSearch:
+      type: 'boolean'
+      default: false
     scrollToResultOnLiveSearch:
       type: 'boolean'
       default: false

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -145,6 +145,7 @@ class ProjectFindView extends View
       @setInfoMessage('Searching...')
 
     updateInterfaceForResults = (results) =>
+      return @panel?.hide() if atom.config.get('find-and-replace.closeFindPanelAfterSearch')
       if results.matchCount is 0 and results.findPattern is ''
         @clearMessages()
       else

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -312,6 +312,17 @@ describe 'ProjectFindView', ->
         atom.commands.dispatch(document.activeElement, 'core:cancel')
         expect(getAtomPanel()).not.toBeVisible()
 
+    describe "when close option is true", ->
+      beforeEach ->
+        atom.config.set('find-and-replace.closeFindPanelAfterSearch', true)
+        atom.commands.dispatch(projectFindView[0], 'core:confirm')
+
+      it "close the panel after search", ->
+        waitsForPromise ->
+          searchPromise
+        runs ->
+          expect(getAtomPanel()).not.toBeVisible()
+
     describe "splitting into a second pane", ->
       beforeEach ->
         workspaceElement.style.height = '1000px'


### PR DESCRIPTION
To have the same behaviour as Sublime, if I enable this option the find panel is closed when the search is finished.