### PR TITLE
automatic search within selection

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -479,12 +479,12 @@ class FindView extends View
     @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
 
   activateSelectionOption: =>
-    @search(@findEditor.getText(),inCurrentSelection: true)
+    @search(@findEditor.getText(), inCurrentSelection: true)
     @model.getFindOptions().inCurrentSelection=true
     @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
 
   deactivateSelectionOption: =>
-    @search(@findEditor.getText(),inCurrentSelection: false)
+    @search(@findEditor.getText(), inCurrentSelection: false)
     @model.getFindOptions().inCurrentSelection=false
     @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
 

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -479,15 +479,13 @@ class FindView extends View
     @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
 
   activateSelectionOption: =>
-    @search(@findEditor.getText(), inCurrentSelection: true)
-    @model.getFindOptions().inCurrentSelection=true
-    @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
+    if !@model.getFindOptions().inCurrentSelection
+      @toggleSelectionOption()
 
   deactivateSelectionOption: =>
-    @search(@findEditor.getText(), inCurrentSelection: false)
-    @model.getFindOptions().inCurrentSelection=false
-    @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
-
+    if @model.getFindOptions().inCurrentSelection
+      @toggleSelectionOption()
+      
   updateReplaceEnablement: ->
     canReplace = @markers?.length > 0
     return if canReplace and not @replaceAllButton[0].classList.contains('disabled')

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -479,13 +479,13 @@ class FindView extends View
     @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
 
   activateSelectionOption: =>
-    if !@model.getFindOptions().inCurrentSelection
+    if not @model.getFindOptions().inCurrentSelection
       @toggleSelectionOption()
 
   deactivateSelectionOption: =>
     if @model.getFindOptions().inCurrentSelection
       @toggleSelectionOption()
-      
+
   updateReplaceEnablement: ->
     canReplace = @markers?.length > 0
     return if canReplace and not @replaceAllButton[0].classList.contains('disabled')

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -208,8 +208,12 @@ class FindView extends View
   focusFindEditor: =>
     selectedText = atom.workspace.getActiveTextEditor()?.getSelectedText?()
     if selectedText and selectedText.indexOf('\n') < 0
+      @deactivateSelectionOption()
       selectedText = Util.escapeRegex(selectedText) if @model.getFindOptions().useRegex
       @findEditor.setText(selectedText)
+    else if selectedText and selectedText.indexOf('\n') > 0
+      @activateSelectionOption()
+      @findEditor.setText("")
     @findEditor.focus()
     @findEditor.getModel().selectAll()
 
@@ -472,6 +476,16 @@ class FindView extends View
 
   toggleWholeWordOption: =>
     @search(@findEditor.getText(), wholeWord: not @model.getFindOptions().wholeWord)
+    @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
+
+  activateSelectionOption: =>
+    @search(@findEditor.getText(),inCurrentSelection: true)
+    @model.getFindOptions().inCurrentSelection=true
+    @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
+
+  deactivateSelectionOption: =>
+    @search(@findEditor.getText(),inCurrentSelection: false)
+    @model.getFindOptions().inCurrentSelection=false
     @selectFirstMarkerAfterCursor() unless @anyMarkersAreSelected()
 
   updateReplaceEnablement: ->


### PR DESCRIPTION
The objective of this enhancement is to automatically activate search within selection when find-and-replace is called and the selected text has one or more '/n' if no newline is found the selected text is used as the search pattern as it was implemented before.

Would love to have feedback both on my implementation (which is buggy, but at the moment I don't know how to fix it) and on the idea.
