### PR TITLE
Add ability to pull selected text into replace field

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -16,6 +16,7 @@
   'cmd-ctrl-g': 'find-and-replace:select-all'
   'cmd-d': 'find-and-replace:select-next'
   'cmd-e': 'find-and-replace:use-selection-as-find-pattern'
+  'cmd-shift-e': 'find-and-replace:use-selection-as-replace-pattern'
   'cmd-u': 'find-and-replace:select-undo'
   'cmd-k cmd-d': 'find-and-replace:select-skip'
 
@@ -27,6 +28,7 @@
   'alt-f3': 'find-and-replace:select-all'
   'ctrl-d': 'find-and-replace:select-next'
   'ctrl-e': 'find-and-replace:use-selection-as-find-pattern'
+  'ctrl-shift-e': 'find-and-replace:use-selection-as-replace-pattern'
   'ctrl-u': 'find-and-replace:select-undo'
   'ctrl-k ctrl-d': 'find-and-replace:select-skip'
 

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -196,6 +196,7 @@ class FindView extends View
       'find-and-replace:find-next-selected': @findNextSelected
       'find-and-replace:find-previous-selected': @findPreviousSelected
       'find-and-replace:use-selection-as-find-pattern': @setSelectionAsFindPattern
+      'find-and-replace:use-selection-as-replace-pattern': @setSelectionAsReplacePattern
 
   handleReplaceEvents: ->
     @replaceNextButton.on 'click', @replaceNext
@@ -427,6 +428,16 @@ class FindView extends View
       findPattern = editor.getSelectedText() or editor.getWordUnderCursor()
       findPattern = Util.escapeRegex(findPattern) if @model.getFindOptions().useRegex
       @search(findPattern) if findPattern
+
+  setSelectionAsReplacePattern: =>
+    editor = @model.getEditor()
+    if editor?.getSelectedText?
+      replacePattern = editor.getSelectedText() or editor.getWordUnderCursor()
+      replacePattern = Util.escapeRegex(replacePattern) if @model.getFindOptions().useRegex
+      if replacePattern
+        @replaceEditor.setText(replacePattern)
+        @replaceEditor.focus()
+        @replaceEditor.getModel().selectAll()
 
   findNextSelected: =>
     @setSelectionAsFindPattern()

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -50,13 +50,18 @@ module.exports =
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:use-selection-as-find-pattern', =>
       return if @projectFindPanel?.isVisible() or @findPanel?.isVisible()
 
+      @createViews()
+      @projectFindPanel.hide()
+      @findPanel.show()
+      @findView.focusFindEditor()
+
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:use-selection-as-replace-pattern', =>
       return if @projectFindPanel?.isVisible() or @findPanel?.isVisible()
 
       @createViews()
       @projectFindPanel.hide()
       @findPanel.show()
-      @findView.focusFindEditor()
+      @findView.focusReplaceEditor()
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:toggle', =>
       @createViews()

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -50,6 +50,9 @@ module.exports =
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:use-selection-as-find-pattern', =>
       return if @projectFindPanel?.isVisible() or @findPanel?.isVisible()
 
+    @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:use-selection-as-replace-pattern', =>
+      return if @projectFindPanel?.isVisible() or @findPanel?.isVisible()
+
       @createViews()
       @projectFindPanel.hide()
       @findPanel.show()

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -49,11 +49,7 @@ module.exports =
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:use-selection-as-find-pattern', =>
       return if @projectFindPanel?.isVisible() or @findPanel?.isVisible()
-
-      @createViews()
-      @projectFindPanel.hide()
-      @findPanel.show()
-      @findView.focusFindEditor()
+      showPanel @findPanel, @projectFindPanel, => @findView.focusReplaceEditor()
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:use-selection-as-replace-pattern', =>
       return if @projectFindPanel?.isVisible() or @findPanel?.isVisible()

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -133,6 +133,8 @@ class ProjectFindView extends View
   handleEvents: ->
     @subscriptions.add atom.commands.add 'atom-workspace',
       'find-and-replace:use-selection-as-find-pattern': @setSelectionAsFindPattern
+    @subscriptions.add atom.commands.add 'atom-workspace',
+      'find-and-replace:use-selection-as-replace-pattern': @setSelectionAsReplacePattern
 
     @subscriptions.add atom.commands.add @element,
       'find-and-replace:focus-next': => @focusNextElement(1)
@@ -345,6 +347,13 @@ class ProjectFindView extends View
       pattern = editor.getSelectedText() or editor.getWordUnderCursor()
       pattern = Util.escapeRegex(pattern) if @model.getFindOptions().useRegex
       @findEditor.setText(pattern) if pattern
+
+  setSelectionAsReplacePattern: =>
+    editor = atom.workspace.getActivePaneItem()
+    if editor?.getSelectedText?
+      pattern = editor.getSelectedText() or editor.getWordUnderCursor()
+      pattern = Util.escapeRegex(pattern) if @model.getFindOptions().useRegex
+      @replaceEditor.setText(pattern) if pattern
 
   updateOptionViews: =>
     @updateOptionButtons()

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "find-and-replace:find-next-selected",
       "find-and-replace:find-previous-selected",
       "find-and-replace:use-selection-as-find-pattern",
+      "find-and-replace:use-selection-as-replace-pattern",
       "find-and-replace:show-replace",
       "find-and-replace:replace-next",
       "find-and-replace:replace-all",

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -704,6 +704,52 @@ describe 'FindView', ->
         atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
         expect(findView.findEditor.getText()).toBe 'current < pivot \\? left\\.push\\(current\\) : right\\.push\\(current\\);'
 
