### PR TITLE
:bug: Fix #496 - Option buttons shouldn't move away from valid match.

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -447,30 +447,27 @@ class FindView extends View
     else
       optionButton.removeClass 'selected'
 
-  anySelectionsMatchFindPattern: =>
-    editor = @model.getEditor()
-    selections = editor?.getSelections() or []
+  anyMarkersAreSelected: =>
+    selections = @model.getEditor()?.getSelections() or []
     _.any selections, (selection) =>
-      selectionMatchesFindPattern = false
-      editor.scanInBufferRange @model.getFindPatternRegex(), selection.getBufferRange(), ({range}) ->
-        selectionMatchesFindPattern = selectionMatchesFindPattern or _.isEqual(range, selection.getBufferRange())
-      selectionMatchesFindPattern
+      _.any @model.markers or [], (marker) =>
+        _.isEqual(marker.getBufferRange(), selection.getBufferRange())
 
   toggleRegexOption: =>
     @search(useRegex: not @model.getFindOptions().useRegex)
-    @selectFirstMarkerAfterCursor() unless @anySelectionsMatchFindPattern()
+    @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
 
   toggleCaseOption: =>
     @search(caseSensitive: not @model.getFindOptions().caseSensitive)
-    @selectFirstMarkerAfterCursor() unless @anySelectionsMatchFindPattern()
+    @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
 
   toggleSelectionOption: =>
     @search(inCurrentSelection: not @model.getFindOptions().inCurrentSelection)
-    @selectFirstMarkerAfterCursor() unless @anySelectionsMatchFindPattern()
+    @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
 
   toggleWholeWordOption: =>
     @search(@findEditor.getText(), wholeWord: not @model.getFindOptions().wholeWord)
-    @selectFirstMarkerAfterCursor() unless @anySelectionsMatchFindPattern()
+    @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
 
   updateReplaceEnablement: ->
     canReplace = @markers?.length > 0

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -449,11 +449,11 @@ class FindView extends View
 
   anySelectionsMatchFindPattern: =>
     editor = @model.getEditor()
-    selections = editor?.getSelections() || []
+    selections = editor?.getSelections() or []
     _.any selections, (selection) =>
       selectionMatchesFindPattern = false
-      editor.scanInBufferRange @model.getFindPatternRegex(), selection.getBufferRange(), ({range}) =>
-        selectionMatchesFindPattern = selectionMatchesFindPattern || _.isEqual(range, selection.getBufferRange())
+      editor.scanInBufferRange @model.getFindPatternRegex(), selection.getBufferRange(), ({range}) ->
+        selectionMatchesFindPattern = selectionMatchesFindPattern or _.isEqual(range, selection.getBufferRange())
       selectionMatchesFindPattern
 
   toggleRegexOption: =>

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -447,21 +447,30 @@ class FindView extends View
     else
       optionButton.removeClass 'selected'
 
+  anySelectionsMatchFindPattern: =>
+    editor = @model.getEditor()
+    selections = editor?.getSelections() || []
+    _.any selections, (selection) =>
+      selectionMatchesFindPattern = false
+      editor.scanInBufferRange @model.getFindPatternRegex(), selection.getBufferRange(), ({range}) =>
+        selectionMatchesFindPattern = selectionMatchesFindPattern || _.isEqual(range, selection.getBufferRange())
+      selectionMatchesFindPattern
+
   toggleRegexOption: =>
     @search(useRegex: not @model.getFindOptions().useRegex)
-    @selectFirstMarkerAfterCursor()
+    @selectFirstMarkerAfterCursor() unless @anySelectionsMatchFindPattern()
 
   toggleCaseOption: =>
     @search(caseSensitive: not @model.getFindOptions().caseSensitive)
-    @selectFirstMarkerAfterCursor()
+    @selectFirstMarkerAfterCursor() unless @anySelectionsMatchFindPattern()
 
   toggleSelectionOption: =>
     @search(inCurrentSelection: not @model.getFindOptions().inCurrentSelection)
-    @selectFirstMarkerAfterCursor()
+    @selectFirstMarkerAfterCursor() unless @anySelectionsMatchFindPattern()
 
   toggleWholeWordOption: =>
     @search(@findEditor.getText(), wholeWord: not @model.getFindOptions().wholeWord)
