### PR TITLE
Ability to see context of project search results - More lines

### DIFF
--- a/lib/project/match-view.coffee
+++ b/lib/project/match-view.coffee
@@ -13,8 +13,9 @@ class MatchView extends View
     prefix = removeLeadingWhitespace(match.lineText[0...matchStart])
     suffix = match.lineText[matchEnd..]
     lines = match.lines
-    prefixLines = lines.slice(0, 2)
-    suffixLines = lines.slice(2+1)
+    contextLines = atom.config.get('find-and-replace.searchContextExtraLines')
+    prefixLines = lines.slice(0, contextLines)
+    suffixLines = lines.slice(contextLines+1)
     @pre =>
       for line, index in prefixLines
         @li class: 'search-result list-item', =>

--- a/lib/project/match-view.coffee
+++ b/lib/project/match-view.coffee
@@ -15,7 +15,7 @@ class MatchView extends View
     lines = match.lines
     contextLines = atom.config.get('find-and-replace.searchContextExtraLines')
     prefixLines = lines.slice(0, contextLines)
-    suffixLines = lines.slice(contextLines+1)
+    suffixLines = lines.slice(contextLines + 1)
     @pre =>
       for line, index in prefixLines
         @li class: 'search-result list-item', =>

--- a/lib/project/match-view.coffee
+++ b/lib/project/match-view.coffee
@@ -15,7 +15,7 @@ class MatchView extends View
     lines = atom.project.findBufferForPath(filePath)?.lines
     prefixLines = []
     suffixLines = []
-    if lines.length
+    if lines
       prefixLines = lines?.slice(range.start.row - 2, range.start.row)
       suffixLines = lines?.slice(range.end.row + 1, range.end.row + 2 + 1)
     @div =>

--- a/lib/project/match-view.coffee
+++ b/lib/project/match-view.coffee
@@ -12,13 +12,13 @@ class MatchView extends View
     matchEnd = range.end.column - match.lineTextOffset
     prefix = removeLeadingWhitespace(match.lineText[0...matchStart])
     suffix = match.lineText[matchEnd..]
-    lines = atom.project.findBufferForPath(filePath)?.lines
+    lines = model.results[filePath].lines
     prefixLines = []
     suffixLines = []
     if lines
       prefixLines = lines?.slice(range.start.row - 2, range.start.row)
       suffixLines = lines?.slice(range.end.row + 1, range.end.row + 2 + 1)
-    @div =>
+    @pre =>
       for line, index in prefixLines
         @li class: 'search-result list-item', =>
           @span range.start.row + 1 - prefixLines.length + index, class: 'line-number text-subtle'

--- a/lib/project/match-view.coffee
+++ b/lib/project/match-view.coffee
@@ -13,13 +13,15 @@ class MatchView extends View
     prefix = removeLeadingWhitespace(match.lineText[0...matchStart])
     suffix = match.lineText[matchEnd..]
     lines = atom.project.findBufferForPath(filePath)?.lines
-
-    prefixLines = lines.slice(range.start.row - 2, range.start.row)
-    suffixLines = lines.slice(range.end.row + 1, range.end.row + 2 + 1)
+    prefixLines = []
+    suffixLines = []
+    if lines.length
+      prefixLines = lines?.slice(range.start.row - 2, range.start.row)
+      suffixLines = lines?.slice(range.end.row + 1, range.end.row + 2 + 1)
     @div =>
       for line, index in prefixLines
         @li class: 'search-result list-item', =>
-          @span range.start.row - prefixLines.length + index, class: 'line-number text-subtle'
+          @span range.start.row + 1 - prefixLines.length + index, class: 'line-number text-subtle'
           @span class: 'preview', outlet: 'preview', =>
             @span line
       @li class: 'search-result list-item', =>
@@ -31,7 +33,7 @@ class MatchView extends View
           @span suffix
       for line, index in suffixLines
         @li class: 'search-result list-item', =>
-          @span range.end.row + 1 + index, class: 'line-number text-subtle'
+          @span range.end.row + 1 + index + 1, class: 'line-number text-subtle'
           @span class: 'preview', outlet: 'preview', =>
             @span line
 

--- a/lib/project/match-view.coffee
+++ b/lib/project/match-view.coffee
@@ -12,12 +12,9 @@ class MatchView extends View
     matchEnd = range.end.column - match.lineTextOffset
     prefix = removeLeadingWhitespace(match.lineText[0...matchStart])
     suffix = match.lineText[matchEnd..]
-    lines = model.results[filePath].lines
-    prefixLines = []
-    suffixLines = []
-    if lines
-      prefixLines = lines?.slice(range.start.row - 2, range.start.row)
-      suffixLines = lines?.slice(range.end.row + 1, range.end.row + 2 + 1)
+    lines = match.lines
+    prefixLines = lines.slice(0, 2)
+    suffixLines = lines.slice(2+1)
     @pre =>
       for line, index in prefixLines
         @li class: 'search-result list-item', =>

--- a/lib/project/match-view.coffee
+++ b/lib/project/match-view.coffee
@@ -12,14 +12,28 @@ class MatchView extends View
     matchEnd = range.end.column - match.lineTextOffset
     prefix = removeLeadingWhitespace(match.lineText[0...matchStart])
     suffix = match.lineText[matchEnd..]
+    lines = atom.project.findBufferForPath(filePath)?.lines
 
