### PR TITLE
Disconnect SelectNext from findOptions and vary behavior based on initial selection.

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -125,7 +125,7 @@ module.exports =
       editor = editorElement.getModel()
       selectNext = @selectNextObjects.get(editor)
       unless selectNext?
-        selectNext = new SelectNext(editor, {@findOptions})
+        selectNext = new SelectNext(editor)
         @selectNextObjects.set(editor, selectNext)
       selectNext
 

--- a/lib/select-next.coffee
+++ b/lib/select-next.coffee
@@ -54,7 +54,7 @@ class SelectNext
     lastSelection = @editor.getLastSelection()
     if @wordSelected = @isWordSelected(lastSelection)
       disposables = new CompositeDisposable
-      clearWordSelected = () =>
+      clearWordSelected = =>
         @wordSelected = null
         disposables.dispose()
       disposables.add lastSelection.onDidChangeRange clearWordSelected

--- a/spec/select-next-spec.coffee
+++ b/spec/select-next-spec.coffee
@@ -2,7 +2,7 @@ path = require 'path'
 SelectNext = require '../lib/select-next'
 
 describe "SelectNext", ->
-  [workspaceElement, editorElement, editor, promise, findOptions] = []
+  [workspaceElement, editorElement, editor, promise] = []
 
   beforeEach ->
     workspaceElement = atom.views.getView(atom.workspace)
@@ -15,8 +15,7 @@ describe "SelectNext", ->
       jasmine.attachToDOM(workspaceElement)
       editor = atom.workspace.getActiveTextEditor()
       editorElement = atom.views.getView(editor)
-      promise = atom.packages.activatePackage("find-and-replace").then ({mainModule}) ->
-        findOptions = mainModule.findOptions
+      promise = atom.packages.activatePackage("find-and-replace")
       atom.commands.dispatch editorElement, 'find-and-replace:show'
 
     waitsForPromise ->
@@ -30,11 +29,60 @@ describe "SelectNext", ->
         expect(editor.getSelectedBufferRanges()).toEqual [[[1, 2], [1, 5]]]
 
     describe "when a word is selected", ->
-      describe "when findOptions.wholeWord is false", ->
+      describe "when the selection was created using select-next", ->
         beforeEach ->
-          findOptions.set(wholeWord: false, caseSensitive: true)
 
         it "selects the next occurrence of the selected word skipping any non-word matches", ->
