### PR TITLE
Adapt specs to work with the logical DisplayBuffer

### DIFF
--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -912,7 +912,8 @@ describe 'FindView', ->
 
       it "scrolls to the first match if the settings scrollToResultOnLiveSearch is true", ->
         atom.config.set('find-and-replace.scrollToResultOnLiveSearch', true)
-        editor.setHeight(3)
+        editorView.style.height = "3px"
+        editorView.component.measureDimensions()
         editor.moveToTop()
         originalScrollPosition = editor.getScrollTop()
         findView.findEditor.setText 'Array'
@@ -923,7 +924,8 @@ describe 'FindView', ->
 
       it "doesn't scroll to the first match if the settings scrollToResultOnLiveSearch is false", ->
         atom.config.set('find-and-replace.scrollToResultOnLiveSearch', false)
-        editor.setHeight(3)
+        editorView.style.height = "3px"
+        editorView.component.measureDimensions()
         editor.moveToTop()
         originalScrollPosition = editor.getScrollTop()
         findView.findEditor.setText 'Array'


### PR DESCRIPTION
This changes the specs so that they use the editor element to test visual changes, so that they still continue to pass as soon as we merge atom/atom#8905.

/cc: @nathansobo 