### PR TITLE
Catch scanInBufferRange errors

### DIFF
--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -116,8 +116,9 @@ class BufferSearch
         try
           @editor.scanInBufferRange regex, Range(start, end), ({range}) =>
             newMarkers.push(@createMarker(range)) unless range.isEmpty()
-        catch e
-          @emitter.emit 'did-error', e
+        catch error
+          error.message = "Search string is too large"
+          @emitter.emit 'did-error', error
           return false
       else
         return false

--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -99,8 +99,12 @@ class BufferSearch
         end = Point.min(end, selectedRange.end)
 
       if regex = @getFindPatternRegex()
-        @editor.scanInBufferRange regex, Range(start, end), ({range}) =>
-          newMarkers.push(@createMarker(range)) unless range.isEmpty()
+        try
+          @editor.scanInBufferRange regex, Range(start, end), ({range}) =>
+            newMarkers.push(@createMarker(range)) unless range.isEmpty()
+        catch e
+          @emitter.emit 'did-error', e
+          null
       else
         return false
     newMarkers

--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -115,7 +115,7 @@ class BufferSearch
       if regex = @getFindPatternRegex()
         try
           @editor.scanInBufferRange regex, Range(start, end), ({range}) =>
-            newMarkers.push(@createMarker(range)) unless range.isEmpty()
+            newMarkers.push(@createMarker(range))
         catch error
           error.message = "Search string is too large" if /RegExp too big$/.test(error.message)
           @emitter.emit 'did-error', error

--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -117,7 +117,7 @@ class BufferSearch
           @editor.scanInBufferRange regex, Range(start, end), ({range}) =>
             newMarkers.push(@createMarker(range)) unless range.isEmpty()
         catch error
-          error.message = "Search string is too large"
+          error.message = "Search string is too large" if /RegExp too big$/.test(error.message)
           @emitter.emit 'did-error', error
           return false
       else

--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -118,7 +118,7 @@ class BufferSearch
             newMarkers.push(@createMarker(range)) unless range.isEmpty()
         catch e
           @emitter.emit 'did-error', e
-          null
+          return false
       else
         return false
     newMarkers

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -484,7 +484,7 @@ describe 'FindView', ->
             expect(findView.descriptionLabel).not.toHaveClass 'text-error'
             expect(findView.descriptionLabel.text()).toContain "6 results"
 
-        fdescribe "when the search string is too large", ->
+        describe "when the search string is too large", ->
           beforeEach ->
             largeText = "abcdefghijklmnopqrstuvwxyz"
             largeText += "abcdefghijklmnopqrstuvwxyz" for num in [0...2000]

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -484,10 +484,9 @@ describe 'FindView', ->
             expect(findView.descriptionLabel).not.toHaveClass 'text-error'
             expect(findView.descriptionLabel.text()).toContain "6 results"
 
-        describe "when the search string is too large", ->
+        fdescribe "when the search string is too large", ->
           beforeEach ->
-            largeText = "abcdefghijklmnopqrstuvwxyz"
-            largeText += "abcdefghijklmnopqrstuvwxyz" for num in [0...2000]
+            largeText = "x".repeat(50000)
             findView.findEditor.setText largeText
             atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
 

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -484,7 +484,7 @@ describe 'FindView', ->
             expect(findView.descriptionLabel).not.toHaveClass 'text-error'
             expect(findView.descriptionLabel.text()).toContain "6 results"
 
-        fdescribe "when the search string is too large", ->
+        describe "when the search string is too large", ->
           beforeEach ->
             largeText = "x".repeat(50000)
             findView.findEditor.setText largeText

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -460,31 +460,51 @@ describe 'FindView', ->
         atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
         expect(findView.descriptionLabel.text()).toContain "Find in Current Buffer"
 
-      describe "when there is a find-error", ->
-        beforeEach ->
-          editor.setCursorBufferPosition([2, 0])
-          atom.commands.dispatch(findView.findEditor.element, 'find-and-replace:toggle-regex-option')
+      describe "when there is an error", ->
+        describe "when the regex search string is invalid", ->
+          beforeEach ->
+            atom.commands.dispatch(findView.findEditor.element, 'find-and-replace:toggle-regex-option')
+            findView.findEditor.setText 'i[t'
+            atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
 
-        it "displays the error", ->
-          findView.findEditor.setText 'i[t'
-          atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
-          expect(findView.descriptionLabel).toHaveClass 'text-error'
-          expect(findView.descriptionLabel.text()).toContain 'Invalid regular expression'
+          it "displays the error", ->
+            expect(findView.descriptionLabel).toHaveClass 'text-error'
+            expect(findView.descriptionLabel.text()).toContain 'Invalid regular expression'
 
-        it "will be reset when there is no longer an error", ->
-          findView.findEditor.setText 'i[t'
-          atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
-          expect(findView.descriptionLabel).toHaveClass 'text-error'
+          it "will be reset when there is no longer an error", ->
+            expect(findView.descriptionLabel).toHaveClass 'text-error'
 
-          findView.findEditor.setText ''
-          atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
-          expect(findView.descriptionLabel).not.toHaveClass 'text-error'
-          expect(findView.descriptionLabel.text()).toContain "Find in Current Buffer"
+            findView.findEditor.setText ''
+            atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
+            expect(findView.descriptionLabel).not.toHaveClass 'text-error'
+            expect(findView.descriptionLabel.text()).toContain "Find in Current Buffer"
 
-          findView.findEditor.setText 'item'
-          atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
-          expect(findView.descriptionLabel).not.toHaveClass 'text-error'
-          expect(findView.descriptionLabel.text()).toContain "6 results"
+            findView.findEditor.setText 'item'
+            atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
+            expect(findView.descriptionLabel).not.toHaveClass 'text-error'
+            expect(findView.descriptionLabel.text()).toContain "6 results"
+
+        fdescribe "when the search string is too large", ->
+          beforeEach ->
+            largeText = "abcdefghijklmnopqrstuvwxyz"
+            largeText += "abcdefghijklmnopqrstuvwxyz" for num in [0...2000]
+            findView.findEditor.setText largeText
+            atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
+
+          it "displays the error", ->
+            expect(findView.descriptionLabel).toHaveClass 'text-error'
+            expect(findView.descriptionLabel.text()).toContain 'Search string is too large'
+
+          it "will be reset when there is no longer an error", ->
+            findView.findEditor.setText ''
+            atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
+            expect(findView.descriptionLabel).not.toHaveClass 'text-error'
+            expect(findView.descriptionLabel.text()).toContain "Find in Current Buffer"
+
+            findView.findEditor.setText 'item'
+            atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
+            expect(findView.descriptionLabel).not.toHaveClass 'text-error'
+            expect(findView.descriptionLabel.text()).toContain "6 results"
 
     it "selects the first match following the cursor", ->
       expect(findView.resultCounter.text()).toEqual('2 of 6')


### PR DESCRIPTION
This will catch `RegExp too big` errors and properly display them in the find box instead of a) displaying a uncaught exception, b) breaking tab switching, and c) (sometimes) preventing the find box from being usable.

TODO:
* [x] Figure out why the error isn't being displayed in the find box 
* [x] Nicely format the error so that it's actually readable (`RegExp too big` should suffice) - changed to "Search string is too large"
* [x] Specs

Fixes #510
Fixes #532