### PR TITLE
Use findOptions.caseSensitive when selecting next occurrence (cmd-d)

### DIFF
--- a/lib/select-next.coffee
+++ b/lib/select-next.coffee
@@ -87,7 +87,7 @@ class SelectNext
       nonWordCharacters = atom.config.get('editor.nonWordCharacters')
       text = "(^|[ \t#{_.escapeRegExp(nonWordCharacters)}]+)#{text}(?=$|[\\s#{_.escapeRegExp(nonWordCharacters)}]+)"
 
-    @editor.scanInBufferRange new RegExp(text, 'g'), range, (result) ->
+    @editor.scanInBufferRange new RegExp(text, (if @findOptions.caseSensitive then 'g' else 'gi')), range, (result) ->
       if prefix = result.match[1]
         result.range = result.range.translate([0, prefix.length], [0, 0])
       callback(result)

--- a/spec/select-next-spec.coffee
+++ b/spec/select-next-spec.coffee
@@ -32,7 +32,7 @@ describe "SelectNext", ->
     describe "when a word is selected", ->
       describe "when findOptions.wholeWord is false", ->
         beforeEach ->
-          findOptions.set(wholeWord: false, caseSensitive:true)
+          findOptions.set(wholeWord: false, caseSensitive: true)
 
         it "selects the next occurrence of the selected word skipping any non-word matches", ->
           editor.setText """
@@ -83,7 +83,7 @@ describe "SelectNext", ->
 
       describe "when findOptions.wholeWord is true", ->
         beforeEach ->
-          findOptions.set(wholeWord: true, caseSensitive:true)
+          findOptions.set(wholeWord: true, caseSensitive: true)
 
         it "selects the next occurrence of the selected word skipping any non-word matches", ->
           editor.setText """
@@ -131,7 +131,6 @@ describe "SelectNext", ->
           ]
 
       describe "When buffer text is of mixed case", ->
-
         beforeEach ->
           editor.setText """
             FooBar
@@ -146,8 +145,7 @@ describe "SelectNext", ->
 
         describe "When findOptions.wholeWord is true and findOptions.caseSensitive is true", ->
           it "does not select partial words or wrong case", ->
-
-            findOptions.set(wholeWord: true, caseSensitive:true)
+            findOptions.set(wholeWord: true, caseSensitive: true)
 
             editor.setSelectedBufferRange([[0, 0], [0, 6]]) #First FooBar
             atom.commands.dispatch editorElement, 'find-and-replace:select-next'
@@ -165,8 +163,7 @@ describe "SelectNext", ->
 
         describe "When findOptions.wholeWord is true and findOptions.caseSensitive is false", ->
           it "does not select partial words but allows case insensitive match", ->
-
-            findOptions.set(wholeWord: true, caseSensitive:false)
+            findOptions.set(wholeWord: true, caseSensitive: false)
 
             editor.setSelectedBufferRange([[0, 0], [0, 6]]) #First FooBar
             atom.commands.dispatch editorElement, 'find-and-replace:select-next'
@@ -182,8 +179,7 @@ describe "SelectNext", ->
 
         describe "When findOptions.wholeWord is false and findOptions.caseSensitive is true", ->
           it "selects partial words but require case sensitive match", ->
-
-            findOptions.set(wholeWord: false, caseSensitive:true)
+            findOptions.set(wholeWord: false, caseSensitive: true)
 
             editor.setSelectedBufferRange([[0, 0], [0, 6]]) #First FooBar
             atom.commands.dispatch editorElement, 'find-and-replace:select-next'
@@ -199,8 +195,7 @@ describe "SelectNext", ->
 
         describe "When findOptions.wholeWord is false and findOptions.caseSensitive is false", ->
           it "selects case insensitive partial words", ->
-
-            findOptions.set(wholeWord: false, caseSensitive:false)
+            findOptions.set(wholeWord: false, caseSensitive: false)
 
             editor.setSelectedBufferRange([[0, 0], [0, 6]]) #First FooBar
             atom.commands.dispatch editorElement, 'find-and-replace:select-next'
@@ -225,7 +220,7 @@ describe "SelectNext", ->
     describe "when part of a word is selected", ->
       describe "when findOptions.wholeWord is false", ->
         beforeEach ->
-          findOptions.set(wholeWord: false, caseSensitive:true)
+          findOptions.set(wholeWord: false, caseSensitive: true)
 
         it "selects the next occurrence of the selected text", ->
           editor.setText """
@@ -254,7 +249,7 @@ describe "SelectNext", ->
 
       describe "when findOptions.wholeWord is true", ->
         beforeEach ->
