### PR TITLE
Show wrap around icon when searching (close #401)

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -363,7 +363,7 @@ class FindView extends View
       return index if markerStartPosition.isEqual(start) and indexIncluded
       return index if markerStartPosition.isGreaterThan(start)
 
-    @showWrapIcon('icon-arrow-up')
+    @showWrapIcon('icon-move-up')
     0
 
   selectFirstMarkerBeforeCursor: =>
@@ -382,7 +382,7 @@ class FindView extends View
       markerEndPosition = marker.bufferMarker.getEndPosition()
       return index if markerEndPosition.isLessThan(start)
 
-    @showWrapIcon('icon-arrow-down')
+    @showWrapIcon('icon-move-down')
     @markers.length - 1
 
   selectAllMarkers: =>

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -24,6 +24,8 @@ class FindView extends View
       placeholderText: 'Replace in current buffer'
 
     @div tabIndex: -1, class: 'find-and-replace', =>
+      @div outlet: 'wrapIcon', class: 'wrap-icon'
+
       @header class: 'header', =>
         @span outlet: 'descriptionLabel', class: 'header-item description', 'Find in Current Buffer'
         @span class: 'header-item options-label pull-right', =>
@@ -360,6 +362,8 @@ class FindView extends View
       markerStartPosition = marker.bufferMarker.getStartPosition()
       return index if markerStartPosition.isEqual(start) and indexIncluded
       return index if markerStartPosition.isGreaterThan(start)
+
+    @showWrapIcon('icon-arrow-up')
     0
 
   selectFirstMarkerBeforeCursor: =>
@@ -378,6 +382,7 @@ class FindView extends View
       markerEndPosition = marker.bufferMarker.getEndPosition()
       return index if markerEndPosition.isLessThan(start)
 
+    @showWrapIcon('icon-arrow-down')
     @markers.length - 1
 
   selectAllMarkers: =>
@@ -490,3 +495,8 @@ class FindView extends View
         title: "Replace Next [when there are results]"
       @replaceTooltipSubscriptions.add atom.tooltips.add @replaceAllButton,
         title: "Replace All [when there are results]"
+
+  showWrapIcon: (icon) ->
+    @wrapIcon.attr('class', "wrap-icon #{icon}").fadeIn()
+    clearTimeout(@wrapTimeout)
+    @wrapTimeout = setTimeout (=> @wrapIcon.fadeOut()), 1000

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -574,6 +574,20 @@ describe 'FindView', ->
       editor.setSelectedBufferRange([[2, 34], [2, 39]])
       expect(findView.resultCounter.text()).toEqual('3 of 6')
 
+    it "shows an icon when search wraps around", ->
+      atom.commands.dispatch editorView, 'find-and-replace:find-previous'
+      expect(findView.wrapIcon).not.toBeVisible()
+
+      atom.commands.dispatch editorView, 'find-and-replace:find-previous'
+      expect(findView.resultCounter.text()).toEqual('6 of 6')
+      expect(findView.wrapIcon).toBeVisible()
+      expect(findView.wrapIcon).toHaveClass 'icon-arrow-down'
+
+      atom.commands.dispatch editorView, 'find-and-replace:find-next'
+      expect(findView.resultCounter.text()).toEqual('1 of 6')
+      expect(findView.wrapIcon).toBeVisible()
+      expect(findView.wrapIcon).toHaveClass 'icon-arrow-up'
+
     describe "when find-and-replace:use-selection-as-find-pattern is triggered", ->
       it "places the selected text into the find editor", ->
         editor.setSelectedBufferRange([[1, 6], [1, 10]])

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -581,12 +581,12 @@ describe 'FindView', ->
       atom.commands.dispatch editorView, 'find-and-replace:find-previous'
       expect(findView.resultCounter.text()).toEqual('6 of 6')
       expect(findView.wrapIcon).toBeVisible()
-      expect(findView.wrapIcon).toHaveClass 'icon-arrow-down'
+      expect(findView.wrapIcon).toHaveClass 'icon-move-down'
 
       atom.commands.dispatch editorView, 'find-and-replace:find-next'
       expect(findView.resultCounter.text()).toEqual('1 of 6')
       expect(findView.wrapIcon).toBeVisible()
-      expect(findView.wrapIcon).toHaveClass 'icon-arrow-up'
+      expect(findView.wrapIcon).toHaveClass 'icon-move-up'
 
     describe "when find-and-replace:use-selection-as-find-pattern is triggered", ->
       it "places the selected text into the find editor", ->

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -166,6 +166,25 @@ atom-workspace.find-visible {
       margin-right: @component-padding;
     }
   }
+
+  .wrap-icon {
+    @wrap-size: 96px;
+
+    display: none;
+    position: absolute;
+    left: 50%;
+    top: @wrap-size * -1.5;
+    margin-left: @wrap-size * -0.5;
+    background: rgba(136,136,136, 0.2);
+    border-radius: 10px;
+    text-align: center;
+    pointer-events: none;
+    &:before {
+      font-size: @wrap-size;
+      height: @wrap-size;
+      width: @wrap-size;
+    }
+  }
 }
 
 // Project find and replace

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -168,7 +168,7 @@ atom-workspace.find-visible {
   }
 
   .wrap-icon {
-    @wrap-size: 96px;
+    @wrap-size: @font-size * 10;
 
     display: none;
     position: absolute;
@@ -176,11 +176,13 @@ atom-workspace.find-visible {
     top: @wrap-size * -1.5;
     margin-left: @wrap-size * -0.5;
     background: rgba(136,136,136, 0.2);
-    border-radius: 10px;
+    border-radius: @component-border-radius * 5;
     text-align: center;
     pointer-events: none;
     &:before {
-      font-size: @wrap-size;
+      // Octicons look best in sizes that are multiples of 16px
+      font-size: @wrap-size - mod(@wrap-size, 16px) - 16px;
+      line-height: @wrap-size;
       height: @wrap-size;
       width: @wrap-size;
     }


### PR DESCRIPTION
Flashes an arrow indicator for one second when find wraps around. This helps the user quickly see if he/she has reached the bottom or top. Also found in XCode, Eclipse, Mac Terminal, BBEdit, etc.

![atom-wrap-around](https://cloud.githubusercontent.com/assets/659763/10710908/65f5da5c-7a6b-11e5-984d-1fa3a40b48d3.gif)