### PR TITLE
Fix exception when double-clicking file name from results view

### DIFF
--- a/lib/project/result-view.coffee
+++ b/lib/project/result-view.coffee
@@ -80,3 +80,4 @@ class ResultView extends View
 
   confirm: ->
     @expand(not @isExpanded)
+    null

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -23,7 +23,7 @@ class ResultsView extends ScrollView
         if e.originalEvent?.detail is 1
           @editorPromise = view.confirm(pending: true)
         else if e.originalEvent?.detail is 2
-          @editorPromise?.then (editor) =>
+          @editorPromise?.then? (editor) =>
             if atom.workspace.getActivePane().getPendingItem?
               atom.workspace.getActivePane().clearPendingItem() if atom.workspace.getActivePane().getPendingItem() is editor
             else if editor.terminatePendingState?


### PR DESCRIPTION
`confirm` from `ResultView` returns a boolean, so `editorPromise?.then` fails with an exception. This (1) fixes the issue in `ResultView`, and (2) ensures that the thing we get back from `confirm` is actually promise-like by checking for the existence of a `then` method.

/cc @kuychaco 