+          editor.setText """
+            for
+            information
+            format
+            another for
+            fork
+            a 3rd for is here
+          """
+
+          editor.setCursorBufferPosition([0, 0])
+          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+          expect(editor.getSelectedBufferRanges()).toEqual [
+            [[0, 0], [0, 3]]
+          ]
+
+          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+          expect(editor.getSelectedBufferRanges()).toEqual [
+            [[0, 0], [0, 3]]
+            [[3, 8], [3, 11]]
+          ]
+
+          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+          expect(editor.getSelectedBufferRanges()).toEqual [
+            [[0, 0], [0, 3]]
+            [[3, 8], [3, 11]]
+            [[5, 6], [5, 9]]
+          ]
+
+          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+          expect(editor.getSelectedBufferRanges()).toEqual [
+            [[0, 0], [0, 3]]
+            [[3, 8], [3, 11]]
+            [[5, 6], [5, 9]]
+          ]
+
+          editor.setText "Testing reallyTesting"
+          editor.setCursorBufferPosition([0, 0])
+
+          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+          expect(editor.getSelectedBufferRanges()).toEqual [
+            [[0, 0], [0, 7]]
+          ]
+
+          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+          expect(editor.getSelectedBufferRanges()).toEqual [
+            [[0, 0], [0, 7]]
+          ]
+
+      describe "when the selection was not created using select-next", ->
+        it "selects the next occurrence of the selected characters including non-word matches", ->
           editor.setText """
             for
             information
@@ -68,12 +116,7 @@ describe "SelectNext", ->
           ]
 
           editor.setText "Testing reallyTesting"
-          editor.setCursorBufferPosition([0, 0])
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[0, 0], [0, 7]]
-          ]
+          editor.setSelectedBufferRange([[0, 0], [0, 7]])
 
           atom.commands.dispatch editorElement, 'find-and-replace:select-next'
           expect(editor.getSelectedBufferRanges()).toEqual [
@@ -81,227 +124,58 @@ describe "SelectNext", ->
             [[0, 14], [0, 21]]
           ]
 
-      describe "when findOptions.wholeWord is true", ->
-        beforeEach ->
-          findOptions.set(wholeWord: true, caseSensitive: true)
-
-        it "selects the next occurrence of the selected word skipping any non-word matches", ->
-          editor.setText """
-            for
-            information
-            format
-            another for
-            fork
-            a 3rd for is here
-          """
-
-          editor.setSelectedBufferRange([[0, 0], [0, 3]])
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[0, 0], [0, 3]]
-            [[3, 8], [3, 11]]
-          ]
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[0, 0], [0, 3]]
-            [[3, 8], [3, 11]]
-            [[5, 6], [5, 9]]
-          ]
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[0, 0], [0, 3]]
-            [[3, 8], [3, 11]]
-            [[5, 6], [5, 9]]
-          ]
-
-          editor.setText "Testing reallyTesting"
-          editor.setCursorBufferPosition([0, 0])
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[0, 0], [0, 7]]
-          ]
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[0, 0], [0, 7]]
-          ]
-
-      describe "When buffer text is of mixed case", ->
-        beforeEach ->
-          editor.setText """
-            FooBar
-            foobar
-            testFooBar
-            FooBarTest
-            test_foobar
-            foobar_test
-            FooBar
-            foobar
-          """
-
-        describe "When findOptions.wholeWord is true and findOptions.caseSensitive is true", ->
-          it "does not select partial words or wrong case", ->
-            findOptions.set(wholeWord: true, caseSensitive: true)
-
-            editor.setSelectedBufferRange([[0, 0], [0, 6]]) #First FooBar
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-            expect(editor.getSelectedBufferRanges()).toEqual [
-              [[0, 0], [0, 6]]  #First FooBar
-              [[6, 0], [6, 6]]  #Second FooBar
-            ]
-
-            editor.setSelectedBufferRange([[1, 0], [1, 6]]) #First foobar
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-            expect(editor.getSelectedBufferRanges()).toEqual [
-              [[1, 0], [1, 6]]  #First foobar
-              [[7, 0], [7, 6]]  #Second foobar
-            ]
-
-        describe "When findOptions.wholeWord is true and findOptions.caseSensitive is false", ->
-          it "does not select partial words but allows case insensitive match", ->
-            findOptions.set(wholeWord: true, caseSensitive: false)
-
-            editor.setSelectedBufferRange([[0, 0], [0, 6]]) #First FooBar
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-
-            expect(editor.getSelectedBufferRanges()).toEqual [
-              [[0, 0], [0, 6]] #First FooBar
-              [[1, 0], [1, 6]] #First foobar
-              [[6, 0], [6, 6]] #Second FooBar
-              [[7, 0], [7, 6]] #Second foobar
-            ]
-
-        describe "When findOptions.wholeWord is false and findOptions.caseSensitive is true", ->
-          it "selects partial words but require case sensitive match", ->
-            findOptions.set(wholeWord: false, caseSensitive: true)
-
-            editor.setSelectedBufferRange([[0, 0], [0, 6]]) #First FooBar
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-
-            expect(editor.getSelectedBufferRanges()).toEqual [
-              [[0, 0], [0, 6]]  #First FooBar
-              [[2, 4], [2, 10]] #testFooBar
-              [[3, 0], [3, 6]]  #FooBarTest
-              [[6, 0], [6, 6]]  #Second FooBar
-            ]
-
-        describe "When findOptions.wholeWord is false and findOptions.caseSensitive is false", ->
-          it "selects case insensitive partial words", ->
-            findOptions.set(wholeWord: false, caseSensitive: false)
-
-            editor.setSelectedBufferRange([[0, 0], [0, 6]]) #First FooBar
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-            atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-
-            expect(editor.getSelectedBufferRanges()).toEqual [
-              [[0, 0], [0, 6]]  #First FooBar
-              [[1, 0], [1, 6]]  #First foobar
-              [[2, 4], [2, 10]] #testFooBar
-              [[3, 0], [3, 6]]  #FooBarTest
-              [[4, 5], [4, 11]] #test_foobar
-              [[5, 0], [5, 6]]  #foobar_test
-              [[6, 0], [6, 6]]  #Second FooBar
-              [[7, 0], [7, 6]]  #Second foobar
-            ]
-
     describe "when part of a word is selected", ->
-      describe "when findOptions.wholeWord is false", ->
-        beforeEach ->
-          findOptions.set(wholeWord: false, caseSensitive: true)
+      it "selects the next occurrence of the selected text", ->
+        editor.setText """
+          for
+          information
+          format
+          another for
+          fork
+          a 3rd for is here
+        """
 
-        it "selects the next occurrence of the selected text", ->
-          editor.setText """
-            for
-            information
-            format
-            another for
-            fork
-            a 3rd for is here
-          """
+        editor.setSelectedBufferRange([[1, 2], [1, 5]])
 
-          editor.setSelectedBufferRange([[1, 2], [1, 5]])
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[1, 2], [1, 5]]
+          [[2, 0], [2, 3]]
+        ]
 
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[1, 2], [1, 5]]
-            [[2, 0], [2, 3]]
-          ]
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[1, 2], [1, 5]]
+          [[2, 0], [2, 3]]
+          [[3, 8], [3, 11]]
+        ]
 
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[1, 2], [1, 5]]
-            [[2, 0], [2, 3]]
-            [[3, 8], [3, 11]]
-          ]
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[1, 2], [1, 5]]
+          [[2, 0], [2, 3]]
+          [[3, 8], [3, 11]]
+          [[4, 0], [4, 3]]
+        ]
 
-      describe "when findOptions.wholeWord is true", ->
-        beforeEach ->
-          findOptions.set(wholeWord: true, caseSensitive: true)
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[1, 2], [1, 5]]
+          [[2, 0], [2, 3]]
+          [[3, 8], [3, 11]]
+          [[4, 0], [4, 3]]
+          [[5, 6], [5, 9]]
+        ]
 
-        it "selects the next occurrence of the selected text", ->
-          editor.setText """
-            for
-            information
-            format
-            another for
-            fork
-            a 3rd for is here
-          """
-
-          editor.setSelectedBufferRange([[1, 2], [1, 5]])
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[1, 2], [1, 5]]
-            [[2, 0], [2, 3]]
-          ]
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[1, 2], [1, 5]]
-            [[2, 0], [2, 3]]
-            [[3, 8], [3, 11]]
-          ]
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[1, 2], [1, 5]]
-            [[2, 0], [2, 3]]
-            [[3, 8], [3, 11]]
-            [[4, 0], [4, 3]]
-          ]
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[1, 2], [1, 5]]
-            [[2, 0], [2, 3]]
-            [[3, 8], [3, 11]]
-            [[4, 0], [4, 3]]
-            [[5, 6], [5, 9]]
-          ]
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[1, 2], [1, 5]]
-            [[2, 0], [2, 3]]
-            [[3, 8], [3, 11]]
-            [[4, 0], [4, 3]]
-            [[5, 6], [5, 9]]
-            [[0, 0], [0, 3]]
-          ]
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[1, 2], [1, 5]]
+          [[2, 0], [2, 3]]
+          [[3, 8], [3, 11]]
+          [[4, 0], [4, 3]]
+          [[5, 6], [5, 9]]
+          [[0, 0], [0, 3]]
+        ]
 
     describe "when a non-word is selected", ->
       it "selects the next occurrence of the selected text", ->
@@ -343,62 +217,7 @@ describe "SelectNext", ->
 
   describe "find-and-replace:select-all", ->
     describe "when there is no selection", ->
-      describe "when findOptions.wholeWord is false", ->
-        beforeEach ->
-          findOptions.set(wholeWord: false, caseSensitive: true)
-
-        it "find and selects all occurrences of the word under the cursor", ->
-          editor.setText """
-            for
-            information
-            format
-            another for
-            fork
-            a 3rd for is here
-          """
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-all'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[0, 0], [0, 3]]
-            [[1, 2], [1, 5]]
-            [[2, 0], [2, 3]]
-            [[3, 8], [3, 11]]
-            [[4, 0], [4, 3]]
-            [[5, 6], [5, 9]]
-          ]
-
-      describe "when findOptions.wholeWord is true", ->
-        beforeEach ->
-          findOptions.set(wholeWord: true, caseSensitive: true)
-
-        it "find and selects all occurrences of the word under the cursor", ->
-          editor.setText """
-            for
-            information
-            format
-            another for
-            fork
-            a 3rd for is here
-          """
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-all'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[0, 0], [0, 3]]
-            [[3, 8], [3, 11]]
-            [[5, 6], [5, 9]]
-          ]
-
-          atom.commands.dispatch editorElement, 'find-and-replace:select-all'
-          expect(editor.getSelectedBufferRanges()).toEqual [
-            [[0, 0], [0, 3]]
-            [[3, 8], [3, 11]]
-            [[5, 6], [5, 9]]
-          ]
-
-    describe "when a word is selected", ->
-      it "find and selects all occurrences", ->
-        findOptions.set(wholeWord: true, caseSensitive: true)
-
+      it "find and selects all occurrences of the word under the cursor", ->
         editor.setText """
           for
           information
