### PR TITLE
Add package option to disable search-wrap icon

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -522,6 +522,7 @@ class FindView extends View
     @wrapIcon = $(wrapIcon)
 
   showWrapIcon: (icon) ->
+    return unless atom.config.get('find-and-replace.showSearchWrapIcon')
     editor = @model.getEditor()
     return unless editor?
     editorView = atom.views.getView(editor)

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -30,6 +30,11 @@ module.exports =
       default: false
       title: 'Scroll To Result On Live-Search (incremental find in buffer)'
       description: 'Scroll to and select the closest match while typing in the buffer find box.'
+    showSearchWrapIcon:
+      type: 'boolean'
+      default: true
+      title: 'Show Search Wrap Icon'
+      description: 'Display a visual cue over the editor when looping through search results.'
     liveSearchMinimumCharacters:
       type: 'integer'
       default: 3


### PR DESCRIPTION
The wrap-around icon added in #572 is a nice touch, but it might be (slightly) distracting to some users... I've added an option to control the visibility of the visual cue. It's enabled by default; turning it off will hide the overlay.