### PR TITLE
Watch paths to remove results on file deletion

### DIFF
--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -72,6 +72,7 @@ class ResultsModel
     @matchCount = 0
     @regex = null
     @results = {}
+    @watchSubscriptions[path].close() for path of @watchSubscriptions
     @watchSubscriptions = {}
     @paths = []
     @active = false

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -72,6 +72,7 @@ class ResultsModel
     @matchCount = 0
     @regex = null
     @results = {}
+    @watchSubscriptions = {}
     @paths = []
     @active = false
     @searchErrors = null
@@ -203,7 +204,7 @@ class ResultsModel
       @removeResult(filePath)
 
   addResult: (filePath, result) ->
-    watch filePath, (eventType) =>
+    @watchSubscriptions[filePath] = watch filePath, (eventType) =>
       @removeResult(filePath) if eventType is 'delete'
     filePathInsertedIndex = null
     if @results[filePath]
@@ -219,6 +220,10 @@ class ResultsModel
     @emitter.emit 'did-add-result', {filePath, result, filePathInsertedIndex}
 
   removeResult: (filePath) ->
+    if @watchSubscriptions[filePath]?
+      @watchSubscriptions[filePath].close()
+      delete @watchSubscriptions[filePath]
+
     if @results[filePath]
       @pathCount--
       @matchCount -= @results[filePath].matches.length

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -1,6 +1,7 @@
 _ = require 'underscore-plus'
 {Emitter} = require 'atom'
 escapeHelper = require '../escape-helper'
+{watch} = require 'pathwatcher'
 
 class Result
   @create: (result) ->
@@ -202,6 +203,8 @@ class ResultsModel
       @removeResult(filePath)
 
   addResult: (filePath, result) ->
+    watch filePath, (eventType) =>
+      @removeResult(filePath) if eventType is 'delete'
     filePathInsertedIndex = null
     if @results[filePath]
       @matchCount -= @results[filePath].matches.length

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "atom-space-pen-views": "^2.1.0",
     "fs-plus": "2.x",
+    "pathwatcher": "^6.3.1",
     "temp": "0.8.1",
     "underscore-plus": "1.x"
   },


### PR DESCRIPTION
**WORK IN PROGRESS** 

Fixes https://github.com/atom/find-and-replace/issues/634.

Current specs are failing when adding results manually ([like here](https://github.com/atom/find-and-replace/blob/master/spec/results-view-spec.coffee#L69)), as `node-patwatcher` is unable to watch the path.
Specs for the introduced change are missing.
