### PR TITLE
Only show search wrap icon when scroll position changed

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -282,8 +282,8 @@ class FindView extends View
 
     if @markers?.length > 0
       unless currentMarker = @model.currentResultMarker
-        markerIndex = @[nextIndexFn]()
-        currentMarker = @markers[markerIndex]
+        if position = @[nextIndexFn]()
+          currentMarker = @markers[position.index]
 
       @model.replace([currentMarker], @replaceEditor.getText())
       @[nextOrPreviousFn](fieldToFocus: @replaceEditor)
@@ -342,16 +342,23 @@ class FindView extends View
     @descriptionLabel.html('Find in Current Buffer <span class="subtle-info-message">Close this panel with the <span class="highlight">esc</span> key</span>').removeClass('text-error')
 
   selectFirstMarkerAfterCursor: =>
-    markerIndex = @firstMarkerIndexAfterCursor()
-    @selectMarkerAtIndex(markerIndex)
+    {index, wrapped} = @firstMarkerIndexAfterCursor()
+    @selectMarkerAtIndex(index, wrapped)
 
   selectFirstMarkerStartingFromCursor: =>
-    markerIndex = @firstMarkerIndexAfterCursor(true)
-    @selectMarkerAtIndex(markerIndex)
+    {index, wrapped} = @firstMarkerIndexAfterCursor(true)
+    @selectMarkerAtIndex(index, wrapped)
+
+  selectFirstMarkerBeforeCursor: =>
+    {index, wrapped} = @firstMarkerIndexBeforeCursor()
+    @selectMarkerAtIndex(index, wrapped)
+
+  firstMarkerIndexStartingFromCursor: =>
+    @firstMarkerIndexAfterCursor(true)
 
   firstMarkerIndexAfterCursor: (indexIncluded=false) ->
     editor = @model.getEditor()
-    return -1 unless editor
+    return null unless editor
 
     selection = editor.getLastSelection()
     {start, end} = selection.getBufferRange()
@@ -359,22 +366,16 @@ class FindView extends View
 
     for marker, index in @markers
       markerStartPosition = marker.bufferMarker.getStartPosition()
-      return index if markerStartPosition.isEqual(start) and indexIncluded
-      return index if markerStartPosition.isGreaterThan(start)
+      switch markerStartPosition.compare(start)
+        when -1 then continue
+        when 0 then continue unless indexIncluded
+      return {index, wrapped: null}
 
-    @showWrapIcon('icon-move-up')
-    0
-
-  firstMarkerIndexStartingFromCursor: =>
-    @firstMarkerIndexAfterCursor(true)
-
-  selectFirstMarkerBeforeCursor: =>
-    markerIndex = @firstMarkerIndexBeforeCursor()
-    @selectMarkerAtIndex(markerIndex)
+    {index: 0, wrapped: 'up'}
 
   firstMarkerIndexBeforeCursor: ->
     editor = @model.getEditor()
-    return -1 unless editor
+    return null unless editor
 
     selection = @model.getEditor().getLastSelection()
     {start, end} = selection.getBufferRange()
@@ -382,25 +383,36 @@ class FindView extends View
 
     for marker, index in @markers by -1
       markerEndPosition = marker.bufferMarker.getEndPosition()
-      return index if markerEndPosition.isLessThan(start)
+      return {index, wrapped: null} if markerEndPosition.isLessThan(start)
 
-    @showWrapIcon('icon-move-down')
-    @markers.length - 1
+    {index: @markers.length - 1, wrapped: 'down'}
 
   selectAllMarkers: =>
     return unless @markers?.length > 0
     ranges = (marker.getBufferRange() for marker in @markers)
-    scrollMarker = @markers[@firstMarkerIndexAfterCursor()]
+    scrollMarker = @markers[@firstMarkerIndexAfterCursor().index]
     editor = @model.getEditor()
     editor.setSelectedBufferRanges(ranges, flash: true)
     editor.scrollToBufferPosition(scrollMarker.getStartBufferPosition(), center: true)
 
