### PR TITLE
Enable autocompletion in the find editor

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -14,6 +14,9 @@ class FindView extends View
       softWrapped: false
       buffer: findBuffer
       placeholderText: 'Find in current buffer'
+    if atom.textEditors?
+      disposable = atom.textEditors.add(findEditor)
+      findEditor.onDidDestroy -> disposable.dispose()
 
     replaceEditor = buildTextEditor
       mini: true

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -115,6 +115,16 @@ module.exports =
       'find-and-replace:select-skip': (event) ->
         selectNextObjectForEditorElement(this).skipCurrentSelection()
 
+    # Request autocompletions for the find field.
+    autocompletePackage = atom.packages.activePackages['autocomplete-plus']
+    if autocompletePackage?
+      autocompleteManager = autocompletePackage.mainModule.autocompleteManager
+      for providerData in autocompleteManager.providerManager.providers
+        if providerData.provider.constructor.name is 'SymbolProvider'
+          providerData.provider.addTextEditorSelector?(
+            '.find-container atom-text-editor')
+          break
+
   provideService: ->
     resultsMarkerLayerForTextEditor: @findModel.resultsMarkerLayerForTextEditor.bind(@findModel)
 


### PR DESCRIPTION
This PR enables autocompletion in the find editor by:
1. Registering the find editor so it's observable by `autocomplete-plus`
2. Adding a corresponding CSS selector to `SymbolProvider` so it knows to provide completions for that editor.

Fixes atom/find-and-replace#92

/cc @as-cii 
