### PR TITLE
Utilize layer decorations for improved performance

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -357,7 +357,7 @@ class FindView extends View
     start = end if selection.isReversed()
 
     for marker, index in @markers
-      markerStartPosition = marker.bufferMarker.getStartPosition()
+      markerStartPosition = marker.getStartPosition()
       return index if markerStartPosition.isEqual(start) and indexIncluded
       return index if markerStartPosition.isGreaterThan(start)
     0
@@ -375,25 +375,25 @@ class FindView extends View
     start = end if selection.isReversed()
 
     for marker, index in @markers by -1
-      markerEndPosition = marker.bufferMarker.getEndPosition()
+      markerEndPosition = marker.getEndPosition()
       return index if markerEndPosition.isLessThan(start)
 
     @markers.length - 1
 
   selectAllMarkers: =>
     return unless @markers?.length > 0
-    ranges = (marker.getBufferRange() for marker in @markers)
+    ranges = (marker.getRange() for marker in @markers)
     scrollMarker = @markers[@firstMarkerIndexAfterCursor()]
     editor = @model.getEditor()
     editor.setSelectedBufferRanges(ranges, flash: true)
-    editor.scrollToBufferPosition(scrollMarker.getStartBufferPosition(), center: true)
+    editor.scrollToBufferPosition(scrollMarker.getStartPosition(), center: true)
 
   selectMarkerAtIndex: (markerIndex) ->
     return unless @markers?.length > 0
 
     if marker = @markers[markerIndex]
       editor = @model.getEditor()
-      editor.setSelectedBufferRange(marker.getBufferRange(), flash: true)
+      editor.setSelectedBufferRange(marker.getRange(), flash: true)
       editor.scrollToCursorPosition(center: true)
 
   setSelectionAsFindPattern: =>

--- a/spec/buffer-search-spec.coffee
+++ b/spec/buffer-search-spec.coffee
@@ -44,10 +44,11 @@ describe "BufferSearch", ->
 
   getHighlightedRanges = ->
     ranges = []
-    for decoration in editor.getDecorations(type: 'highlight')
-      marker = decoration.getMarker()
-      if marker.isValid() and decoration.getProperties()['class'] in ['find-result', 'current-result']
-        ranges.push(marker.getBufferRange())
+    state = editor.decorationsStateForScreenRowRange(0, editor.getLineCount())
+    for id, {properties, screenRange} of state
+      if properties.class in ['find-result', 'current-result']
+        ranges.push(screenRange)
+
     ranges
       .sort (a, b) -> a.compare(b)
       .map (range) -> range.serialize()
@@ -56,7 +57,7 @@ describe "BufferSearch", ->
     expect(markersListener.callCount).toBe 1
     emittedMarkerRanges = markersListener
       .mostRecentCall.args[0]
-      .map (marker) -> marker.getBufferRange().serialize()
+      .map (marker) -> marker.getRange().serialize()
     expect(emittedMarkerRanges).toEqual(getHighlightedRanges())
     markersListener.reset()
 
@@ -388,8 +389,9 @@ describe "BufferSearch", ->
       markers = markersListener.mostRecentCall.args[0]
       markersListener.reset()
 
-      editor.setSelectedBufferRange(markers[1].getBufferRange())
-      expect(currentResultListener).toHaveBeenCalledWith(markers[1])
+      editor.setSelectedBufferRange(markers[1].getRange())
+      expect(model.currentResultMarker.getRange()).toEqual markers[1].getRange()
+      expect(currentResultListener).toHaveBeenCalled()
       currentResultListener.reset()
 
       model.replace([markers[1]], "new-text")
@@ -415,8 +417,9 @@ describe "BufferSearch", ->
         [[7, 8], [7, 11]]
       ]
 
-      editor.setSelectedBufferRange(markers[2].getBufferRange())
-      expect(currentResultListener).toHaveBeenCalledWith(markers[2])
+      editor.setSelectedBufferRange(markers[2].getRange())
+      expect(model.currentResultMarker.getRange()).toEqual markers[2].getRange()
+      expect(currentResultListener).toHaveBeenCalled()
       currentResultListener.reset()
 
       advanceClock(editor.buffer.stoppedChangingDelay)
@@ -434,5 +437,5 @@ describe "BufferSearch", ->
       ]
 
       expect(currentResultListener).toHaveBeenCalled()
-      expect(currentResultListener.mostRecentCall.args[0].getBufferRange()).toEqual markers[2].getBufferRange()
+      expect(currentResultListener.mostRecentCall.args[0].getRange()).toEqual markers[2].getRange()
       expect(currentResultListener.mostRecentCall.args[0].isDestroyed()).toBe false

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -849,12 +849,13 @@ describe 'ProjectFindView', ->
 
     describe "buffer search sharing of the find options", ->
       getResultDecorations = (className) ->
-        markerIdForDecorations = editor.decorationsForScreenRowRange(0, editor.getLineCount())
-        resultDecorations = []
-        for markerId, decorations of markerIdForDecorations
-          for decoration in decorations
-            resultDecorations.push decoration if decoration.getProperties().class is className
-        resultDecorations
+        decorationPropertiesById = editor.decorationsStateForScreenRowRange(0, editor.getLineCount())
+        results = []
+        for markerId, decorationProperties of decorationPropertiesById
+          if decorationProperties.properties.class is className
+            results.push decorationProperties
+
+        results
 
       it "setting the find text does not interfere with the project replace state", ->
         # Not sure why I need to advance the clock before setting the text. If


### PR DESCRIPTION
This depends on https://github.com/atom/atom/pull/9219 in Atom core.

Rather than decorating each search result marker, we create a unique marker layer with which we populate search results and decorate that. The “current result” relies on the ability to override properties in the layer decoration for a single marker.