### PR TITLE
Add logic to consume file-icons service

### DIFF
--- a/lib/default-file-icons.coffee
+++ b/lib/default-file-icons.coffee
@@ -1,0 +1,23 @@
+fs = require 'fs-plus'
+path = require 'path'
+
+class DefaultFileIcons
+  iconClassForPath: (filePath) ->
+    extension = path.extname(filePath)
+
+    if fs.isSymbolicLinkSync(filePath)
+      'icon-file-symlink-file'
+    else if fs.isReadmePath(filePath)
+      'icon-book'
+    else if fs.isCompressedExtension(extension)
+      'icon-file-zip'
+    else if fs.isImageExtension(extension)
+      'icon-file-media'
+    else if fs.isPdfExtension(extension)
+      'icon-file-pdf'
+    else if fs.isBinaryExtension(extension)
+      'icon-file-binary'
+    else
+      'icon-file-text'
+
+module.exports = DefaultFileIcons

--- a/lib/file-icons.coffee
+++ b/lib/file-icons.coffee
@@ -1,0 +1,15 @@
+DefaultFileIcons = require './default-file-icons'
+
+class FileIcons
+  constructor: ->
+    @service = new DefaultFileIcons
+
+  getService: ->
+    @service
+
+  resetService: ->
+    @service = new DefaultFileIcons
+
+  setService: (@service) ->
+
+module.exports = new FileIcons

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -5,6 +5,7 @@ SelectNext = require './select-next'
 {History, HistoryCycler} = require './history'
 FindOptions = require './find-options'
 BufferSearch = require './buffer-search'
+FileIcons = require './file-icons'
 FindView = require './find-view'
 ProjectFindView = require './project-find-view'
 ResultsModel = require './project/results-model'
@@ -111,6 +112,11 @@ module.exports =
         selectNextObjectForEditorElement(this).undoLastSelection()
       'find-and-replace:select-skip': (event) ->
         selectNextObjectForEditorElement(this).skipCurrentSelection()
+
+  consumeFileIcons: (service) ->
+    FileIcons.setService service
+    @subscriptions.add service.onWillDeactivate ->
+      FileIcons.resetService()
 
   provideService: ->
     resultsMarkerLayerForTextEditor: @findModel.resultsMarkerLayerForTextEditor.bind(@findModel)

--- a/lib/project/result-view.coffee
+++ b/lib/project/result-view.coffee
@@ -7,7 +7,7 @@ path = require 'path'
 module.exports =
 class ResultView extends View
   @content: (model, filePath, result) ->
-    iconClass = FileIcons.getService().iconClassForPath(filePath) or []
+    iconClass = FileIcons.getService().iconClassForPath(filePath, "find-and-replace") or []
     unless Array.isArray iconClass
       iconClass = iconClass?.toString().split(/\s+/g)
     fileBasename = path.basename(filePath)

--- a/lib/project/result-view.coffee
+++ b/lib/project/result-view.coffee
@@ -1,13 +1,15 @@
 _ = require 'underscore-plus'
 {$, View} = require 'atom-space-pen-views'
-fs = require 'fs-plus'
+FileIcons = require '../file-icons'
 MatchView = require './match-view'
 path = require 'path'
 
 module.exports =
 class ResultView extends View
   @content: (model, filePath, result) ->
-    iconClass = if fs.isReadmePath(filePath) then 'icon-book' else 'icon-file-text'
+    iconClass = FileIcons.getService().iconClassForPath(filePath) or []
+    unless Array.isArray iconClass
+      iconClass = iconClass?.toString().split(/\s+/g)
     fileBasename = path.basename(filePath)
 
     if atom.project?
@@ -20,7 +22,7 @@ class ResultView extends View
     @li class: 'path list-nested-item', 'data-path': _.escapeAttribute(filePath), =>
       @div outlet: 'pathDetails', class: 'path-details list-item', =>
         @span class: 'disclosure-arrow'