-    @selectFirstMarkerAfterCursor()
+    @selectFirstMarkerAfterCursor() unless @anySelectionsMatchFindPattern()
 
   updateReplaceEnablement: ->
     canReplace = @markers?.length > 0

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -448,10 +448,8 @@ class FindView extends View
       optionButton.removeClass 'selected'
 
   anyMarkersAreSelected: =>
-    selections = @model.getEditor()?.getSelections() or []
-    _.any selections, (selection) =>
-      _.any @model.markers or [], (marker) =>
-        _.isEqual(marker.getBufferRange(), selection.getBufferRange())
+    @model.getEditor().getSelectedBufferRanges().some (selectedRange) =>
+      @model.findMarker(selectedRange)
 
   toggleRegexOption: =>
     @search(useRegex: not @model.getFindOptions().useRegex)

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -844,6 +844,37 @@ describe 'FindView', ->
           atom.commands.dispatch(findView.findEditor.element, 'core:confirm')
           expect(findView.descriptionLabel).toHaveClass 'text-error'
 
+      describe "when there are existing selections", ->
+        describe "when any existing selections match the pattern", ->
+          it "shouldn't jump to the next match when toggled on", ->
+            findView.model.setFindOptions useRegex: false
+            findView.findEditor.setText 'items.length'
+            editor.setSelectedBufferRange [[2, 8], [2, 20]]
+            findView.regexOptionButton.click()
+            expect(editor.getSelectedBufferRange()).toEqual [[2, 8], [2, 20]]
+
+          it "shouldn't jump to the next match when toggled off", ->
+            findView.model.setFindOptions useRegex: true
+            findView.findEditor.setText 'items.length'
+            editor.setSelectedBufferRange [[2, 8], [2, 20]]
+            findView.regexOptionButton.click()
+            expect(editor.getSelectedBufferRange()).toEqual [[2, 8], [2, 20]]
+
+        describe "when no existing selections match the pattern", ->
+          it "should jump to the next match when toggled on", ->
+            findView.model.setFindOptions useRegex: false
+            findView.findEditor.setText 'pivot ?'
+            editor.setSelectedBufferRange [[6, 16], [6, 23]]
+            findView.regexOptionButton.click()
+            expect(editor.getSelectedBufferRange()).toEqual [[8, 29], [8, 34]]
+
+          it "should jump to the next match when toggled off", ->
+            findView.model.setFindOptions useRegex: true
+            findView.findEditor.setText 'pivot ?'
+            editor.setSelectedBufferRange [[8, 29], [8, 34]]
+            findView.regexOptionButton.click()
+            expect(editor.getSelectedBufferRange()).toEqual [[6, 16], [6, 23]]
+
     describe "when whole-word is toggled", ->
       it "toggles whole-word via an event and finds text matching the pattern", ->
         editor.setCursorBufferPosition([0, 0])
@@ -869,6 +900,39 @@ describe 'FindView', ->
         atom.commands.dispatch findView.findEditor.element, 'find-and-replace:toggle-whole-word-option'
         expect(editor.getSelectedBufferRange()).toEqual [[11, 20], [11, 25]]
 
+      describe "when there are existing selections", ->
+        describe "when any existing selections match the pattern", ->
+          it "shouldn't jump to the next match when toggled on", ->
+            findView.model.setFindOptions wholeWord: false
+            findView.findEditor.setText 'sort'
+            editor.setSelectedBufferRange [[1, 6], [1, 10]]
+            findView.wholeWordOptionButton.click()
+            expect(editor.getSelectedBufferRange()).toEqual [[1, 6], [1, 10]]
+
+          it "shouldn't jump to the next match when toggled off", ->
+            findView.model.setFindOptions wholeWord: true
+            findView.findEditor.setText 'sort'
+            editor.setSelectedBufferRange [[1, 6], [1, 10]]
+            findView.wholeWordOptionButton.click()
+            expect(editor.getSelectedBufferRange()).toEqual [[1, 6], [1, 10]]
+
+        describe "when no existing selections match the pattern", ->
+          it "should jump to the next match when toggled on", ->
+            findView.model.setFindOptions wholeWord: false
+            findView.findEditor.setText 'sort'
+            editor.setSelectedBufferRange [[0, 9], [0, 13]]
+            findView.wholeWordOptionButton.click()
+            expect(editor.getSelectedBufferRange()).toEqual [[1, 6], [1, 10]]
+
+          it "should jump to the next match when toggled off", ->
+            # It's impossible to create a test where `wholeWord: true` matches but `wholeWord: false` doesn't.
+            # Instead we'll create a generic selection and ensure that it jumps to the next match.
+            findView.model.setFindOptions wholeWord: true
+            findView.findEditor.setText 'sort'
+            editor.setSelectedBufferRange [[0, 0], [0, 5]]
+            findView.wholeWordOptionButton.click()
+            expect(editor.getSelectedBufferRange()).toEqual [[0, 9], [0, 13]]
+
     describe "when case sensitivity is toggled", ->
       beforeEach ->
         editor.setText "-----\nwords\nWORDs\n"
