### PR TITLE
Reset search query when initialised

### DIFF
--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -16,7 +16,7 @@ class FindOptions
   constructor: (state={}) ->
     @emitter = new Emitter
 
-    @findPattern = state.findPattern ? ''
+    @findPattern = ''
     @replacePattern = state.replacePattern ? ''
     @pathsPattern = state.pathsPattern ? ''
     @useRegex = state.useRegex ? atom.config.get('find-and-replace.useRegex') ? false

--- a/spec/buffer-search-spec.coffee
+++ b/spec/buffer-search-spec.coffee
@@ -21,7 +21,7 @@ describe "BufferSearch", ->
       -----------
     """
 
-    findOptions = new FindOptions
+    findOptions = new FindOptions findPattern: "a+"
     model = new BufferSearch(findOptions)
 
     markersListener = jasmine.createSpy('markersListener')


### PR DESCRIPTION
This PR fixes a rather esoteric bug that blocks a user from rerunning the session's last buffer search.

## Steps to reproduce
1. Open a project file in Atom, and search for something that will match
2. Close project
3. Reopen project and project's file
4. Bring up the buffer search and enter the last search term verbatim. This should be done quickly, either by typing fast or pressing the <kbd>Up Arrow</kbd> key to access search history.
5. Hit <kbd>Enter</kbd>

**Expectation:** Markers should appear in the buffer
**Reality:** The program beeps at you as if the field was left blank