### PR TITLE
Fix disabled replace buttons and their tooltips

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -486,6 +486,6 @@ class FindView extends View
       @replaceNextButton[0].classList.add('disabled')
 
       @replaceTooltipSubscriptions.add atom.tooltips.add @replaceNextButton,
-        title: "Search to enable replacement"
+        title: "Replace Next [when there are results]"
       @replaceTooltipSubscriptions.add atom.tooltips.add @replaceAllButton,
-        title: "Search to enable replacement"
+        title: "Replace All [when there are results]"

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -473,5 +473,9 @@ class FindView extends View
 
   updateReplaceEnablement: ->
     canReplace = @markers?.length > 0
-    @replaceAllButton[0].disabled = not canReplace
-    @replaceNextButton[0].disabled = not canReplace
+    if canReplace
+      @replaceAllButton[0].classList.remove('disabled')
+      @replaceNextButton[0].classList.remove('disabled')
+    else
+      @replaceAllButton[0].classList.add('disabled')
+      @replaceNextButton[0].classList.add('disabled')

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -137,15 +137,6 @@ class FindView extends View
       keyBindingCommand: 'find-and-replace:find-next',
       keyBindingTarget: @findEditor.element
 
-    subs.add atom.tooltips.add @replaceNextButton,
-      title: "Replace Next",
-      keyBindingCommand: 'find-and-replace:replace-next',
-      keyBindingTarget: @replaceEditor.element
-    subs.add atom.tooltips.add @replaceAllButton,
-      title: "Replace All",
-      keyBindingCommand: 'find-and-replace:replace-all',
-      keyBindingTarget: @replaceEditor.element
-
   didHide: ->
     @hideAllTooltips()
     workspaceElement = atom.views.getView(atom.workspace)
@@ -473,9 +464,28 @@ class FindView extends View
 
   updateReplaceEnablement: ->
     canReplace = @markers?.length > 0
+    return if canReplace and not @replaceAllButton[0].classList.contains('disabled')
+
+    @replaceTooltipSubscriptions?.dispose()
+    @replaceTooltipSubscriptions = new CompositeDisposable
+
     if canReplace
       @replaceAllButton[0].classList.remove('disabled')
       @replaceNextButton[0].classList.remove('disabled')
+
+      @replaceTooltipSubscriptions.add atom.tooltips.add @replaceNextButton,
+        title: "Replace Next"
+        keyBindingCommand: 'find-and-replace:replace-next'
+        keyBindingTarget: @replaceEditor.element
+      @replaceTooltipSubscriptions.add atom.tooltips.add @replaceAllButton,
+        title: "Replace All"
+        keyBindingCommand: 'find-and-replace:replace-all'
+        keyBindingTarget: @replaceEditor.element
     else
       @replaceAllButton[0].classList.add('disabled')
       @replaceNextButton[0].classList.add('disabled')
+
+      @replaceTooltipSubscriptions.add atom.tooltips.add @replaceNextButton,
+        title: "Search to enable replacement"
+      @replaceTooltipSubscriptions.add atom.tooltips.add @replaceAllButton,
+        title: "Search to enable replacement"

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -335,7 +335,7 @@ class ProjectFindView extends View
     else
       @replaceAllButton[0].classList.add('disabled')
       @replaceTooltipSubscriptions.add atom.tooltips.add @replaceAllButton,
-        title: "Search to enable replacement"
+        title: "Replace All [run a search to enable]"
 
   setSelectionAsFindPattern: =>
     editor = atom.workspace.getActivePaneItem()

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -65,7 +65,7 @@ class ProjectFindView extends View
           @subview 'replaceEditor', new TextEditorView(editor: replaceEditor)
         @div class: 'input-block-item', =>
           @div class: 'btn-group btn-group-replace-all', =>
-            @button outlet: 'replaceAllButton', class: 'btn', disabled: 'disabled', 'Replace All'
+            @button outlet: 'replaceAllButton', class: 'btn disabled', 'Replace All'
 
       @section class: 'input-block paths-container', =>
         @div class: 'input-block-item editor-container', =>
@@ -325,7 +325,10 @@ class ProjectFindView extends View
 
   updateReplaceAllButtonEnablement: (results) ->
     canReplace = results?.matchCount and results?.findPattern is @findEditor.getText()
-    @replaceAllButton[0].disabled = not canReplace
+    if canReplace
+      @replaceAllButton[0].classList.remove('disabled')
+    else
+      @replaceAllButton[0].classList.add('disabled')
 
   setSelectionAsFindPattern: =>
     editor = atom.workspace.getActivePaneItem()

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -248,9 +248,9 @@ class ProjectFindView extends View
 
   replaceAll: ->
     return atom.beep() unless @model.matchCount
