### PR TITLE
Enable and disable search in selection automatically

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -205,11 +205,23 @@ class FindView extends View
       'find-and-replace:replace-next': @replaceNext
       'find-and-replace:replace-all': @replaceAll
 
+  activateSelectionOption: =>
+    # This forces search the selection again if selection is changed.
+    @search(inCurrentSelection: false)
+    @search(inCurrentSelection: true)
+
+  deactivateSelectionOption: =>
+    @search(inCurrentSelection: false)
+
   focusFindEditor: =>
     selectedText = atom.workspace.getActiveTextEditor()?.getSelectedText?()
     if selectedText and selectedText.indexOf('\n') < 0
       selectedText = Util.escapeRegex(selectedText) if @model.getFindOptions().useRegex
       @findEditor.setText(selectedText)
+      @deactivateSelectionOption()
+    else
+      @activateSelectionOption()
+
     @findEditor.focus()
     @findEditor.getModel().selectAll()
 
@@ -217,6 +229,9 @@ class FindView extends View
     selectedText = atom.workspace.getActiveTextEditor()?.getSelectedText?()
     if selectedText and selectedText.indexOf('\n') < 0
       @replaceEditor.setText(selectedText)
+      @deactivateSelectionOption()
+    else:
+      @activateSelectionOption()
     @replaceEditor.focus()
     @replaceEditor.getModel().selectAll()
 

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -219,8 +219,10 @@ class FindView extends View
       selectedText = Util.escapeRegex(selectedText) if @model.getFindOptions().useRegex
       @findEditor.setText(selectedText)
       @deactivateSelectionOption()
-    else
+    else if selectedText
       @activateSelectionOption()
+    else
+      @deactivateSelectionOption()
 
     @findEditor.focus()
     @findEditor.getModel().selectAll()
@@ -230,8 +232,10 @@ class FindView extends View
     if selectedText and selectedText.indexOf('\n') < 0
       @replaceEditor.setText(selectedText)
       @deactivateSelectionOption()
-    else:
+    else if selectedText
       @activateSelectionOption()
+    else
+      @deactivateSelectionOption()
     @replaceEditor.focus()
     @replaceEditor.getModel().selectAll()
 

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -206,7 +206,7 @@ class FindView extends View
       'find-and-replace:replace-all': @replaceAll
 
   activateSelectionOption: =>
-    # This forces search the selection again if selection is changed.
+    # This forces search the selection again in case selection is changed.
     @search(inCurrentSelection: false)
     @search(inCurrentSelection: true)
 

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -106,7 +106,7 @@ describe 'FindView', ->
       runs ->
         expect(findView.caseOptionButton).toHaveClass 'selected'
         expect(findView.regexOptionButton).toHaveClass 'selected'
-        expect(findView.selectionOptionButton).toHaveClass 'selected'
+        expect(findView.selectionOptionButton).not.toHaveClass 'selected'
 
     it "places selected text into the find editor and escapes it when Regex is enabled", ->
       atom.config.set('find-and-replace.useRegex', true)
@@ -323,7 +323,7 @@ describe 'FindView', ->
       runs ->
         expect(findView.caseOptionButton).toHaveClass 'selected'
         expect(findView.regexOptionButton).toHaveClass 'selected'
-        expect(findView.selectionOptionButton).toHaveClass 'selected'
+        expect(findView.selectionOptionButton).not.toHaveClass 'selected'
         expect(findView.wholeWordOptionButton).toHaveClass 'selected'
 
   describe "finding", ->


### PR DESCRIPTION
The objective of this enhancement is to automatically activate search within selection when find-and-replace is called and the selected text has one or more '/n' if no newline is found the selected text is used as the search pattern as it was implemented before. 

This is a reimplement of PR #616

This is how most editor works if the editor supports search in selection. For example, this is exactly how Visual Studio Code works.

I want to also point how it can be very tricky to turn on and off "search in selection" manually.
For example, if you select a word, and then ctrl-f, but forget to turn off "search in selection", then atom reports only one match, which is extremely misleading.

If you still have concern, I can provide a config option to turn this function on.