+    describe "when find-and-replace:use-selection-as-replace-pattern is triggered", ->
+      it "places the selected text into the replace editor", ->
+        editor.setSelectedBufferRange([[3, 8], [3, 13]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-replace-pattern'
+        expect(findView.replaceEditor.getText()).toBe 'pivot'
+        expect(editor.getSelectedBufferRange()).toEqual [[3, 8], [3, 13]]
+
+        findView.findEditor.setText('sort')
+        atom.commands.dispatch workspaceElement, 'find-and-replace:find-next'
+        expect(editor.getSelectedBufferRange()).toEqual [[8, 11], [8, 15]]
+        expect(editor.getTextInBufferRange(editor.getSelectedBufferRange())).toEqual 'sort'
+        atom.commands.dispatch workspaceElement, 'find-and-replace:replace-next'
+        expect(editor.getTextInBufferRange([[8, 11], [8, 16]])).toEqual 'pivot'
+        expect(editor.getSelectedBufferRange()).toEqual [[8, 44], [8, 48]]
+        expect(editor.getTextInBufferRange(editor.getSelectedBufferRange())).toEqual 'sort'
+
+      it "places the word under the cursor into the replace editor", ->
+        editor.setSelectedBufferRange([[3, 8], [3, 8]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-replace-pattern'
+        expect(findView.replaceEditor.getText()).toBe 'pivot'
+        expect(editor.getSelectedBufferRange()).toEqual [[3, 8], [3, 8]]
+
+        findView.findEditor.setText('sort')
+        atom.commands.dispatch workspaceElement, 'find-and-replace:find-next'
+        expect(editor.getSelectedBufferRange()).toEqual [[8, 11], [8, 15]]
+        expect(editor.getTextInBufferRange(editor.getSelectedBufferRange())).toEqual 'sort'
+        atom.commands.dispatch workspaceElement, 'find-and-replace:replace-next'
+        expect(editor.getTextInBufferRange([[8, 11], [8, 16]])).toEqual 'pivot'
+        expect(editor.getSelectedBufferRange()).toEqual [[8, 44], [8, 48]]
+        expect(editor.getTextInBufferRange(editor.getSelectedBufferRange())).toEqual 'sort'
+
+      it "places the previously selected text into the replace editor if no selection", ->
+        editor.setSelectedBufferRange([[1, 6], [1, 10]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-replace-pattern'
+        expect(findView.replaceEditor.getText()).toBe 'sort'
+
+        editor.setSelectedBufferRange([[1, 1], [1, 1]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-replace-pattern'
+        expect(findView.replaceEditor.getText()).toBe 'sort'
+
+      it "places selected text into the replace editor and escapes it when Regex is enabled", ->
+        atom.commands.dispatch(findView.replaceEditor.element, 'find-and-replace:toggle-regex-option')
+        editor.setSelectedBufferRange([[6, 6], [6, 65]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-replace-pattern'
+        expect(findView.replaceEditor.getText()).toBe 'current < pivot \\? left\\.push\\(current\\) : right\\.push\\(current\\);'
+
     describe "when find-and-replace:find-next-selected is triggered", ->
       it "places the selected text into the find editor and finds the next occurrence", ->
         editor.setSelectedBufferRange([[0, 9], [0, 13]])

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -813,6 +813,40 @@ describe 'ProjectFindView', ->
         atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
         expect(projectFindView.findEditor.getText()).toBe 'current < pivot \\? left\\.push\\(current\\) : right\\.push\\(current\\);'
 
+    describe "when find-and-replace:use-selection-as-replace-pattern is triggered", ->
+      it "places the selected text into the replace editor", ->
+        editor.setSelectedBufferRange([[1, 6], [1, 10]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-replace-pattern'
+        expect(projectFindView.replaceEditor.getText()).toBe 'sort'
+
+        editor.setSelectedBufferRange([[1, 13], [1, 21]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-replace-pattern'
+        expect(projectFindView.replaceEditor.getText()).toBe 'function'
+
+      it "places the word under the cursor into the replace editor", ->
+        editor.setSelectedBufferRange([[1, 8], [1, 8]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-replace-pattern'
+        expect(projectFindView.replaceEditor.getText()).toBe 'sort'
+
+        editor.setSelectedBufferRange([[1, 15], [1, 15]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-replace-pattern'
+        expect(projectFindView.replaceEditor.getText()).toBe 'function'
+
+      it "places the previously selected text into the replace editor if no selection and no word under cursor", ->
+        editor.setSelectedBufferRange([[1, 13], [1, 21]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-replace-pattern'
+        expect(projectFindView.replaceEditor.getText()).toBe 'function'
+
+        editor.setSelectedBufferRange([[1, 1], [1, 1]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-replace-pattern'
+        expect(projectFindView.replaceEditor.getText()).toBe 'function'
+
+      it "places selected text into the replace editor and escapes it when Regex is enabled", ->
+        atom.commands.dispatch(projectFindView[0], 'project-find:toggle-regex-option')
+        editor.setSelectedBufferRange([[6, 6], [6, 65]])
+        atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-replace-pattern'
+        expect(projectFindView.replaceEditor.getText()).toBe 'current < pivot \\? left\\.push\\(current\\) : right\\.push\\(current\\);'
+
     describe "when there is an error searching", ->
       it "displays the errors in the results pane", ->
         [callback, resolve, called, resultsPaneView, errorList] = []


### PR DESCRIPTION
…t-e for slurpping selected text into replace field, as requested in #67

The hotkey is cmd-shift-e for Mac, and ctrl-shift-e for Windows/Linux. If this pull request and pull request #713 are accepted, then issue #67 should be resolved.

Please let me know if you have any feedback on this pull request. It's my first time writing specs! Thanks very much in advance.