@@ -408,21 +227,68 @@ describe "SelectNext", ->
           a 3rd for is here
         """
 
-        editor.setSelectedBufferRange([[3, 8], [3, 11]])
-
         atom.commands.dispatch editorElement, 'find-and-replace:select-all'
         expect(editor.getSelectedBufferRanges()).toEqual [
-          [[3, 8], [3, 11]]
           [[0, 0], [0, 3]]
+          [[3, 8], [3, 11]]
           [[5, 6], [5, 9]]
         ]
 
         atom.commands.dispatch editorElement, 'find-and-replace:select-all'
         expect(editor.getSelectedBufferRanges()).toEqual [
-          [[3, 8], [3, 11]]
           [[0, 0], [0, 3]]
+          [[3, 8], [3, 11]]
           [[5, 6], [5, 9]]
         ]
+
+    describe "when a word is selected", ->
+      describe "when the word was selected using select-next", ->
+        it "find and selects all occurrences of the word", ->
+          editor.setText """
+            for
+            information
+            format
+            another for
+            fork
+            a 3rd for is here
+          """
+
+          atom.commands.dispatch editorElement, 'find-and-replace:select-all'
+          expect(editor.getSelectedBufferRanges()).toEqual [
+            [[0, 0], [0, 3]]
+            [[3, 8], [3, 11]]
+            [[5, 6], [5, 9]]
+          ]
+
+          atom.commands.dispatch editorElement, 'find-and-replace:select-all'
+          expect(editor.getSelectedBufferRanges()).toEqual [
+            [[0, 0], [0, 3]]
+            [[3, 8], [3, 11]]
+            [[5, 6], [5, 9]]
+          ]
+
+      describe "when the word was not selected using select-next", ->
+        it "find and selects all occurrences including non-words", ->
+          editor.setText """
+            for
+            information
+            format
+            another for
+            fork
+            a 3rd for is here
+          """
+
+          editor.setSelectedBufferRange([[3, 8], [3, 11]])
+
+          atom.commands.dispatch editorElement, 'find-and-replace:select-all'
+          expect(editor.getSelectedBufferRanges()).toEqual [
+            [[3, 8], [3, 11]]
+            [[0, 0], [0, 3]]
+            [[1, 2], [1, 5]]
+            [[2, 0], [2, 3]]
+            [[4, 0], [4, 3]]
+            [[5, 6], [5, 9]]
+          ]
 
     describe "when a non-word is selected", ->
       it "selects the next occurrence of the selected text", ->
@@ -497,9 +363,6 @@ describe "SelectNext", ->
         ]
 
     describe "when three words are selected", ->
-      beforeEach ->
-        findOptions.set(wholeWord: true, caseSensitive: true)
-
       it "unselects words in order", ->
         editor.setText """
           for
