### PR TITLE
Open file in pending state on single click

### DIFF
--- a/lib/project/match-view.coffee
+++ b/lib/project/match-view.coffee
@@ -42,12 +42,13 @@ class MatchView extends View
       @replacementText.text('').hide()
       @matchText.removeClass('highlight-error').addClass('highlight-info')
 
-  confirm: ->
+  confirm: (options = {}) ->
     openInRightPane = atom.config.get('find-and-replace.openProjectFindResultsInRightPane')
-    options = {}
-    options = {split: 'left'} if openInRightPane
-    atom.workspace.open(@filePath, options).then (editor) =>
+    options.split = 'left' if openInRightPane
+    editorPromise = atom.workspace.open(@filePath, options)
+    editorPromise.then (editor) =>
       editor.setSelectedBufferRange(@match.range, autoscroll: true)
+    editorPromise
 
   copy: ->
     atom.clipboard.write(@match.lineText)

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -15,11 +15,17 @@ class ResultsView extends ScrollView
     @pixelOverdraw = 100
     @lastRenderedResultIndex = 0
 
-    @on 'mousedown', '.match-result, .path', ({target, which, ctrlKey}) =>
+    @on 'mousedown', '.match-result, .path', (e) =>
       @find('.selected').removeClass('selected')
-      view = $(target).view()
+      view = $(e.target).view()
       view.addClass('selected')
-      view.confirm() if which is 1 and not ctrlKey
+      if not e.ctrlKey
+        if e.originalEvent?.detail is 1
+          @editorPromise = view.confirm(pending: true)
+        else if e.originalEvent?.detail is 2
+          @editorPromise?.then (editor) =>
+            editor.terminatePendingState?()
+        e.preventDefault()
       @renderResults()
 
     @on 'scroll', => @renderResults()

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -421,6 +421,29 @@ describe 'ResultsView', ->
       runs ->
         expect(atom.workspace.getActivePaneItem().getPath()).toContain('sample.')
 
+    it "opens the file containing the result in pending state when the search result is single-clicked", ->
+      pathNode = resultsView.find(".search-result")[0]
+      pathNode.dispatchEvent(buildMouseEvent('mousedown', target: pathNode, which: 1))
+      editor = null
+      waitsFor ->
+        editor = atom.workspace.getActiveTextEditor()
+
+      runs ->
+        expect(editor.isPending()).toBe true
+        expect(atom.views.getView(editor)).toHaveFocus()
+
+    it "opens the file containing the result in non-pending state when the search result is double-clicked", ->
+      pathNode = resultsView.find(".search-result")[0]
+      pathNode.dispatchEvent(buildMouseEvent('mousedown', target: pathNode, detail: 1))
+      pathNode.dispatchEvent(buildMouseEvent('mousedown', target: pathNode, detail: 2))
+      editor = null
+      waitsFor ->
+        editor = atom.workspace.getActiveTextEditor()
+
+      runs ->
+        expect(editor.isPending()).toBe false
+        expect(atom.views.getView(editor)).toHaveFocus()
+
     describe "when `openProjectFindResultsInRightPane` option is true", ->
       beforeEach ->
         atom.config.set('find-and-replace.openProjectFindResultsInRightPane', true)

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -421,28 +421,29 @@ describe 'ResultsView', ->
       runs ->
         expect(atom.workspace.getActivePaneItem().getPath()).toContain('sample.')
 
-    it "opens the file containing the result in pending state when the search result is single-clicked", ->
-      pathNode = resultsView.find(".search-result")[0]
-      pathNode.dispatchEvent(buildMouseEvent('mousedown', target: pathNode, which: 1))
-      editor = null
-      waitsFor ->
-        editor = atom.workspace.getActiveTextEditor()
+    if atom.workspace.buildTextEditor().isPending?
+      it "opens the file containing the result in pending state when the search result is single-clicked", ->
+        pathNode = resultsView.find(".search-result")[0]
+        pathNode.dispatchEvent(buildMouseEvent('mousedown', target: pathNode, which: 1))
+        editor = null
+        waitsFor ->
+          editor = atom.workspace.getActiveTextEditor()
 
-      runs ->
-        expect(editor.isPending()).toBe true
-        expect(atom.views.getView(editor)).toHaveFocus()
+        runs ->
+          expect(editor.isPending()).toBe true
+          expect(atom.views.getView(editor)).toHaveFocus()
 
-    it "opens the file containing the result in non-pending state when the search result is double-clicked", ->
-      pathNode = resultsView.find(".search-result")[0]
-      pathNode.dispatchEvent(buildMouseEvent('mousedown', target: pathNode, detail: 1))
-      pathNode.dispatchEvent(buildMouseEvent('mousedown', target: pathNode, detail: 2))
-      editor = null
-      waitsFor ->
-        editor = atom.workspace.getActiveTextEditor()
+      it "opens the file containing the result in non-pending state when the search result is double-clicked", ->
+        pathNode = resultsView.find(".search-result")[0]
+        pathNode.dispatchEvent(buildMouseEvent('mousedown', target: pathNode, detail: 1))
+        pathNode.dispatchEvent(buildMouseEvent('mousedown', target: pathNode, detail: 2))
+        editor = null
+        waitsFor ->
+          editor = atom.workspace.getActiveTextEditor()
 
-      runs ->
-        expect(editor.isPending()).toBe false
-        expect(atom.views.getView(editor)).toHaveFocus()
+        runs ->
+          expect(editor.isPending()).toBe false
+          expect(atom.views.getView(editor)).toHaveFocus()
 
     describe "when `openProjectFindResultsInRightPane` option is true", ->
       beforeEach ->


### PR DESCRIPTION
Single click on search result opens file in pending state. Double click opens file in regular non-pending state.

Corresponds to [atom/atom/pull/10178](https://github.com/atom/atom/pull/10178)
Addresses [atom/atom/issues/9165](https://github.com/atom/atom/issues/9165)

Specs included. 