@@ -891,6 +955,39 @@ describe 'FindView', ->
         editor.setCursorBufferPosition([0, 0])
         findView.caseOptionButton.click()
         expect(editor.getSelectedBufferRange()).toEqual [[2, 0], [2, 5]]
+
+      describe "when there are existing selections", ->
+        describe "when any existing selections match the pattern", ->
+          it "shouldn't jump to the next match when toggled on", ->
+            findView.model.setFindOptions caseSensitive: false
+            findView.findEditor.setText 'WORDs'
+            editor.setSelectedBufferRange [[2, 0], [2, 5]]
+            findView.caseOptionButton.click()
+            expect(editor.getSelectedBufferRange()).toEqual [[2, 0], [2, 5]]
+
+          it "shouldn't jump to the next match when toggled off", ->
+            findView.model.setFindOptions caseSensitive: true
+            findView.findEditor.setText 'WORDs'
+            editor.setSelectedBufferRange [[2, 0], [2, 5]]
+            findView.caseOptionButton.click()
+            expect(editor.getSelectedBufferRange()).toEqual [[2, 0], [2, 5]]
+
+        describe "when no existing selections match the pattern", ->
+          it "should jump to the next match when toggled on", ->
+            findView.model.setFindOptions caseSensitive: false
+            findView.findEditor.setText 'WORDs'
+            editor.setSelectedBufferRange [[1, 0], [1, 5]]
+            findView.caseOptionButton.click()
+            expect(editor.getSelectedBufferRange()).toEqual [[2, 0], [2, 5]]
+
+          it "should jump to the next match when toggled off", ->
+            # It's impossible to create a test where `caseSensitive: true` matches but `caseSensitive: false` doesn't.
+            # Instead we'll create a generic selection and ensure that it jumps to the next match.
+            findView.model.setFindOptions caseSensitive: true
+            findView.findEditor.setText 'WORDs'
+            editor.setSelectedBufferRange [[0, 0], [0, 5]]
+            findView.caseOptionButton.click()
+            expect(editor.getSelectedBufferRange()).toEqual [[1, 0], [1, 5]]
 
     describe "highlighting search results", ->
       getResultDecoration = (clazz) ->

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -845,35 +845,27 @@ describe 'FindView', ->
           expect(findView.descriptionLabel).toHaveClass 'text-error'
 
       describe "when there are existing selections", ->
-        describe "when any existing selections match the pattern", ->
-          it "shouldn't jump to the next match when toggled on", ->
-            findView.model.setFindOptions useRegex: false
-            findView.findEditor.setText 'items.length'
-            editor.setSelectedBufferRange [[2, 8], [2, 20]]
-            findView.regexOptionButton.click()
-            expect(editor.getSelectedBufferRange()).toEqual [[2, 8], [2, 20]]
+        it "does not jump to the next match when any selections match the pattern", ->
+          findView.model.setFindOptions useRegex: false
+          findView.findEditor.setText 'items.length'
+          editor.setSelectedBufferRange [[2, 8], [2, 20]]
 
-          it "shouldn't jump to the next match when toggled off", ->
-            findView.model.setFindOptions useRegex: true
-            findView.findEditor.setText 'items.length'
-            editor.setSelectedBufferRange [[2, 8], [2, 20]]
-            findView.regexOptionButton.click()
-            expect(editor.getSelectedBufferRange()).toEqual [[2, 8], [2, 20]]
+          findView.regexOptionButton.click()
+          expect(editor.getSelectedBufferRange()).toEqual [[2, 8], [2, 20]]
 
-        describe "when no existing selections match the pattern", ->
-          it "should jump to the next match when toggled on", ->
-            findView.model.setFindOptions useRegex: false
-            findView.findEditor.setText 'pivot ?'
-            editor.setSelectedBufferRange [[6, 16], [6, 23]]
-            findView.regexOptionButton.click()
-            expect(editor.getSelectedBufferRange()).toEqual [[8, 29], [8, 34]]
+          findView.regexOptionButton.click()
+          expect(editor.getSelectedBufferRange()).toEqual [[2, 8], [2, 20]]
 
