### PR TITLE
Increase spec resiliency by not relying on actual numbers

### DIFF
--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -319,15 +319,17 @@ describe 'ResultsView', ->
         itemHeight = resultsView.find('.selected').outerHeight()
         pageHeight = Math.round(resultsView.innerHeight() / itemHeight) * itemHeight
         initialScrollTop = resultsView.scrollTop()
+        itemsPerPage = Math.floor(pageHeight / itemHeight)
+        originalItemIndex = Math.floor(initialScrollTop / itemHeight) + itemsPerPage
 
         atom.commands.dispatch resultsView.element, 'core:page-up'
         expect(resultsView.find("li:last")).not.toHaveClass 'selected'
-        expect(resultsView.find("li:eq(215)")).toHaveClass 'selected'
+        expect(resultsView.find("li:eq(#{originalItemIndex - itemsPerPage})")).toHaveClass 'selected'
         expect(resultsView.prop('scrollTop')).toBe initialScrollTop - pageHeight
 
         atom.commands.dispatch resultsView.element, 'core:page-up'
-        expect(resultsView.find("li:eq(215)")).not.toHaveClass 'selected'
-        expect(resultsView.find("li:eq(210)")).toHaveClass 'selected'
+        expect(resultsView.find("li:eq(#{originalItemIndex - itemsPerPage})")).not.toHaveClass 'selected'
+        expect(resultsView.find("li:eq(#{originalItemIndex - itemsPerPage * 2})")).toHaveClass 'selected'
         expect(resultsView.prop('scrollTop')).toBe initialScrollTop - pageHeight * 2
 
         _.times 60, ->

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -314,22 +314,23 @@ describe 'ResultsView', ->
 
       it "selects the first result on the next page when core:page-up is triggered", ->
         atom.commands.dispatch resultsView.element, 'core:move-to-bottom'
-        expect(resultsView.find("li:last")).toHaveClass 'selected'
 
         itemHeight = resultsView.find('.selected').outerHeight()
         pageHeight = Math.round(resultsView.innerHeight() / itemHeight) * itemHeight
         initialScrollTop = resultsView.scrollTop()
         itemsPerPage = Math.floor(pageHeight / itemHeight)
-        originalItemIndex = Math.floor(initialScrollTop / itemHeight) + itemsPerPage
+
+        initiallySelectedIndex = Math.floor(initialScrollTop / itemHeight) + itemsPerPage
+        expect(resultsView.find("li:eq(#{initiallySelectedIndex})")).toHaveClass 'selected'
 
         atom.commands.dispatch resultsView.element, 'core:page-up'
-        expect(resultsView.find("li:last")).not.toHaveClass 'selected'
-        expect(resultsView.find("li:eq(#{originalItemIndex - itemsPerPage})")).toHaveClass 'selected'
+        expect(resultsView.find("li:eq(#{initiallySelectedIndex})")).not.toHaveClass 'selected'
+        expect(resultsView.find("li:eq(#{initiallySelectedIndex - itemsPerPage})")).toHaveClass 'selected'
         expect(resultsView.prop('scrollTop')).toBe initialScrollTop - pageHeight
 
         atom.commands.dispatch resultsView.element, 'core:page-up'
-        expect(resultsView.find("li:eq(#{originalItemIndex - itemsPerPage})")).not.toHaveClass 'selected'
-        expect(resultsView.find("li:eq(#{originalItemIndex - itemsPerPage * 2})")).toHaveClass 'selected'
+        expect(resultsView.find("li:eq(#{initiallySelectedIndex - itemsPerPage})")).not.toHaveClass 'selected'
+        expect(resultsView.find("li:eq(#{initiallySelectedIndex - itemsPerPage * 2})")).toHaveClass 'selected'
         expect(resultsView.prop('scrollTop')).toBe initialScrollTop - pageHeight * 2
 
         _.times 60, ->


### PR DESCRIPTION
The spec changed in this PR seems to be the only failure (at least locally) for https://github.com/atom/atom/pull/8968. I couldn't backtrack the reason why this started to fail, but there seems to be a super slender change in the height of displayed items.

Manually logging out the `.selected` items revealed that, e.g. instead of `215`, item `216` gets selected: this might be related to the test runner stylesheets setup, but it seems quite negligible given that we haven't changed any line of production code in this package. As a result, I changed the spec so that it doesn't rely on _static_ numbers anymore: other than telling a better story, I think this increases its resiliency as well.

I'd :heart: to have some feedback on this before merging it.

/cc: @nathansobo @maxbrunsfeld