@@ -510,10 +373,11 @@ describe "SelectNext", ->
           a 3rd for is here
         """
 
-        editor.setSelectedBufferRange([[0, 0], [0, 3]])
+        editor.setCursorBufferPosition([0, 0])
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
 
-        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
-        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
         atom.commands.dispatch editorElement, 'find-and-replace:select-undo'
         expect(editor.getSelectedBufferRanges()).toEqual [
           [[0, 0], [0, 3]]
@@ -526,9 +390,6 @@ describe "SelectNext", ->
         ]
 
     describe "when starting at the bottom word", ->
-      beforeEach ->
-        findOptions.set(wholeWord: true, caseSensitive: true)
-
       it "unselects words in order", ->
         editor.setText """
           for
@@ -539,7 +400,11 @@ describe "SelectNext", ->
           a 3rd for is here
         """
 
-        editor.setSelectedBufferRange([[5, 6], [5, 9]])
+        editor.setCursorBufferPosition([5, 7])
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[5, 6], [5, 9]]
+        ]
         atom.commands.dispatch editorElement, 'find-and-replace:select-next'
         expect(editor.getSelectedBufferRanges()).toEqual [
           [[5, 6], [5, 9]]
@@ -560,7 +425,11 @@ describe "SelectNext", ->
           a 3rd for is here
         """
 
