### PR TITLE
Add find-and-replace:hide-all activation.

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -90,6 +90,11 @@ module.exports =
         @findPanel.show()
         @findView.focusFindEditor()
 
+    @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:hide-all', =>
+      @createViews()
+      @projectFindPanel.hide()
+      @findPanel.hide()
+
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:show', =>
       @createViews()
       @projectFindPanel.hide()

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
       "project-find:show",
       "project-find:toggle",
       "project-find:show-in-current-directory",
+      "find-and-replace:hide-all",
       "find-and-replace:show",
       "find-and-replace:toggle",
       "find-and-replace:find-next",

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -123,6 +123,18 @@ describe 'FindView', ->
         atom.commands.dispatch workspaceElement, 'find-and-replace:toggle'
         expect(getFindAtomPanel()).not.toBeVisible()
 
+  describe "find-and-replace:hide-all is triggered", ->
+    it "hides the FindView", ->
+      atom.commands.dispatch workspaceElement, 'find-and-replace:show'
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        expect(getFindAtomPanel()).toBeVisible()
+        atom.commands.dispatch workspaceElement, 'find-and-replace:hide-all'
+        expect(getFindAtomPanel()).not.toBeVisible()
+
   describe "when the find-view is focused and window:focus-next-pane is triggered", ->
     beforeEach ->
       atom.commands.dispatch editorView, 'find-and-replace:show'

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -138,6 +138,18 @@ describe 'ProjectFindView', ->
         atom.commands.dispatch(workspaceElement, 'project-find:toggle')
         expect(getAtomPanel()).not.toBeVisible()
 
+  describe "find-and-replace:hide-all is triggered", ->
+    it "hides the ProjectFindView", ->
+      atom.commands.dispatch(workspaceElement, 'project-find:show')
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        expect(getAtomPanel()).toBeVisible()
+        atom.commands.dispatch(workspaceElement, 'find-and-replace:hide-all')
+        expect(getAtomPanel()).not.toBeVisible()
+
   describe "when project-find:show-in-current-directory is triggered", ->
     [nested, tree, projectPath] = []
 


### PR DESCRIPTION
This PR exposes a new activation command which hides either a Package or Find panel. The purpose of exposing this is to resolve [this issue](https://github.com/atom/vim-mode/issues/165) in the vim-mode package.

[This](https://github.com/atom/vim-mode/pull/869) is the corresponding PR in the `vim-mode` package.