### PR TITLE
Allow Project Find Results to be copied to clipboard

### DIFF
--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -178,6 +178,10 @@ class ProjectFindView {
       'find-and-replace:use-selection-as-find-pattern': () => this.setSelectionAsFindPattern()
     }));
 
+    this.subscriptions.add(atom.commands.add('.preview-pane', {
+      'project-find:copy-search-results': this.copySearchResultFromPane
+    }));
+
     this.subscriptions.add(atom.commands.add(this.element, {
       'find-and-replace:focus-next': () => this.focusNextElement(1),
       'find-and-replace:focus-previous': () => this.focusNextElement(-1),
@@ -188,7 +192,8 @@ class ProjectFindView {
       'project-find:toggle-regex-option': () => this.toggleRegexOption(),
       'project-find:toggle-case-option': () => this.toggleCaseOption(),
       'project-find:toggle-whole-word-option': () => this.toggleWholeWordOption(),
-      'project-find:replace-all': () => this.replaceAll()
+      'project-find:replace-all': () => this.replaceAll(),
+      'project-find:copy-search-results': () => this.copySearchResultFromPane()
     }));
 
     let updateInterfaceForSearching = () => {
@@ -233,6 +238,11 @@ class ProjectFindView {
       this.updateReplaceAllButtonEnablement(this.model.getResultsSummary());
     });
     this.handleEventsForReplace();
+  }
+
+  copySearchResultFromPane() {
+    atom.clipboard.write(Util.parseSearchResult());
+    atom.notifications.addInfo('Search results have been copied to clipboard');
   }
 
   handleEventsForReplace() {

--- a/lib/project/util.coffee
+++ b/lib/project/util.coffee
@@ -36,7 +36,29 @@ showIf = (condition) ->
   else
     {display: 'none'}
 
+parseSearchResult = ->
+  searchResult = []
+  summary = document.querySelector('span.preview-count').textContent
+  searchResult.push summary, ''
+
+  orderList = document.querySelectorAll('.results-view ol.list-tree.has-collapsable-children')
+  orderListArray = Array.prototype.slice.call(orderList) # only visible item shown in DOM, you cannot query all search results
+  resItems = orderListArray[1].querySelectorAll('div > li') # omit first element which is dummy
+
+  resItems.forEach (el) ->
+    path = el.querySelector('div > span.path-name').textContent
+    matches = el.querySelector('div > span.path-match-number').textContent
+    searchResult.push "#{path} #{matches}"
+
+    el.querySelectorAll('li.search-result').forEach (e) ->
+      return if e.offsetParent is null  # skip invisible elements
+      lineNumber = e.querySelector('span.line-number').textContent
+      preview = e.querySelector('span.preview').textContent
+      searchResult.push "\t#{lineNumber}\t#{preview}"
+    searchResult.push ''
+  searchResult.join('\n')
+
 module.exports = {
   escapeHtml, escapeRegex, sanitizePattern, getReplacementResultsMessage,
-  getSearchResultsMessage, showIf
+  getSearchResultsMessage, showIf, parseSearchResult
 }

--- a/menus/find-and-replace.cson
+++ b/menus/find-and-replace.cson
@@ -28,3 +28,6 @@
   '.path-details.list-item': [
     { 'label': 'Copy Path', 'command': 'find-and-replace:copy-path' }
   ]
+  'div.preview-pane': [
+    { 'label': 'Copy to Clipboard', 'command': 'project-find:copy-search-results' }
+  ]

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -724,6 +724,24 @@ describe('ProjectFindView', () => {
           expect(projectFindView.errorMessages).not.toBeVisible();
         });
 
+        it("can copy search results to clipboard", async () => {
+          oldClipboardText = atom.clipboard.read();
+
+          atom.commands.dispatch(projectFindView.element, 'core:confirm');
+          await searchPromise;
+
+          const resultsView = getResultsView();
+          await resultsView.heightInvalidationPromise;
+
+          atom.commands.dispatch(resultsView.element, 'project-find:copy-search-results');
+          searchResults = atom.clipboard.read().split('\n');
+          expect(searchResults[0]).toBe("13 results found in 2 files for items");
+          expect(searchResults[2]).toBe("sample.coffee (7 matches)");
+          expect(searchResults[3]).toBe("\t2\tsort: (items) ->");
+          expect(searchResults[4]).toBe("\t3\treturn items if items.length <= 1");
+          atom.clipboard.write(oldClipboardText);
+        });
+
         it("only searches paths matching text in the path filter", async () => {
           spyOn(atom.workspace, 'scan').andCallFake(async () => {});
           projectFindView.pathsEditor.setText('*.js');


### PR DESCRIPTION
Related issue [#416](https://github.com/atom/find-and-replace/issues/416).
copy result of _Project-Find_ to clipboard.

changes:
1. add `Util.copySearchResultFromPane()` to copy text from search result pane
2. add context menu item supporting right-click on project-find result page. 
   (of course can use it via command-palette)

demo:
![demo](https://cloud.githubusercontent.com/assets/4994705/17399255/9907ebb8-5a73-11e6-8ef5-2522cb7d3ba2.png)

NOTE: hidden entries under collapsed item are not copied to clipboard so that result is consistent with view.