-    @li class: 'search-result list-item', =>
-      @span range.start.row + 1, class: 'line-number text-subtle'
-      @span class: 'preview', outlet: 'preview', =>
-        @span prefix
-        @span match.matchText, class: 'match highlight-info', outlet: 'matchText'
-        @span match.matchText, class: 'replacement highlight-success', outlet: 'replacementText'
-        @span suffix
+    prefixLines = lines.slice(range.start.row - 2, range.start.row)
+    suffixLines = lines.slice(range.end.row + 1, range.end.row + 2 + 1)
+    @div =>
+      for line, index in prefixLines
+        @li class: 'search-result list-item', =>
+          @span range.start.row - prefixLines.length + index, class: 'line-number text-subtle'
+          @span class: 'preview', outlet: 'preview', =>
+            @span line
+      @li class: 'search-result list-item', =>
+        @span range.start.row + 1, class: 'line-number text-subtle'
+        @span class: 'preview', outlet: 'preview', =>
+          @span prefix
+          @span match.matchText, class: 'match highlight-info', outlet: 'matchText'
+          @span match.matchText, class: 'replacement highlight-success', outlet: 'replacementText'
+          @span suffix
+      for line, index in suffixLines
+        @li class: 'search-result list-item', =>
+          @span range.end.row + 1 + index, class: 'line-number text-subtle'
+          @span class: 'preview', outlet: 'preview', =>
+            @span line
 
   initialize: (@model, {@filePath, @match}) ->
     @render()

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -210,10 +210,12 @@ class ResultsModel
       filePathInsertedIndex = binaryIndex(@paths, filePath, stringCompare)
       @paths.splice(filePathInsertedIndex, 0, filePath)
 
-    @matchCount += result.matches.length
-
-    @results[filePath] = result
-    @emitter.emit 'did-add-result', {filePath, result, filePathInsertedIndex}
+    bufferPromise = atom.project.buildBuffer(filePath)
+    bufferPromise.then (buffer) =>
+      result.lines = buffer.lines
+      @matchCount += result.matches.length
+      @results[filePath] = result
+      @emitter.emit 'did-add-result', {filePath, result, filePathInsertedIndex}
 
   removeResult: (filePath) ->
     if @results[filePath]

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -1,5 +1,5 @@
 _ = require 'underscore-plus'
-{Emitter} = require 'atom'
+{Emitter, Range} = require 'atom'
 escapeHelper = require '../escape-helper'
 
 class Result
@@ -212,7 +212,9 @@ class ResultsModel
 
     bufferPromise = atom.project.buildBuffer(filePath)
     bufferPromise.then (buffer) =>
-      result.lines = buffer.lines
+      for match in result.matches
+        range = Range.fromObject(match.range)
+        match.lines = buffer.lines.slice(range.start.row, range.start.row+2+1+2)
       @matchCount += result.matches.length
       @results[filePath] = result
       @emitter.emit 'did-add-result', {filePath, result, filePathInsertedIndex}

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -215,7 +215,7 @@ class ResultsModel
       for match in result.matches
         range = Range.fromObject(match.range)
         linesAmount = atom.config.get('find-and-replace.searchContextExtraLines')
-        match.lines = buffer.lines.slice(range.start.row, range.start.row+linesAmount*2+1)
+        match.lines = buffer.lines.slice(range.start.row-linesAmount, range.end.row+linesAmount+1)
       @matchCount += result.matches.length
       @results[filePath] = result
       @emitter.emit 'did-add-result', {filePath, result, filePathInsertedIndex}

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -214,7 +214,8 @@ class ResultsModel
     bufferPromise.then (buffer) =>
       for match in result.matches
         range = Range.fromObject(match.range)
-        match.lines = buffer.lines.slice(range.start.row, range.start.row+2+1+2)
+        linesAmount = atom.config.get('find-and-replace.searchContextExtraLines')
+        match.lines = buffer.lines.slice(range.start.row, range.start.row+linesAmount*2+1)
       @matchCount += result.matches.length
       @results[filePath] = result
       @emitter.emit 'did-add-result', {filePath, result, filePathInsertedIndex}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,12 @@
       "minimum": 0,
       "description": "The minimum number of characters which need to be typed into the buffer find box before search starts matching and highlighting matches as you type."
     },
+    "searchContextExtraLines": {
+      "type": "integer",
+      "default": 1,
+      "minimum": 0,
+      "description": "The amount of extra lines of context to show for project results"
+    },
     "showSearchWrapIcon": {
       "type": "boolean",
       "default": true,


### PR DESCRIPTION
Closes #190 
This is my first contribution to an official core atom package.

I know that this PR is missing the ability to configure the amount of lines to see.
Any hints on how to improve this PR is very much appreciated.

I acknowledge the importance of this package to work properly, so please point out any required improvements.

The additions are not tested via Jasmine/Mocha or whatever testing engine you use. No specs provided.

**Features**
- [x] Show extra lines of context
- [ ] Correct indentation
- [ ] Overlapping lines should resolve to only show what is required
- [ ] Gaps between code in the same file should be expandable (max gap: 3 lines?)
- [x] Set amount of lines to see via config
- [ ] Results on the same line or context should appear on that result
- [ ] Remove empty lines in result (maybe)
- [ ] Syntax highlighting (maybe)

**Fixing known issues**
- [ ] Arrow Key navigation
- [ ] Even if there are results, the statusbars say "No results for ..."
- [x] Only buildBuffer or save lines that are required within the model

**Current Status**
![image](https://cloud.githubusercontent.com/assets/2950505/14427033/cacd65fa-fff2-11e5-9fe5-c1b9f920a078.png)
