### PR TITLE
Add menu command to clear find/replace history.

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -109,6 +109,10 @@ module.exports =
       @findPanel.show()
       @findView.focusReplaceEditor()
 
+    @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:clear-history', =>
+      @findHistory.clear()
+      @replaceHistory.clear()
+
     # Handling cancel in the workspace + code editors
     handleEditorCancel = ({target}) =>
       isMiniEditor = target.tagName is 'ATOM-TEXT-EDITOR' and target.hasAttribute('mini')

--- a/lib/history.coffee
+++ b/lib/history.coffee
@@ -25,6 +25,10 @@ class History
     @length = @items.length
     @emitter.emit 'did-add-item', text
 
+  clear: ->
+    @items = []
+    @length = 0
+
 # Adds the ability to cycle through history
 class HistoryCycler
 

--- a/menus/find-and-replace.cson
+++ b/menus/find-and-replace.cson
@@ -15,6 +15,8 @@
     { 'label': 'Replace Next', 'command': 'find-and-replace:replace-next'}
     { 'label': 'Replace All', 'command': 'find-and-replace:replace-all'}
     { 'type': 'separator' }
+    { 'label': 'Clear History', 'command': 'find-and-replace:clear-history'}
+    { 'type': 'separator' }
   ]
 ]
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
       "find-and-replace:replace-next",
       "find-and-replace:replace-all",
       "find-and-replace:select-next",
-      "find-and-replace:select-all"
+      "find-and-replace:select-all",
+      "find-and-replace:clear-history"
     ]
   },
   "repository": "https://github.com/atom/find-and-replace",

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -174,6 +174,29 @@ describe 'FindView', ->
       runs ->
         expect(findView.replaceEditor.getText()).toBe 'function ()'
 
+  describe "when find-and-replace:clear-history is triggered", ->
+    it "clears the find and replace histories", ->
+      atom.commands.dispatch editorView, 'find-and-replace:show'
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        findView.findEditor.setText("items")
+        findView.replaceEditor.setText("cat")
+        findView.replaceAll()
+
+        findView.findEditor.setText("sort")
+        findView.replaceEditor.setText("dog")
+        findView.replaceNext()
+
+        atom.commands.dispatch editorView, 'find-and-replace:clear-history'
+
+        atom.commands.dispatch(findView.findEditor.element, 'core:move-up')
+        expect(findView.findEditor.getText()).toBe ''
+        atom.commands.dispatch(findView.replaceEditor.element, 'core:move-up')
+        expect(findView.replaceEditor.getText()).toBe ''
+
   describe "core:cancel", ->
     beforeEach ->
       atom.commands.dispatch editorView, 'find-and-replace:show'


### PR DESCRIPTION
Sometimes I search and replace sensitive info and I don't want to leave it laying around on the system. I added a menu item to allow a user to clear the find/replace history data.