### PR TITLE
Fix wrong history serialized for paths

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -193,4 +193,4 @@ module.exports =
     findOptions: @findOptions.serialize()
     findHistory: @findHistory.serialize()
     replaceHistory: @replaceHistory.serialize()
-    pathsHistory: @replaceHistory.serialize()
+    pathsHistory: @pathsHistory.serialize()


### PR DESCRIPTION
Not sure if it's just a copy/paste issue but I think it should serialize the `pathsHistory` and not the `replaceHistory`.

Initially reported on discuss: https://discuss.atom.io/t/remember-search-filter/21437