-        @span class: iconClass + ' icon', 'data-name': fileBasename
+        @span class: iconClass.join(' ') + ' icon', 'data-name': fileBasename
         @span class: 'path-name bright', relativePath
         @span outlet: 'description', class: 'path-match-number'
       @ul outlet: 'matches', class: 'matches list-tree'

--- a/package.json
+++ b/package.json
@@ -37,6 +37,13 @@
   "devDependencies": {
     "coffeelint": "^1.9.7"
   },
+  "consumedServices": {
+    "atom.file-icons": {
+      "versions": {
+        "1.0.0": "consumeFileIcons"
+      }
+    }
+  },
   "providedServices": {
     "find-and-replace": {
       "description": "Atom's bundled find-and-replace package",

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -705,7 +705,10 @@ describe 'ResultsView', ->
 
   describe "handling of multiple icon-classes", ->
     beforeEach ->
-      service = iconClassForPath: -> "first second"
+      service =
+        iconClassForPath: (path, context) ->
+          expect(context).toBe "find-and-replace"
+          "first second"
       FileIcons.setService(service)
       projectFindView.findEditor.setText('i')
       atom.commands.dispatch projectFindView.element, 'core:confirm'

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -4,6 +4,7 @@ _ = require 'underscore-plus'
 temp = require "temp"
 
 ResultsPaneView = require '../lib/project/results-pane'
+FileIcons = require '../lib/file-icons'
 
 # Default to 30 second promises
 waitsForPromise = (fn) -> window.waitsForPromise timeout: 30000, fn
@@ -673,6 +674,57 @@ describe 'ResultsView', ->
       _.times 2, -> atom.commands.dispatch resultsView.element, 'core:move-down'
       atom.commands.dispatch resultsView.element, 'core:copy'
       expect(atom.clipboard.read()).toBe '    return items if items.length <= 1'
+
+  describe "icon-service lifecycle", ->
+    beforeEach ->
+      projectFindView.findEditor.setText('i')
+      atom.commands.dispatch projectFindView.element, 'core:confirm'
+    
+    it "displays default file-icons", ->
+      waitsForPromise -> searchPromise
+      
+      runs ->
+        resultsView = getResultsView()
+        expect(resultsView.find('.path-details .icon-file-text')).not.toHaveLength 0
+    
+    it "allows the service to be overridden", ->
+      service = iconClassForPath: -> ""
+      FileIcons.setService(service)
+      expect(FileIcons.getService()).toBe(service)
+      
+    it "allows an overridden service to be reset", ->
+      service = iconClassForPath: -> ""
+      FileIcons.setService(service)
+      FileIcons.resetService()
+      expect(FileIcons.getService()).not.toBe(service)
+
+  describe "handling of multiple icon-classes", ->
+    beforeEach ->
+      service = iconClassForPath: -> "first second"
+      FileIcons.setService(service)
+      projectFindView.findEditor.setText('i')
+      atom.commands.dispatch projectFindView.element, 'core:confirm'
+    
+    it "allows multiple classes to be passed as a string", ->
+      waitsForPromise -> searchPromise
+      
+      runs ->
+        resultsView = getResultsView()
+        expect(resultsView.find('.path-details .icon.first.second')).not.toHaveLength 0
+
+  describe "handling of icon-class arrays", ->
+    beforeEach ->
+      service = iconClassForPath: -> ["uno", "dos", "tres"]
+      FileIcons.setService(service)
+      projectFindView.findEditor.setText('i')
+      atom.commands.dispatch projectFindView.element, 'core:confirm'
+    
+    it "allows multiple classes to be passed as a string", ->
+      waitsForPromise -> searchPromise
+      
+      runs ->
+        resultsView = getResultsView()
+        expect(resultsView.find('.path-details .icon.uno.dos.tres')).not.toHaveLength 0
 
   # Keep. Useful for debugging.
   logSelectedIndex = ->


### PR DESCRIPTION
[Same affair as before](https://github.com/atom/fuzzy-finder/pull/211). Hooks the `find-and-replace` package up to the icon-service, allowing packages to customise the file-icons that're displayed in project search results.