### PR TITLE
On second click, open without `pending` option

### DIFF
--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -21,10 +21,9 @@ class ResultsView extends ScrollView
       view.addClass('selected')
       if not e.ctrlKey
         if e.originalEvent?.detail is 1
-          @editorPromise = view.confirm(pending: true)
+          view.confirm(pending: true)
         else if e.originalEvent?.detail is 2
-          @editorPromise?.then (editor) =>
-            editor.terminatePendingState?()
+          view.confirm()
         e.preventDefault()
       @renderResults()
 


### PR DESCRIPTION
Merge once Atom v1.7.0 is released

With https://github.com/atom/atom/pull/10872 it’s no longer necessary to 
explicitly `terminatePendingState` here