### PR TITLE
Add find in parent directory functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Find and replace in the current buffer or across the entire project in Atom.
 ## Find in project (cmd-shift-f)
 
 ![screen shot 2013-11-26 at 12 26 02 pm](https://f.cloud.github.com/assets/69169/1625945/b216d7b8-56d9-11e3-8b14-6afc33467be9.png)
+
+## Provided Service
+
+If you need access the marker layer containing result markers for a given editor, use the `find-and-replace@0.0.1` service. The service exposes one method, `resultsMarkerLayerForTextEditor`, which takes a `TextEditor` and returns a `TextEditorMarkerLayer` that you can interact with. Keep in mind that any work you do in synchronous event handlers on this layer will impact the performance of find and replace.

--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -4,7 +4,7 @@
   'cmd-alt-f': 'find-and-replace:show-replace'
 
 'atom-text-editor':
-  'alt-a': 'project-find:show-in-parent-directory'
+  'alt-a': 'project-find:show-in-current-directory'
 
 '.platform-win32, .platform-linux':
   'ctrl-F': 'project-find:show'

--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -3,6 +3,9 @@
   'cmd-f': 'find-and-replace:show'
   'cmd-alt-f': 'find-and-replace:show-replace'
 
+'atom-text-editor':
+  'alt-a': 'project-find:show-in-parent-directory'
+
 '.platform-win32, .platform-linux':
   'ctrl-F': 'project-find:show'
   'ctrl-f': 'find-and-replace:show'

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -79,6 +79,13 @@ module.exports =
       @projectFindPanel.show()
       @projectFindView.findInCurrentlySelectedDirectory(target)
 
+    @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:show-in-parent-directory', ({target}) =>
+      @createViews()
+      @findPanel.hide()
+      @projectFindPanel.show()
+      @projectFindView.focusFindElement()
+      @projectFindView.findInParentDirectory(target)
+
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:use-selection-as-find-pattern', =>
       return if @projectFindPanel?.isVisible() or @findPanel?.isVisible()
 

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -77,14 +77,8 @@ module.exports =
       @createViews()
       @findPanel.hide()
       @projectFindPanel.show()
-      @projectFindView.findInCurrentlySelectedDirectory(target)
-
-    @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:show-in-parent-directory', ({target}) =>
-      @createViews()
-      @findPanel.hide()
-      @projectFindPanel.show()
       @projectFindView.focusFindElement()
-      @projectFindView.findInParentDirectory(target)
+      @projectFindView.findInCurrentlySelectedDirectory(target)
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:use-selection-as-find-pattern', =>
       return if @projectFindPanel?.isVisible() or @findPanel?.isVisible()

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -297,6 +297,17 @@ class ProjectFindView extends View
       @findEditor.focus()
       @findEditor.getModel().selectAll()
 
+  findInParentDirectory: () ->
+    if textEditor = atom.workspace.getActiveTextEditor()
+      filePath = textEditor.getPath()
+      absPath = path.dirname(filePath)
+      [rootPath, relPath] = atom.project.relativizePath(absPath)
+      if rootPath? and atom.project.getDirectories().length > 1
+        relPath = path.join(path.basename(rootPath), relPath)
+        @pathsEditor.setText(relPath)
+        @findEditor.focus()
+        @findEditor.getModel().selectAll()
+
   showResultPane: ->
     options = {searchAllPanes: true}
     options.split = 'right' if atom.config.get('find-and-replace.openProjectFindResultsInRightPane')

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -282,6 +282,9 @@ class ProjectFindView extends View
         elementPath = element.dataset.path
         break if elementPath
         element = element.parentElement
+      # Use the active editor path if all elements don't have a path
+      unless elementPath
+        elementPath = atom.workspace.getActiveTextEditor().getPath()
 
     if fs.isFileSync(elementPath)
       require('path').dirname(elementPath)
@@ -296,17 +299,6 @@ class ProjectFindView extends View
       @pathsEditor.setText(relPath)
       @findEditor.focus()
       @findEditor.getModel().selectAll()
-
-  findInParentDirectory: () ->
-    if textEditor = atom.workspace.getActiveTextEditor()
-      filePath = textEditor.getPath()
-      absPath = path.dirname(filePath)
-      [rootPath, relPath] = atom.project.relativizePath(absPath)
-      if rootPath? and atom.project.getDirectories().length > 1
-        relPath = path.join(path.basename(rootPath), relPath)
-        @pathsEditor.setText(relPath)
-        @findEditor.focus()
-        @findEditor.getModel().selectAll()
 
   showResultPane: ->
     options = {searchAllPanes: true}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "find-and-replace",
   "main": "./lib/find",
   "description": "Find and replace within buffers and across the project.",
-  "version": "0.194.0",
+  "version": "0.195.0",
   "license": "MIT",
   "activationCommands": {
     "atom-workspace": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "find-and-replace",
   "main": "./lib/find",
   "description": "Find and replace within buffers and across the project.",
-  "version": "0.193.0",
+  "version": "0.194.0",
   "license": "MIT",
   "activationCommands": {
     "atom-workspace": [

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "atom-workspace": [
       "project-find:show",
       "project-find:toggle",
+      "project-find:show-in-parent-directory",
       "project-find:show-in-current-directory",
       "find-and-replace:show",
       "find-and-replace:toggle",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "atom-workspace": [
       "project-find:show",
       "project-find:toggle",
-      "project-find:show-in-parent-directory",
       "project-find:show-in-current-directory",
       "find-and-replace:show",
       "find-and-replace:toggle",


### PR DESCRIPTION
This request is to add finding the selected word in the parent directory functionality and mapping to 'alt-a' key.
Finding in parent directory is frequently used when reading souce code.
And using hot key is more convenient than using the 'Search In Directory' context menu command. 