-          it "should jump to the next match when toggled off", ->
-            findView.model.setFindOptions useRegex: true
-            findView.findEditor.setText 'pivot ?'
-            editor.setSelectedBufferRange [[8, 29], [8, 34]]
-            findView.regexOptionButton.click()
-            expect(editor.getSelectedBufferRange()).toEqual [[6, 16], [6, 23]]
+        it "jumps to the next match when no selections match the pattern", ->
+          findView.model.setFindOptions useRegex: false
+          findView.findEditor.setText 'pivot ?'
+          editor.setSelectedBufferRange [[6, 16], [6, 23]]
+
+          findView.regexOptionButton.click()
+          expect(editor.getSelectedBufferRange()).toEqual [[8, 29], [8, 34]]
+
+          findView.regexOptionButton.click()
+          expect(editor.getSelectedBufferRange()).toEqual [[6, 16], [6, 23]]
 
     describe "when whole-word is toggled", ->
       it "toggles whole-word via an event and finds text matching the pattern", ->
@@ -901,37 +893,29 @@ describe 'FindView', ->
         expect(editor.getSelectedBufferRange()).toEqual [[11, 20], [11, 25]]
 
       describe "when there are existing selections", ->
-        describe "when any existing selections match the pattern", ->
-          it "shouldn't jump to the next match when toggled on", ->
-            findView.model.setFindOptions wholeWord: false
-            findView.findEditor.setText 'sort'
-            editor.setSelectedBufferRange [[1, 6], [1, 10]]
-            findView.wholeWordOptionButton.click()
-            expect(editor.getSelectedBufferRange()).toEqual [[1, 6], [1, 10]]
+        it "does not jump to the next match when any selections match the pattern", ->
+          findView.model.setFindOptions wholeWord: false
+          findView.findEditor.setText 'sort'
+          editor.setSelectedBufferRange [[1, 6], [1, 10]]
 
-          it "shouldn't jump to the next match when toggled off", ->
-            findView.model.setFindOptions wholeWord: true
-            findView.findEditor.setText 'sort'
-            editor.setSelectedBufferRange [[1, 6], [1, 10]]
-            findView.wholeWordOptionButton.click()
-            expect(editor.getSelectedBufferRange()).toEqual [[1, 6], [1, 10]]
+          findView.wholeWordOptionButton.click()
+          expect(editor.getSelectedBufferRange()).toEqual [[1, 6], [1, 10]]
 
-        describe "when no existing selections match the pattern", ->
-          it "should jump to the next match when toggled on", ->
-            findView.model.setFindOptions wholeWord: false
-            findView.findEditor.setText 'sort'
-            editor.setSelectedBufferRange [[0, 9], [0, 13]]
-            findView.wholeWordOptionButton.click()
-            expect(editor.getSelectedBufferRange()).toEqual [[1, 6], [1, 10]]
+          findView.wholeWordOptionButton.click()
+          expect(editor.getSelectedBufferRange()).toEqual [[1, 6], [1, 10]]
 
-          it "should jump to the next match when toggled off", ->
-            # It's impossible to create a test where `wholeWord: true` matches but `wholeWord: false` doesn't.
-            # Instead we'll create a generic selection and ensure that it jumps to the next match.
-            findView.model.setFindOptions wholeWord: true
-            findView.findEditor.setText 'sort'
-            editor.setSelectedBufferRange [[0, 0], [0, 5]]
-            findView.wholeWordOptionButton.click()
-            expect(editor.getSelectedBufferRange()).toEqual [[0, 9], [0, 13]]
+        it "jumps to the next match when no selections match the pattern", ->
+          findView.model.setFindOptions wholeWord: false
+          findView.findEditor.setText 'sort'
+          editor.setSelectedBufferRange [[0, 9], [0, 13]]
+          findView.wholeWordOptionButton.click()
+          expect(editor.getSelectedBufferRange()).toEqual [[1, 6], [1, 10]]
+
+          # It's impossible to create a test where `wholeWord: true` matches but `wholeWord: false` doesn't.
+          # Instead we'll create a generic selection and ensure that it jumps to the next match.
+          editor.setSelectedBufferRange [[0, 0], [0, 5]]
+          findView.wholeWordOptionButton.click()
+          expect(editor.getSelectedBufferRange()).toEqual [[0, 9], [0, 13]]
 
     describe "when case sensitivity is toggled", ->
       beforeEach ->