-        editor.setSelectedBufferRange([[5, 6], [5, 9]])
+        editor.setCursorBufferPosition([5, 7])
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[5, 6], [5, 9]]
+        ]
         atom.commands.dispatch editorElement, 'find-and-replace:select-next'
         atom.commands.dispatch editorElement, 'find-and-replace:select-next'
         atom.commands.dispatch editorElement, 'find-and-replace:select-next'
@@ -571,9 +440,6 @@ describe "SelectNext", ->
         ]
 
   describe "find-and-replace:select-skip", ->
-    beforeEach ->
-      findOptions.set(wholeWord: true, caseSensitive: true)
-
     describe "when there is no selection", ->
       it "does nothing", ->
         editor.setText """
@@ -601,7 +467,11 @@ describe "SelectNext", ->
           a 3rd for is here
         """
 
-        editor.setSelectedBufferRange([[3, 8], [3, 11]])
+        editor.setCursorBufferPosition([3, 8])
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[3, 8], [3, 11]]
+        ]
 
         atom.commands.dispatch editorElement, 'find-and-replace:select-skip'
         expect(editor.getSelectedBufferRanges()).toEqual [
@@ -619,7 +489,11 @@ describe "SelectNext", ->
           a 3rd for is here
         """
 
-        editor.setSelectedBufferRange([[0, 0], [0, 3]])
+        editor.setCursorBufferPosition([0, 0])
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[0, 0], [0, 3]]
+        ]
 
         atom.commands.dispatch editorElement, 'find-and-replace:select-next'
         atom.commands.dispatch editorElement, 'find-and-replace:select-skip'
@@ -644,7 +518,11 @@ describe "SelectNext", ->
           a 3rd for is here
         """
 
-        editor.setSelectedBufferRange([[5, 6], [5, 9]])
+        editor.setCursorBufferPosition([5, 7])
+        atom.commands.dispatch editorElement, 'find-and-replace:select-next'
+        expect(editor.getSelectedBufferRanges()).toEqual [
+          [[5, 6], [5, 9]]
+        ]
         atom.commands.dispatch editorElement, 'find-and-replace:select-next'
         atom.commands.dispatch editorElement, 'find-and-replace:select-skip'
         expect(editor.getSelectedBufferRanges()).toEqual [


### PR DESCRIPTION
This PR fixes #521 and reverts #482 and #541.

`find-and-replace:select-next` has two core functions.  When nothing is selected, it performs the **SelectWord** function and selects the word(s) under the cursor(s).  When a selection exists, it performs the **SelectNext** function and selects the next occurrence of the selected text.

As discussed in #521, this PR changes the behavior of **SelectNext** depending on whether the existing selection was made using **SelectWord**.

- If the existing selection was made using **SelectWord**, then following **SelectNext** actions will match only whole words.
- If the existing selection was made any other way (e.g. mouse, shift + arrow keys, find panel), then following **SelectNext** actions will match any occurrence.

Since `find-and-replace:select-all` piggybacks on `select-next`'s logic, this PR also affects the behavior of `select-all`.  Essentially, `select-all` is the equivalent of dispatching `select-next` until all occurrences are selected.

Demo:
![select-next](https://cloud.githubusercontent.com/assets/185923/11450552/396253f6-9561-11e5-9d21-effa55b58ee8.gif)

I believe this functionality was also suggested in #430.