-          findOptions.set(wholeWord: true, caseSensitive:true)
+          findOptions.set(wholeWord: true, caseSensitive: true)
 
         it "selects the next occurrence of the selected text", ->
           editor.setText """
@@ -350,7 +345,7 @@ describe "SelectNext", ->
     describe "when there is no selection", ->
       describe "when findOptions.wholeWord is false", ->
         beforeEach ->
-          findOptions.set(wholeWord: false, caseSensitive:true)
+          findOptions.set(wholeWord: false, caseSensitive: true)
 
         it "find and selects all occurrences of the word under the cursor", ->
           editor.setText """
@@ -374,7 +369,7 @@ describe "SelectNext", ->
 
       describe "when findOptions.wholeWord is true", ->
         beforeEach ->
-          findOptions.set(wholeWord: true, caseSensitive:true)
+          findOptions.set(wholeWord: true, caseSensitive: true)
 
         it "find and selects all occurrences of the word under the cursor", ->
           editor.setText """
@@ -402,7 +397,7 @@ describe "SelectNext", ->
 
     describe "when a word is selected", ->
       it "find and selects all occurrences", ->
-        findOptions.set(wholeWord: true, caseSensitive:true)
+        findOptions.set(wholeWord: true, caseSensitive: true)
 
         editor.setText """
           for
@@ -503,10 +498,9 @@ describe "SelectNext", ->
 
     describe "when three words are selected", ->
       beforeEach ->
-        findOptions.set(wholeWord: true, caseSensitive:true)
+        findOptions.set(wholeWord: true, caseSensitive: true)
 
       it "unselects words in order", ->
-
         editor.setText """
           for
           information
@@ -533,7 +527,7 @@ describe "SelectNext", ->
 
     describe "when starting at the bottom word", ->
       beforeEach ->
-        findOptions.set(wholeWord: true, caseSensitive:true)
+        findOptions.set(wholeWord: true, caseSensitive: true)
 
       it "unselects words in order", ->
         editor.setText """
@@ -578,7 +572,7 @@ describe "SelectNext", ->
 
   describe "find-and-replace:select-skip", ->
     beforeEach ->
-      findOptions.set(wholeWord: true, caseSensitive:true)
+      findOptions.set(wholeWord: true, caseSensitive: true)
 
     describe "when there is no selection", ->
       it "does nothing", ->

--- a/spec/select-next-spec.coffee
+++ b/spec/select-next-spec.coffee
@@ -32,7 +32,7 @@ describe "SelectNext", ->
     describe "when a word is selected", ->
       describe "when findOptions.wholeWord is false", ->
         beforeEach ->
-          findOptions.set(wholeWord: false)
+          findOptions.set(wholeWord: false, caseSensitive:true)
 
         it "selects the next occurrence of the selected word skipping any non-word matches", ->
           editor.setText """
@@ -83,7 +83,7 @@ describe "SelectNext", ->
 
       describe "when findOptions.wholeWord is true", ->
         beforeEach ->
-          findOptions.set(wholeWord: true)
+          findOptions.set(wholeWord: true, caseSensitive:true)
 
         it "selects the next occurrence of the selected word skipping any non-word matches", ->
           editor.setText """
@@ -130,10 +130,102 @@ describe "SelectNext", ->
             [[0, 0], [0, 7]]
           ]
 