-    findPattern = @model.getFindOptions().findPattern
+    findPattern = @model.getLastFindPattern()
     currentPattern = @findEditor.getText()
-    if findPattern isnt currentPattern
+    if findPattern and findPattern isnt currentPattern
       atom.confirm
         message: "The searched pattern '#{findPattern}' was changed to '#{currentPattern}'"
         detailedMessage: "Please run the search with the new pattern '#{currentPattern}' before running a replace-all"

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -96,6 +96,7 @@ class ProjectFindView extends View
     atom.views.getView(atom.workspace).classList.add('find-visible')
     return if @tooltipSubscriptions?
 
+    @updateReplaceAllButtonEnablement()
     @tooltipSubscriptions = subs = new CompositeDisposable
     subs.add atom.tooltips.add @regexOptionButton,
       title: "Use Regex"
@@ -111,11 +112,6 @@ class ProjectFindView extends View
       title: "Whole Word",
       keyBindingCommand: 'project-find:toggle-whole-word-option',
       keyBindingTarget: @findEditor.element
-
-    subs.add atom.tooltips.add @replaceAllButton,
-      title: "Replace All",
-      keyBindingCommand: 'project-find:replace-all',
-      keyBindingTarget: @replaceEditor.element
 
     subs.add atom.tooltips.add @findAllButton,
       title: "Find All",
@@ -325,10 +321,21 @@ class ProjectFindView extends View
 
   updateReplaceAllButtonEnablement: (results) ->
     canReplace = results?.matchCount and results?.findPattern is @findEditor.getText()
+    return if canReplace and not @replaceAllButton[0].classList.contains('disabled')
+
+    @replaceTooltipSubscriptions?.dispose()
+    @replaceTooltipSubscriptions = new CompositeDisposable
+
     if canReplace
       @replaceAllButton[0].classList.remove('disabled')
+      @replaceTooltipSubscriptions.add atom.tooltips.add @replaceAllButton,
+        title: "Replace All",
+        keyBindingCommand: 'project-find:replace-all',
+        keyBindingTarget: @replaceEditor.element
     else
       @replaceAllButton[0].classList.add('disabled')
+      @replaceTooltipSubscriptions.add atom.tooltips.add @replaceAllButton,
+        title: "Search to enable replacement"
 
   setSelectionAsFindPattern: =>
     editor = atom.workspace.getActivePaneItem()

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -167,8 +167,10 @@ class ResultsModel
 
   getFindOptions: -> @findOptions
 
+  getLastFindPattern: -> @lastFindPattern
+
   getResultsSummary: ->
