### PR TITLE
Add service to access result marker layer

### DIFF
--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -58,7 +58,7 @@ class BufferSearch
 
   resultsMarkerLayerForTextEditor: (editor) ->
     unless layer = ResultsMarkerLayersByEditor.get(editor)
-      layer = editor.addMarkerLayer()
+      layer = editor.addMarkerLayer?()
       ResultsMarkerLayersByEditor.set(editor, layer)
     layer
 

--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -3,7 +3,7 @@ _ = require 'underscore-plus'
 {Patch} = TextBuffer
 escapeHelper = require './escape-helper'
 
-ResultMarkerLayersByEditor = new WeakMap
+ResultsMarkerLayersByEditor = new WeakMap
 
 module.exports =
 class BufferSearch
@@ -45,9 +45,7 @@ class BufferSearch
       @subscriptions.add @editor.onDidAddSelection(@setCurrentMarkerFromSelection.bind(this))
       @subscriptions.add @editor.onDidChangeSelectionRange(@setCurrentMarkerFromSelection.bind(this))
       if @useMarkerLayers = @editor.addMarkerLayer?
-        unless @resultsMarkerLayer = ResultMarkerLayersByEditor.get(@editor)
-          @resultsMarkerLayer = @editor.addMarkerLayer()
-          ResultMarkerLayersByEditor.set(@editor, @resultsMarkerLayer)
+        @resultsMarkerLayer = @resultsMarkerLayerForTextEditor(@editor)
         @resultsLayerDecoration?.destroy()
         @resultsLayerDecoration = @editor.decorateMarkerLayer(@resultsMarkerLayer, {type: 'highlight', class: @constructor.markerClass})
     @recreateMarkers()
@@ -57,6 +55,12 @@ class BufferSearch
   setFindOptions: (newParams) -> @findOptions.set(newParams)
 
   getFindOptions: -> @findOptions
+
+  resultsMarkerLayerForTextEditor: (editor) ->
+    unless layer = ResultsMarkerLayersByEditor.get(editor)
+      layer = editor.addMarkerLayer()
+      ResultsMarkerLayersByEditor.set(editor, layer)
+    layer
 
   search: (findPattern, otherOptions) ->
     options = {findPattern}

--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -3,6 +3,8 @@ _ = require 'underscore-plus'
 {Patch} = TextBuffer
 escapeHelper = require './escape-helper'
 
+ResultMarkerLayersByEditor = new WeakMap
+
 module.exports =
 class BufferSearch
   @markerClass: 'find-result'
@@ -43,7 +45,10 @@ class BufferSearch
       @subscriptions.add @editor.onDidAddSelection(@setCurrentMarkerFromSelection.bind(this))
       @subscriptions.add @editor.onDidChangeSelectionRange(@setCurrentMarkerFromSelection.bind(this))
       if @useMarkerLayers = @editor.addMarkerLayer?
-        @resultsMarkerLayer = @editor.addMarkerLayer()
+        unless @resultsMarkerLayer = ResultMarkerLayersByEditor.get(@editor)
+          @resultsMarkerLayer = @editor.addMarkerLayer()
+          ResultMarkerLayersByEditor.set(@editor, @resultsMarkerLayer)
+        @resultsLayerDecoration?.destroy()
         @resultsLayerDecoration = @editor.decorateMarkerLayer(@resultsMarkerLayer, {type: 'highlight', class: @constructor.markerClass})
     @recreateMarkers()
 

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -139,6 +139,9 @@ module.exports =
       'find-and-replace:select-skip': (event) ->
         selectNextObjectForEditorElement(this).skipCurrentSelection()
 
+  provideService: ->
+    resultsMarkerLayerForTextEditor: @findModel.resultsMarkerLayerForTextEditor.bind(@findModel)
+
   createViews: ->
     return if @findView?
 

--- a/package.json
+++ b/package.json
@@ -35,5 +35,13 @@
   },
   "devDependencies": {
     "coffeelint": "^1.9.7"
+  },
+  "providedServices": {
+    "find-and-replace": {
+      "description": "Atom's bundled find-and-replace package",
+      "versions": {
+        "0.0.1": "provideService"
+      }
+    }
   }
 }

--- a/spec/buffer-search-spec.coffee
+++ b/spec/buffer-search-spec.coffee
@@ -436,6 +436,8 @@ describe "BufferSearch", ->
     it "creates or retrieves the results marker layer for the given editor", ->
       layer1 = model.resultsMarkerLayerForTextEditor(editor)
 
+      return unless layer1 # remove this guard after 1.3.0 hits stable channel
+
       # basic check that this is the expected results layer
       expect(layer1.findMarkers().length).toBeGreaterThan(0)
       for marker in layer1.findMarkers()

--- a/spec/buffer-search-spec.coffee
+++ b/spec/buffer-search-spec.coffee
@@ -431,3 +431,29 @@ describe "BufferSearch", ->
       expect(currentResultListener).toHaveBeenCalled()
       expect(currentResultListener.mostRecentCall.args[0].getBufferRange()).toEqual markers[2].getBufferRange()
       expect(currentResultListener.mostRecentCall.args[0].isDestroyed()).toBe false
+
+  describe ".prototype.resultsMarkerLayerForTextEditor(editor)", ->
+    it "creates or retrieves the results marker layer for the given editor", ->
+      layer1 = model.resultsMarkerLayerForTextEditor(editor)
+
+      # basic check that this is the expected results layer
+      expect(layer1.findMarkers().length).toBeGreaterThan(0)
+      for marker in layer1.findMarkers()
+        expect(editor.getTextInBufferRange(marker.getBufferRange())).toMatch /a+/
+
+      editor2 = buildTextEditor()
+      model.setEditor(editor2)
+      layer2 = model.resultsMarkerLayerForTextEditor(editor2)
+
+      model.setEditor(editor)
+      expect(model.resultsMarkerLayerForTextEditor(editor)).toBe layer1
+      expect(model.resultsMarkerLayerForTextEditor(editor2)).toBe layer2
+
+      model.search "c+",
+        caseSensitive: false
+        useRegex: true
+        wholeWord: false
+
+      expect(layer1.findMarkers().length).toBeGreaterThan(0)
+      for marker in layer1.findMarkers()
+        expect(editor.getTextInBufferRange(marker.getBufferRange())).toMatch /c+/


### PR DESCRIPTION
This PR adds a new `find-and-replace@0.0.1` service that exposes a single method `resultsMarkerLayerForTextEditor`. Give it a `TextEditor`, and it will return a marker layer used to store the search results for that editor. It returns null in versions of Atom prior to 1.3.0.

This should make it straightforward to fix packages that relied on finding find-and-replace markers in the default marker layer by simply wrapping introducing a service call to retrieve the appropriate layer for that editor before calling `findMarkers`. Everything else should remain the same.

I'm planning to hotfix this into beta tomorrow morning so it goes out with the introduction of layers.

Refs atom/atom#9208
/cc @abe33 @lee-dohm 