### PR TITLE
Fix up wrap around icon

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -24,8 +24,6 @@ class FindView extends View
       placeholderText: 'Replace in current buffer'
 
     @div tabIndex: -1, class: 'find-and-replace', =>
-      @div outlet: 'wrapIcon', class: 'wrap-icon'
-
       @header class: 'header', =>
         @span outlet: 'descriptionLabel', class: 'header-item description', 'Find in Current Buffer'
         @span class: 'header-item options-label pull-right', =>

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -1,5 +1,5 @@
 _ = require 'underscore-plus'
-{$$$, View, TextEditorView} = require 'atom-space-pen-views'
+{$, $$$, View, TextEditorView} = require 'atom-space-pen-views'
 {CompositeDisposable} = require 'atom'
 Util = require './project/util'
 buildTextEditor = require './build-text-editor'
@@ -102,6 +102,7 @@ class FindView extends View
     @clearMessage()
     @updateOptionViews()
     @updateReplaceEnablement()
+    @createWrapIcon()
 
   destroy: ->
     @subscriptions?.dispose()
@@ -497,7 +498,24 @@ class FindView extends View
       @replaceTooltipSubscriptions.add atom.tooltips.add @replaceAllButton,
         title: "Replace All [when there are results]"
 
+  # FIXME: The wrap icon should probably be its own view responding to events
+  # when the search wraps.
+  createWrapIcon: ->
+    wrapIcon = document.createElement('div')
+    wrapIcon.classList.add('find-wrap-icon')
+    @wrapIcon = $(wrapIcon)
+
   showWrapIcon: (icon) ->
-    @wrapIcon.attr('class', "wrap-icon #{icon}").fadeIn()
+    editor = @model.getEditor()
+    return unless editor?
+    editorView = atom.views.getView(editor)
+    return unless editorView?.parentNode?
+
+    # Attach to the parent of the active editor, that way we can position it
+    # correctly over the active editor.
+    editorView.parentNode.appendChild(@wrapIcon[0])
+
+    # FIXME: This animation should be in CSS
+    @wrapIcon.attr('class', "find-wrap-icon #{icon}").fadeIn()
     clearTimeout(@wrapTimeout)
     @wrapTimeout = setTimeout (=> @wrapIcon.fadeOut()), 1000

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -166,26 +166,36 @@ atom-workspace.find-visible {
       margin-right: @component-padding;
     }
   }
+}
 
-  .wrap-icon {
-    @wrap-size: @font-size * 10;
+.find-wrap-icon {
+  @wrap-size: @font-size * 10;
 
-    display: none;
-    position: absolute;
-    left: 50%;
-    top: @wrap-size * -1.5;
-    margin-left: @wrap-size * -0.5;
-    background: rgba(136,136,136, 0.2);
-    border-radius: @component-border-radius * 5;
-    text-align: center;
-    pointer-events: none;
-    &:before {
-      // Octicons look best in sizes that are multiples of 16px
-      font-size: @wrap-size - mod(@wrap-size, 16px) - 16px;
-      line-height: @wrap-size;
-      height: @wrap-size;
-      width: @wrap-size;
-    }
+  display: none;
+  position: absolute;
+
+  // These are getting placed in the DOM as a pane item, so override the pane
+  // item positioning styles. :/
+  top: 50% !important;
+  left: 50% !important;
+  right: initial !important;
+  bottom: initial !important;
+
+  margin-top: @wrap-size * -0.5;
+  margin-left: @wrap-size * -0.5;
+
+  background: fadeout(darken(@syntax-background-color, 4%), 55%);
+  border-radius: @component-border-radius * 2;
+  text-align: center;
+  pointer-events: none;
+  &:before {
+    // Octicons look best in sizes that are multiples of 16px
+    font-size: @wrap-size - mod(@wrap-size, 16px) - 32px;
+    line-height: @wrap-size;
+    height: @wrap-size;
+    width: @wrap-size;
+    color: @syntax-text-color;
+    opacity: .5;
   }
 }
 


### PR DESCRIPTION
This is an extension on https://github.com/atom/find-and-replace/pull/572. There were a couple issues:

* The icon was only shown when the find view was open
* The icon could not be centered vertically over the editor in CSS because it was a child of the find view
* The icon was centered horizontally over the fnr panel, not the editor, so it didnt make sense with splits
* The colors didnt work well with some theme combinations

Looks like this now:

![screen shot 2015-12-03 at 3 29 13 pm](https://cloud.githubusercontent.com/assets/69169/11577461/a176b93a-99d2-11e5-9d72-717ecf807609.png)

cc @mrodalgaard