### PR TITLE
Fix future DisplayLayer deprecation by setting `maintainHistory` on the MarkerLayer

### DIFF
--- a/lib/buffer-search.coffee
+++ b/lib/buffer-search.coffee
@@ -54,7 +54,7 @@ class BufferSearch
 
   resultsMarkerLayerForTextEditor: (editor) ->
     unless layer = ResultsMarkerLayersByEditor.get(editor)
-      layer = editor.addMarkerLayer?()
+      layer = editor.addMarkerLayer({maintainHistory: false})
       ResultsMarkerLayersByEditor.set(editor, layer)
     layer
 
@@ -201,11 +201,7 @@ class BufferSearch
     @createMarker(marker.getBufferRange())
 
   createMarker: (range) ->
-    marker = @resultsMarkerLayer.markBufferRange(range,
-      invalidate: 'inside'
-      persistent: false
-      maintainHistory: false
-    )
+    marker = @resultsMarkerLayer.markBufferRange(range, {invalidate: 'inside'})
     marker
 
   bufferChanged: ({oldRange, newRange, newText}) ->


### PR DESCRIPTION
This fixes a leftover deprecation I missed on #697. It should work just fine also on atom stable/beta.