-    findPattern = @findOptions.findPattern
+    findPattern = @lastFindPattern ? @findOptions.findPattern
     replacePattern = @findOptions.replacePattern
     {
       findPattern

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -408,23 +408,23 @@ describe 'FindView', ->
       it "enables the replace buttons when are search results", ->
         findView.findEditor.setText 'item'
         atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
-        expect(findView.replaceAllButton[0].disabled).toBe false
-        expect(findView.replaceNextButton[0].disabled).toBe false
+        expect(findView.replaceAllButton).not.toHaveClass 'disabled'
+        expect(findView.replaceNextButton).not.toHaveClass 'disabled'
 
         findView.findEditor.setText 'nopenotinthefile'
         atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
-        expect(findView.replaceAllButton[0].disabled).toBe true
-        expect(findView.replaceNextButton[0].disabled).toBe true
+        expect(findView.replaceAllButton).toHaveClass 'disabled'
+        expect(findView.replaceNextButton).toHaveClass 'disabled'
 
         findView.findEditor.setText 'i'
         atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
-        expect(findView.replaceAllButton[0].disabled).toBe false
-        expect(findView.replaceNextButton[0].disabled).toBe false
+        expect(findView.replaceAllButton).not.toHaveClass 'disabled'
+        expect(findView.replaceNextButton).not.toHaveClass 'disabled'
 
         findView.findEditor.setText ''
         atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
-        expect(findView.replaceAllButton[0].disabled).toBe true
-        expect(findView.replaceNextButton[0].disabled).toBe true
+        expect(findView.replaceAllButton).toHaveClass 'disabled'
+        expect(findView.replaceNextButton).toHaveClass 'disabled'
 
     describe "updating the descriptionLabel", ->
       it "properly updates the info message", ->

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -411,10 +411,20 @@ describe 'FindView', ->
         expect(findView.replaceAllButton).not.toHaveClass 'disabled'
         expect(findView.replaceNextButton).not.toHaveClass 'disabled'
 
+        disposable = findView.replaceTooltipSubscriptions
+        spyOn(disposable, 'dispose')
+
+        findView.findEditor.setText 'it'
+        atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
+        expect(findView.replaceAllButton).not.toHaveClass 'disabled'
+        expect(findView.replaceNextButton).not.toHaveClass 'disabled'
+        expect(disposable.dispose).not.toHaveBeenCalled()
+
         findView.findEditor.setText 'nopenotinthefile'
         atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
         expect(findView.replaceAllButton).toHaveClass 'disabled'
         expect(findView.replaceNextButton).toHaveClass 'disabled'
+        expect(disposable.dispose).toHaveBeenCalled()
 
         findView.findEditor.setText 'i'
         atom.commands.dispatch(findView.findEditor.element, 'core:confirm')

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -12,7 +12,7 @@ ResultsPaneView = require '../lib/project/results-pane'
 waitsForPromise = (fn) -> window.waitsForPromise timeout: 30000, fn
 
 describe 'ProjectFindView', ->
-  [activationPromise, editor, editorView, projectFindView, searchPromise, resultsPane, workspaceElement, mainModule] = []
+  [activationPromise, editor, editorView, projectFindView, searchPromise, resultsPane, workspaceElement, mainModule, stoppedChangingDelay] = []
 
   getAtomPanel = ->
     workspaceElement.querySelector('.project-find').parentNode
@@ -32,6 +32,7 @@ describe 'ProjectFindView', ->
       mainModule = options.mainModule
       mainModule.createViews()
       {projectFindView} = mainModule
+      stoppedChangingDelay = projectFindView.findEditor.getModel().getBuffer().stoppedChangingDelay
       spy = spyOn(projectFindView, 'search').andCallFake ->
         searchPromise = spy.originalValue.apply(projectFindView, arguments)
         resultsPane = $(workspaceElement).find('.preview-pane').view()
@@ -1069,38 +1070,54 @@ describe 'ProjectFindView', ->
       it "is disabled initially", ->
         expect(projectFindView.replaceAllButton).toHaveClass 'disabled'
 
-      it "is enabled when a search has results and disabled when there are no results", ->
+      it "is disabled when a search returns no results", ->
         projectFindView.findEditor.setText('items')
         atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
-
 
         waitsForPromise ->
           searchPromise
 
         runs ->
-          disposable = projectFindView.replaceTooltipSubscriptions
-          spyOn(disposable, 'dispose')
-
           expect(projectFindView.replaceAllButton).not.toHaveClass 'disabled'
 
           projectFindView.findEditor.setText('nopenotinthefile')
           atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
 
-          projectFindView.findEditor.setText('itemss')
-          expect(projectFindView.replaceAllButton).toHaveClass 'disabled'
-          expect(disposable.dispose).toHaveBeenCalled()
-
-          disposable = projectFindView.replaceTooltipSubscriptions
-          spyOn(disposable, 'dispose')
-          projectFindView.findEditor.setText('items')
-          expect(projectFindView.replaceAllButton).not.toHaveClass 'disabled'
-
         waitsForPromise ->
           searchPromise
 
         runs ->
           expect(projectFindView.replaceAllButton).toHaveClass 'disabled'
+
+      it "is enabled when a search has results and disabled when there are no results", ->
+        projectFindView.findEditor.setText('items')
+        atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
+
+        waitsForPromise ->
+          searchPromise
+
+        runs ->
+          disposable = projectFindView.replaceTooltipSubscriptions
+          spyOn(disposable, 'dispose')
+
+          expect(projectFindView.replaceAllButton).not.toHaveClass 'disabled'
+
+          # The replace all button should still be disabled as the text has been changed and a new search has not been run
+          projectFindView.findEditor.setText('itemss')
+          advanceClock(stoppedChangingDelay)
+          expect(projectFindView.replaceAllButton).toHaveClass 'disabled'
           expect(disposable.dispose).toHaveBeenCalled()
+
+          # The button should still be disabled because the search and search pattern are out of sync
+          projectFindView.replaceEditor.setText('omgomg')
+          advanceClock(stoppedChangingDelay)
+          expect(projectFindView.replaceAllButton).toHaveClass 'disabled'
+
+          disposable = projectFindView.replaceTooltipSubscriptions
+          spyOn(disposable, 'dispose')
+          projectFindView.findEditor.setText('items')
+          advanceClock(stoppedChangingDelay)
+          expect(projectFindView.replaceAllButton).not.toHaveClass 'disabled'
 
           projectFindView.findEditor.setText('')
           atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
@@ -1219,11 +1236,14 @@ describe 'ProjectFindView', ->
           projectFindView.findEditor.setText('sort')
           projectFindView.replaceEditor.setText('ok')
 
-          atom.commands.dispatch(projectFindView[0], 'project-find:replace-all')
+          advanceClock(stoppedChangingDelay)
+          runs ->
+            atom.commands.dispatch(projectFindView[0], 'project-find:replace-all')
 
-          expect(atom.confirm).toHaveBeenCalled()
-          expect(replacePromise).toBeUndefined()
-          expect(atom.workspace.scan).not.toHaveBeenCalled()
+            expect(replacePromise).toBeUndefined()
+            expect(atom.workspace.scan).not.toHaveBeenCalled()
+            expect(atom.confirm).toHaveBeenCalled()
+            expect(atom.confirm.mostRecentCall.args[0].message).toContain 'was changed to'
 
         it "replaces all the matches and updates the results view", ->
           spyOn(atom, 'confirm').andReturn 0

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -1065,6 +1065,7 @@ describe 'ProjectFindView', ->
             expect(fileContent).toBe("\\t\nb\n\\t")
 
     describe "replace all button enablement", ->
+      disposable = null
       it "is disabled initially", ->
         expect(projectFindView.replaceAllButton).toHaveClass 'disabled'
 
@@ -1072,10 +1073,14 @@ describe 'ProjectFindView', ->
         projectFindView.findEditor.setText('items')
         atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
 
+
         waitsForPromise ->
           searchPromise
 
         runs ->
+          disposable = projectFindView.replaceTooltipSubscriptions
+          spyOn(disposable, 'dispose')
+
           expect(projectFindView.replaceAllButton).not.toHaveClass 'disabled'
 
           projectFindView.findEditor.setText('nopenotinthefile')
@@ -1083,7 +1088,10 @@ describe 'ProjectFindView', ->
 
           projectFindView.findEditor.setText('itemss')
           expect(projectFindView.replaceAllButton).toHaveClass 'disabled'
+          expect(disposable.dispose).toHaveBeenCalled()
 
+          disposable = projectFindView.replaceTooltipSubscriptions
+          spyOn(disposable, 'dispose')
           projectFindView.findEditor.setText('items')
           expect(projectFindView.replaceAllButton).not.toHaveClass 'disabled'
 
@@ -1092,6 +1100,7 @@ describe 'ProjectFindView', ->
 
         runs ->
           expect(projectFindView.replaceAllButton).toHaveClass 'disabled'
+          expect(disposable.dispose).toHaveBeenCalled()
 
           projectFindView.findEditor.setText('')
           atom.commands.dispatch(projectFindView[0], 'project-find:confirm')

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -1066,7 +1066,7 @@ describe 'ProjectFindView', ->
 
     describe "replace all button enablement", ->
       it "is disabled initially", ->
-        expect(projectFindView.replaceAllButton[0].disabled).toBe true
+        expect(projectFindView.replaceAllButton).toHaveClass 'disabled'
 
       it "is enabled when a search has results and disabled when there are no results", ->
         projectFindView.findEditor.setText('items')
@@ -1076,27 +1076,27 @@ describe 'ProjectFindView', ->
           searchPromise
 
         runs ->
-          expect(projectFindView.replaceAllButton[0].disabled).toBe false
+          expect(projectFindView.replaceAllButton).not.toHaveClass 'disabled'
 
           projectFindView.findEditor.setText('nopenotinthefile')
           atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
 
           projectFindView.findEditor.setText('itemss')
-          expect(projectFindView.replaceAllButton[0].disabled).toBe true
+          expect(projectFindView.replaceAllButton).toHaveClass 'disabled'
 
           projectFindView.findEditor.setText('items')
-          expect(projectFindView.replaceAllButton[0].disabled).toBe false
+          expect(projectFindView.replaceAllButton).not.toHaveClass 'disabled'
 
         waitsForPromise ->
           searchPromise
 
         runs ->
-          expect(projectFindView.replaceAllButton[0].disabled).toBe true
+          expect(projectFindView.replaceAllButton).toHaveClass 'disabled'
 
           projectFindView.findEditor.setText('')
           atom.commands.dispatch(projectFindView[0], 'project-find:confirm')
 
-          expect(projectFindView.replaceAllButton[0].disabled).toBe true
+          expect(projectFindView.replaceAllButton).toHaveClass 'disabled'
 
     describe "when the replace button is pressed", ->
       beforeEach ->


### PR DESCRIPTION
Basically, this adds a tooltip when the replace buttons are disabled. 

Previously, we were using the `disabled` attribute / prop on the buttons. This doesnt play well with the tooltips, which led to #501. This PR changes the buttons to use a `disabled` CSS class, which looks disabled, but gives us control. There are already guards in place to not allow replacing when no results resulting in a 'beep' (OS X bonk), so clicking a 'disabled' button will just 'beep'.

cc @atom/feedback if you have phrasing ideas on the disabled tooltip, that would be nice.

Fixes #530 
Fixes #501 
Fixes #504 
Fixes #537 