### PR TITLE
Focus project-find search input upon toggle

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -60,19 +60,11 @@ module.exports =
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:show', =>
       @createViews()
-      @findPanel.hide()
-      @projectFindPanel.show()
-      @projectFindView.focusFindElement()
+      showPanel(@projectFindPanel, @findPanel, @projectFindView.focusFindElement)
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:toggle', =>
       @createViews()
-      @findPanel.hide()
-
-      if @projectFindPanel.isVisible()
-        @projectFindPanel.hide()
-      else
-        @projectFindPanel.show()
-        @projectFindView.focusFindElement()
+      togglePanel @projectFindPanel, @findPanel, @projectFindView.focusFindElement
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:show-in-current-directory', ({target}) =>
       @createViews()
@@ -90,25 +82,15 @@ module.exports =
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:toggle', =>
       @createViews()
-      @projectFindPanel.hide()
-
-      if @findPanel.isVisible()
-        @findPanel.hide()
-      else
-        @findPanel.show()
-        @findView.focusFindEditor()
+      togglePanel @findPanel, @projectFindPanel, @findView.focusFindEditor
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:show', =>
       @createViews()
-      @projectFindPanel.hide()
-      @findPanel.show()
-      @findView.focusFindEditor()
+      showPanel @findPanel, @projectFindPanel, @findView.focusFindEditor
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:show-replace', =>
       @createViews()
-      @projectFindPanel?.hide()
-      @findPanel.show()
-      @findView.focusReplaceEditor()
+      showPanel @findPanel, @projectFindPanel, @findView.focusReplaceEditor
 
     # Handling cancel in the workspace + code editors
     handleEditorCancel = ({target}) =>
@@ -129,6 +111,20 @@ module.exports =
         selectNext = new SelectNext(editor)
         @selectNextObjects.set(editor, selectNext)
       selectNext
+
+    showPanel = (panelToShow, panelToHide, action) ->
+      panelToHide.hide()
+      panelToShow.show()
+      if action then action()
+
+    togglePanel = (panelToToggle, panelToHide, action) ->
+      panelToHide.hide()
+
+      if panelToToggle.isVisible()
+        panelToToggle.hide()
+      else
+        panelToToggle.show()
+        if action then action()
 
     atom.commands.add '.editor:not(.mini)',
       'find-and-replace:select-next': (event) ->

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -72,6 +72,7 @@ module.exports =
         @projectFindPanel.hide()
       else
         @projectFindPanel.show()
+        @projectFindView.focusFindElement()
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:show-in-current-directory', ({target}) =>
       @createViews()

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -60,7 +60,7 @@ module.exports =
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:show', =>
       @createViews()
-      showPanel @projectFindPanel, @findPanel, @projectFindView.focusFindElement 
+      showPanel @projectFindPanel, @findPanel, @projectFindView.focusFindElement
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:toggle', =>
       @createViews()

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -60,7 +60,7 @@ module.exports =
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:show', =>
       @createViews()
-      showPanel(@projectFindPanel, @findPanel, @projectFindView.focusFindElement)
+      showPanel @projectFindPanel, @findPanel, @projectFindView.focusFindElement 
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'project-find:toggle', =>
       @createViews()

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -199,7 +199,7 @@ class ProjectFindView extends View
 
     @subscriptions.add @model.onDidFinishReplacing (result) => @onFinishedReplacing(result)
 
-  focusNextElement: (direction) ->
+  focusNextElement: (direction) =>
     elements = [@findEditor, @replaceEditor, @pathsEditor]
     focusedElement = _.find elements, (el) -> el.hasClass('is-focused')
     focusedIndex = elements.indexOf focusedElement
@@ -210,7 +210,7 @@ class ProjectFindView extends View
     elements[focusedIndex].focus()
     elements[focusedIndex].getModel?().selectAll()
 
-  focusFindElement: ->
+  focusFindElement: =>
     selectedText = atom.workspace.getActiveTextEditor()?.getSelectedText?()
     if selectedText and selectedText.indexOf('\n') < 0
       selectedText = Util.escapeRegex(selectedText) if @model.getFindOptions().useRegex


### PR DESCRIPTION
This PR adds the following change: when toggling the project-find panel via the ``project-find:toggle`` command from an invisible state, the search input is focused after the panel becomes visible. This is preferable for the following reasons:

* This exact behaviour is the default for the ``find-and-replace:toggle`` command. Enabling the same behaviour for ``project-find:toggle`` makes find-and-replace more consistent from a UX perspective.
* Some people prefer to use toggling instead of showing and dismissing via ``Esc`` and create according key bindings in their ``keymap.cson``. In such cases it's convenient to also focus the search input.