+      describe "When buffer text is of mixed case", ->
+
+        beforeEach ->
+          editor.setText """
+            FooBar
+            foobar
+            testFooBar
+            FooBarTest
+            test_foobar
+            foobar_test
+            FooBar
+            foobar
+          """
+
+        describe "When findOptions.wholeWord is true and findOptions.caseSensitive is true", ->
+          it "does not select partial words or wrong case", ->
+
+            findOptions.set(wholeWord: true, caseSensitive:true)
+
+            editor.setSelectedBufferRange([[0, 0], [0, 6]]) #First FooBar
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+            expect(editor.getSelectedBufferRanges()).toEqual [
+              [[0, 0], [0, 6]]  #First FooBar
+              [[6, 0], [6, 6]]  #Second FooBar
+            ]
+
+            editor.setSelectedBufferRange([[1, 0], [1, 6]]) #First foobar
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+            expect(editor.getSelectedBufferRanges()).toEqual [
+              [[1, 0], [1, 6]]  #First foobar
+              [[7, 0], [7, 6]]  #Second foobar
+            ]
+
+        describe "When findOptions.wholeWord is true and findOptions.caseSensitive is false", ->
+          it "does not select partial words but allows case insensitive match", ->
+
+            findOptions.set(wholeWord: true, caseSensitive:false)
+
+            editor.setSelectedBufferRange([[0, 0], [0, 6]]) #First FooBar
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+
+            expect(editor.getSelectedBufferRanges()).toEqual [
+              [[0, 0], [0, 6]] #First FooBar
+              [[1, 0], [1, 6]] #First foobar
+              [[6, 0], [6, 6]] #Second FooBar
+              [[7, 0], [7, 6]] #Second foobar
+            ]
+
+        describe "When findOptions.wholeWord is false and findOptions.caseSensitive is true", ->
+          it "selects partial words but require case sensitive match", ->
+
+            findOptions.set(wholeWord: false, caseSensitive:true)
+
+            editor.setSelectedBufferRange([[0, 0], [0, 6]]) #First FooBar
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+
+            expect(editor.getSelectedBufferRanges()).toEqual [
+              [[0, 0], [0, 6]]  #First FooBar
+              [[2, 4], [2, 10]] #testFooBar
+              [[3, 0], [3, 6]]  #FooBarTest
+              [[6, 0], [6, 6]]  #Second FooBar
+            ]
+
+        describe "When findOptions.wholeWord is false and findOptions.caseSensitive is false", ->
+          it "selects case insensitive partial words", ->
+
+            findOptions.set(wholeWord: false, caseSensitive:false)
+
+            editor.setSelectedBufferRange([[0, 0], [0, 6]]) #First FooBar
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+
+            expect(editor.getSelectedBufferRanges()).toEqual [
+              [[0, 0], [0, 6]]  #First FooBar
+              [[1, 0], [1, 6]]  #First foobar
+              [[2, 4], [2, 10]] #testFooBar
+              [[3, 0], [3, 6]]  #FooBarTest
+              [[4, 5], [4, 11]] #test_foobar
+              [[5, 0], [5, 6]]  #foobar_test
+              [[6, 0], [6, 6]]  #Second FooBar
+              [[7, 0], [7, 6]]  #Second foobar
+            ]
+
     describe "when part of a word is selected", ->
       describe "when findOptions.wholeWord is false", ->
         beforeEach ->
-          findOptions.set(wholeWord: false)
+          findOptions.set(wholeWord: false, caseSensitive:true)
 
         it "selects the next occurrence of the selected text", ->
           editor.setText """
@@ -162,7 +254,7 @@ describe "SelectNext", ->
 
       describe "when findOptions.wholeWord is true", ->
         beforeEach ->
-          findOptions.set(wholeWord: true)
+          findOptions.set(wholeWord: true, caseSensitive:true)
 
         it "selects the next occurrence of the selected text", ->
           editor.setText """
@@ -258,7 +350,7 @@ describe "SelectNext", ->
     describe "when there is no selection", ->
       describe "when findOptions.wholeWord is false", ->
         beforeEach ->
-          findOptions.set(wholeWord: false)
+          findOptions.set(wholeWord: false, caseSensitive:true)
 
         it "find and selects all occurrences of the word under the cursor", ->
           editor.setText """
@@ -282,7 +374,7 @@ describe "SelectNext", ->
 
       describe "when findOptions.wholeWord is true", ->
         beforeEach ->
-          findOptions.set(wholeWord: true)
+          findOptions.set(wholeWord: true, caseSensitive:true)
 
         it "find and selects all occurrences of the word under the cursor", ->
           editor.setText """
@@ -310,7 +402,7 @@ describe "SelectNext", ->
 
     describe "when a word is selected", ->
       it "find and selects all occurrences", ->
-        findOptions.set(wholeWord: true)
+        findOptions.set(wholeWord: true, caseSensitive:true)
 
         editor.setText """
           for
@@ -411,7 +503,7 @@ describe "SelectNext", ->
 
     describe "when three words are selected", ->
       beforeEach ->
-        findOptions.set(wholeWord: true)
+        findOptions.set(wholeWord: true, caseSensitive:true)
 
       it "unselects words in order", ->
 
@@ -441,7 +533,7 @@ describe "SelectNext", ->
 
     describe "when starting at the bottom word", ->
       beforeEach ->
-        findOptions.set(wholeWord: true)
+        findOptions.set(wholeWord: true, caseSensitive:true)
 
       it "unselects words in order", ->
         editor.setText """
@@ -486,7 +578,7 @@ describe "SelectNext", ->
 
   describe "find-and-replace:select-skip", ->
     beforeEach ->
-      findOptions.set(wholeWord: true)
+      findOptions.set(wholeWord: true, caseSensitive:true)
 
     describe "when there is no selection", ->
       it "does nothing", ->


### PR DESCRIPTION
Address https://github.com/atom/atom/issues/9003

This was a fun one liner... until it was time to write some specs - there's tons of options permutations !

Ultimately the various cases will use one of 2 regex with 2 flag options for each, so that is 4 tests.
( Note that 2 of those 4 cases are the normal/current behavior so there would be no harm removing them. )

Case sensitive was the default everywhere before this PR, so I explicitly set it to true on other tests to keep things as they where.
