### PR TITLE
Add an "Instant Search" setting that removes the 300ms delay

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -188,7 +188,8 @@ class FindView extends View
       workspaceElement.focus()
 
   handleFindEvents: ->
-    @findEditor.getModel().onDidStopChanging => @liveSearch()
+    changeEventListener = if atom.config.get('find-and-replace.instantSearch') then 'onDidChange' else 'onDidStopChanging'
+    @findEditor.getModel()[changeEventListener] => @liveSearch()
     @nextButton.on 'click', (e) => if e.shiftKey then @findPrevious(focusEditorAfter: true) else @findNext(focusEditorAfter: true)
     @subscriptions.add atom.commands.add 'atom-workspace',
       'find-and-replace:find-next': => @findNext(focusEditorAfter: true)

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "instantSearch": {
       "type": "boolean",
       "default": false,
-      "description": "Search as you type, instead of waiting until you stop typing. You need to restart Atom for changes to this setting to take effect."
+      "description": "Search as you type, instead of waiting until you stop typing."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
       "default": true,
       "title": "Show Search Wrap Icon",
       "description": "Display a visual cue over the editor when looping through search results."
+    },
+    "instantSearch": {
+      "type": "boolean",
+      "default": false,
+      "description": "Search as you type, instead of waiting until you stop typing. You need to restart Atom for changes to this setting to take effect."
     }
   }
 }


### PR DESCRIPTION
I'm sure there's a way to avoid having to restart Atom after the Instant Search setting is toggled, but I don't know how to do that. I'm open to any and all suggestions.