-  selectMarkerAtIndex: (markerIndex) ->
+  selectMarkerAtIndex: (markerIndex, wrapped) ->
     return unless @markers?.length > 0
 
     if marker = @markers[markerIndex]
       editor = @model.getEditor()
-      editor.setSelectedBufferRange(marker.getBufferRange(), flash: true)
+      screenRange = marker.getScreenRange()
+
+      if (
+        screenRange.start.row < editor.getFirstVisibleScreenRow() or
+        screenRange.end.row > editor.getLastVisibleScreenRow()
+      )
+        switch wrapped
+          when 'up'
+            @showWrapIcon('icon-move-up')
+          when 'down'
+            @showWrapIcon('icon-move-down')
+
+      editor.setSelectedScreenRange(screenRange, flash: true)
       editor.scrollToCursorPosition(center: true)
 
   setSelectionAsFindPattern: =>

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -574,19 +574,53 @@ describe 'FindView', ->
       editor.setSelectedBufferRange([[2, 34], [2, 39]])
       expect(findView.resultCounter.text()).toEqual('3 of 6')
 
-    it "shows an icon when search wraps around", ->
+    it "shows an icon when search wraps around and the editor scrolls", ->
+      editorView.style.height = "80px"
+      atom.views.performDocumentPoll()
+      expect(editor.getVisibleRowRange()).toEqual [0, 3]
+
+      expect(findView.resultCounter.text()).toEqual('2 of 6')
+      expect(findView.wrapIcon).not.toBeVisible()
+
       atom.commands.dispatch editorView, 'find-and-replace:find-previous'
+      expect(findView.resultCounter.text()).toEqual('1 of 6')
+      expect(editor.getVisibleRowRange()).toEqual [0, 3]
+
       expect(findView.wrapIcon).not.toBeVisible()
 
       atom.commands.dispatch editorView, 'find-and-replace:find-previous'
       expect(findView.resultCounter.text()).toEqual('6 of 6')
+      expect(editor.getVisibleRowRange()).toEqual [4, 7]
+
       expect(findView.wrapIcon).toBeVisible()
       expect(findView.wrapIcon).toHaveClass 'icon-move-down'
 
       atom.commands.dispatch editorView, 'find-and-replace:find-next'
       expect(findView.resultCounter.text()).toEqual('1 of 6')
+      expect(editor.getVisibleRowRange()).toEqual [0, 3]
+
       expect(findView.wrapIcon).toBeVisible()
       expect(findView.wrapIcon).toHaveClass 'icon-move-up'
+
+    it "does not nshow the wrap icon when the editor does not scroll", ->
+      editorView.style.height = "400px"
+      atom.views.performDocumentPoll()
+      expect(editor.getVisibleRowRange()).toEqual [0, 12]
+
+      atom.commands.dispatch editorView, 'find-and-replace:find-previous'
+      expect(findView.resultCounter.text()).toEqual('1 of 6')
+
+      atom.commands.dispatch editorView, 'find-and-replace:find-previous'
+      expect(findView.resultCounter.text()).toEqual('6 of 6')
+      expect(editor.getVisibleRowRange()).toEqual [0, 12]
+
+      expect(findView.wrapIcon).not.toBeVisible()
+
+      atom.commands.dispatch editorView, 'find-and-replace:find-next'
+      expect(findView.resultCounter.text()).toEqual('1 of 6')
+      expect(editor.getVisibleRowRange()).toEqual [0, 12]
+
+      expect(findView.wrapIcon).not.toBeVisible()
 
     describe "when find-and-replace:use-selection-as-find-pattern is triggered", ->
       it "places the selected text into the find editor", ->


### PR DESCRIPTION
I think @nathansobo, @kevinsawicki and I have all found it annoying that the icon shows up even if the editor does not scroll.