### PR TITLE
Revert "Ignore 0 length matches"

### DIFF
--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -100,7 +100,7 @@ class BufferSearch
 
       if regex = @getFindPatternRegex()
         @editor.scanInBufferRange regex, Range(start, end), ({range}) =>
-          newMarkers.push(@createMarker(range)) unless range.isEmpty()
+          newMarkers.push(@createMarker(range))
       else
         return false
     newMarkers

--- a/spec/buffer-search-spec.coffee
+++ b/spec/buffer-search-spec.coffee
@@ -81,18 +81,6 @@ describe "BufferSearch", ->
       [[0, 0], [Infinity, Infinity]]
     ]
 
-  it "ignores 0 length matches", ->
-    editor.setText('ABCD\n')
-    model.search "\\w*",
-      caseSensitive: false
-      useRegex: true
-      wholeWord: false
-
-    expect(model.markers).toHaveLength 1
-    expect(getHighlightedRanges()).toEqual [
-      [[0, 0], [0, 4]]
-    ]
-
   describe "when the buffer changes", ->
     beforeEach ->
       markersListener.reset()


### PR DESCRIPTION
This reverts commit 9082bc451acf2004696ea3db236918ba2e90e516.
Fixes https://github.com/atom/find-and-replace/issues/497
