### PR TITLE
Project find panel default

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -18,7 +18,7 @@ module.exports =
       description: 'Focus the editor and select the next match when a file search is executed. If no matches are found, the editor will not be focused.'
     openProjectFindResultsInRightPane:
       type: 'boolean'
-      default: false
+      default: true
       description: 'When a project-wide search is executed, open the results in a split pane instead of a tab in the same pane.'
     closeFindPanelAfterSearch:
       type: 'boolean'


### PR DESCRIPTION
Changed default setting to use project find *side* panel.

Standard behaviour is having a tab created for every project find performed. It then gets focus taken off of it everytime you click one of your results. I propose to use side panel as default. One that stays visible when clicking one of the matches.