@@ -957,37 +941,29 @@ describe 'FindView', ->
         expect(editor.getSelectedBufferRange()).toEqual [[2, 0], [2, 5]]
 
       describe "when there are existing selections", ->
-        describe "when any existing selections match the pattern", ->
-          it "shouldn't jump to the next match when toggled on", ->
-            findView.model.setFindOptions caseSensitive: false
-            findView.findEditor.setText 'WORDs'
-            editor.setSelectedBufferRange [[2, 0], [2, 5]]
-            findView.caseOptionButton.click()
-            expect(editor.getSelectedBufferRange()).toEqual [[2, 0], [2, 5]]
+        it "does not jump to the next match when any selections match the pattern", ->
+          findView.model.setFindOptions caseSensitive: false
+          findView.findEditor.setText 'WORDs'
+          editor.setSelectedBufferRange [[2, 0], [2, 5]]
 
-          it "shouldn't jump to the next match when toggled off", ->
-            findView.model.setFindOptions caseSensitive: true
-            findView.findEditor.setText 'WORDs'
-            editor.setSelectedBufferRange [[2, 0], [2, 5]]
-            findView.caseOptionButton.click()
-            expect(editor.getSelectedBufferRange()).toEqual [[2, 0], [2, 5]]
+          findView.caseOptionButton.click()
+          expect(editor.getSelectedBufferRange()).toEqual [[2, 0], [2, 5]]
 
-        describe "when no existing selections match the pattern", ->
-          it "should jump to the next match when toggled on", ->
-            findView.model.setFindOptions caseSensitive: false
-            findView.findEditor.setText 'WORDs'
-            editor.setSelectedBufferRange [[1, 0], [1, 5]]
-            findView.caseOptionButton.click()
-            expect(editor.getSelectedBufferRange()).toEqual [[2, 0], [2, 5]]
+          findView.caseOptionButton.click()
+          expect(editor.getSelectedBufferRange()).toEqual [[2, 0], [2, 5]]
 
-          it "should jump to the next match when toggled off", ->
-            # It's impossible to create a test where `caseSensitive: true` matches but `caseSensitive: false` doesn't.
-            # Instead we'll create a generic selection and ensure that it jumps to the next match.
-            findView.model.setFindOptions caseSensitive: true
-            findView.findEditor.setText 'WORDs'
-            editor.setSelectedBufferRange [[0, 0], [0, 5]]
-            findView.caseOptionButton.click()
-            expect(editor.getSelectedBufferRange()).toEqual [[1, 0], [1, 5]]
+        it "jumps to the next match when no selections match the pattern", ->
+          findView.model.setFindOptions caseSensitive: false
+          findView.findEditor.setText 'WORDs'
+          editor.setSelectedBufferRange [[1, 0], [1, 5]]
+          findView.caseOptionButton.click()
+          expect(editor.getSelectedBufferRange()).toEqual [[2, 0], [2, 5]]
+
+          # It's impossible to create a test where `caseSensitive: true` matches but `caseSensitive: false` doesn't.
+          # Instead we'll create a generic selection and ensure that it jumps to the next match.
+          editor.setSelectedBufferRange [[0, 0], [0, 5]]
+          findView.caseOptionButton.click()
+          expect(editor.getSelectedBufferRange()).toEqual [[1, 0], [1, 5]]
 
     describe "highlighting search results", ->
       getResultDecoration = (clazz) ->


### PR DESCRIPTION
This is a proposal to fix #496.

The problem
---
Toggling the option buttons will jump you away from a selection that already matched the new settings.

The previous behavior
---
Always jump to the next match after the cursor whenever a find option is toggled.

The new behavior
---
Only jump to the next match **if none of the existing selections match** the pattern.  Inversely, **if any of the existing selections match** the pattern, it will not jump you to the next match.

Alternatives
---
I also considered and decided against these possible behaviors:

- Jump to the next match **if any of the existing selections don't match** the pattern.  Inversely, do not jump to the next match **if all of the existing selections match** the pattern.
- When a find option is toggled, destroy any selections that don't match.  If there are any remaining selections, don't jump to the next match.  Otherwise jump to the next match.