### PR TITLE
Add feature collapse and expand results

### DIFF
--- a/lib/project/results-pane.coffee
+++ b/lib/project/results-pane.coffee
@@ -14,8 +14,7 @@ class ResultsPaneView extends ScrollView
         @span outlet: 'previewCount', class: 'preview-count inline-block'
         @div outlet: 'previewControls', class: 'preview-controls', =>
           @div class: 'btn-group', =>
-            @button outlet: 'collapseAll', class: 'btn'
-            @button outlet: 'expandAll', class: 'btn'
+            @button outlet: 'toggleExpanded', class: 'btn'
         @div outlet: 'loadingMessage', class: 'inline-block', =>
           @div class: 'loading loading-spinner-tiny inline-block'
           @div outlet: 'searchedCountBlock', class: 'inline-block', =>
@@ -36,12 +35,9 @@ class ResultsPaneView extends ScrollView
     @on 'focus', @focused
 
     @previewControls.hide()
-    @collapseAll
-      .text('Collapse All')
-      .click(@collapseAllResults)
-    @expandAll
-      .text('Expand All')
-      .click(@expandAllResults)
+    @toggleExpanded
+      .text('Toggle Expanded')
+      .click(@toggleExpandedResults)
 
   attached: ->
     @model.setActive(true)
@@ -153,10 +149,6 @@ class ResultsPaneView extends ScrollView
       @previewControls.hide()
       @addClass('no-results')
 
-  collapseAllResults: =>
-    @resultsView.collapseAllResults()
-    @resultsView.focus()
-
-  expandAllResults: =>
-    @resultsView.expandAllResults()
+  toggleExpandedResults: =>
+    @resultsView.toggleExpandedResults()
     @resultsView.focus()

--- a/lib/project/results-pane.coffee
+++ b/lib/project/results-pane.coffee
@@ -14,7 +14,8 @@ class ResultsPaneView extends ScrollView
         @span outlet: 'previewCount', class: 'preview-count inline-block'
         @div outlet: 'previewControls', class: 'preview-controls', =>
           @div class: 'btn-group', =>
-            @button outlet: 'toggleExpanded', class: 'btn'
+            @button outlet: 'collapseAll', class: 'btn'
+            @button outlet: 'expandAll', class: 'btn'
         @div outlet: 'loadingMessage', class: 'inline-block', =>
           @div class: 'loading loading-spinner-tiny inline-block'
           @div outlet: 'searchedCountBlock', class: 'inline-block', =>
@@ -35,9 +36,12 @@ class ResultsPaneView extends ScrollView
     @on 'focus', @focused
 
     @previewControls.hide()
-    @toggleExpanded
-      .text('Toggle Expanded')
-      .click(@toggleExpandedResults)
+    @collapseAll
+      .text('Collapse All')
+      .click(@collapseAllResults)
+    @expandAll
+      .text('Expand All')
+      .click(@expandAllResults)
 
   attached: ->
     @model.setActive(true)
@@ -149,6 +153,10 @@ class ResultsPaneView extends ScrollView
       @previewControls.hide()
       @addClass('no-results')
 
-  toggleExpandedResults: =>
-    @resultsView.toggleExpandedResults()
+  collapseAllResults: =>
+    @resultsView.collapseAllResults()
+    @resultsView.focus()
+
+  expandAllResults: =>
+    @resultsView.expandAllResults()
     @resultsView.focus()

--- a/lib/project/results-pane.coffee
+++ b/lib/project/results-pane.coffee
@@ -155,6 +155,8 @@ class ResultsPaneView extends ScrollView
 
   collapseAllResults: =>
     @resultsView.collapseAllResults()
+    @resultsView.focus()
 
   expandAllResults: =>
     @resultsView.expandAllResults()
+    @resultsView.focus()

--- a/lib/project/results-pane.coffee
+++ b/lib/project/results-pane.coffee
@@ -10,7 +10,7 @@ class ResultsPaneView extends ScrollView
 
   @content: ->
     @div class: 'preview-pane pane-item', tabindex: -1, =>
-      @header class: 'preview-header', =>
+      @div class: 'preview-header', =>
         @span outlet: 'previewCount', class: 'preview-count inline-block'
         @div outlet: 'previewControls', class: 'preview-controls', =>
           @div class: 'btn-group', =>

--- a/lib/project/results-pane.coffee
+++ b/lib/project/results-pane.coffee
@@ -12,10 +12,10 @@ class ResultsPaneView extends ScrollView
     @div class: 'preview-pane pane-item', tabindex: -1, =>
       @header class: 'preview-header', =>
         @span outlet: 'previewCount', class: 'preview-count inline-block'
-        @div class: 'preview-controls', =>
+        @div outlet: 'previewControlls', class: 'preview-controls', =>
           @div class: 'btn-group', =>
-            @button outlet: 'previewCollapse', class: 'btn'
-            @button outlet: 'previewExpand', class: 'btn'
+            @button outlet: 'collapseAll', class: 'btn'
+            @button outlet: 'expandAll', class: 'btn'
         @div outlet: 'loadingMessage', class: 'inline-block', =>
           @div class: 'loading loading-spinner-tiny inline-block'
           @div outlet: 'searchedCountBlock', class: 'inline-block', =>
@@ -34,10 +34,12 @@ class ResultsPaneView extends ScrollView
     @model = @constructor.model
     @onFinishedSearching(@model.getResultsSummary())
     @on 'focus', @focused
-    @previewCollapse
+
+    @previewControlls.hide()
+    @collapseAll
       .text('Collapse All')
       .click(@collapseAllResults)
-    @previewExpand
+    @expandAll
       .text('Expand All')
       .click(@expandAllResults)
 
@@ -98,6 +100,7 @@ class ResultsPaneView extends ScrollView
     @errorList.html('').hide()
 
   onSearch: (deferred) =>
+    @previewControlls.hide()
     @loadingMessage.show()
 
     @previewCount.text('Searching...')
@@ -125,6 +128,8 @@ class ResultsPaneView extends ScrollView
 
   onFinishedSearching: (results) =>
     @hideOrShowNoResults(results)
+    if @resultsView.lastRenderedResultIndex isnt 0 then @previewControlls.show()
+    else @previewControlls.hide()
     @previewCount.html(Util.getSearchResultsMessage(results))
     if results.searchErrors? or results.replacementErrors?
       errors = _.pluck(results.replacementErrors, 'message')
@@ -151,17 +156,7 @@ class ResultsPaneView extends ScrollView
       @addClass('no-results')
 
   collapseAllResults: =>
-    i=0
-    while i isnt @resultsView.lastRenderedResultIndex
-      @resultsView.collapseResult()
-      @resultsView.selectNextResult()
-      i++
-    @resultsView.selectFirstResult()
+    @resultsView.collapseAllResults()
 
   expandAllResults: =>
-    i=0
-    while i isnt @resultsView.lastRenderedResultIndex
-      @resultsView.expandResult()
-      @resultsView.selectNextResult()
-      i++
-    @resultsView.selectFirstResult()
+    @resultsView.expandAllResults()

--- a/lib/project/results-pane.coffee
+++ b/lib/project/results-pane.coffee
@@ -10,8 +10,12 @@ class ResultsPaneView extends ScrollView
 
   @content: ->
     @div class: 'preview-pane pane-item', tabindex: -1, =>
-      @div class: 'panel-heading', =>
+      @header class: 'preview-header', =>
         @span outlet: 'previewCount', class: 'preview-count inline-block'
+        @div class: 'preview-controls', =>
+            @div class: 'btn-group', =>
+                @button outlet: 'previewCollapse', class: 'btn'
+                @button outlet: 'previewExpand', class: 'btn'
         @div outlet: 'loadingMessage', class: 'inline-block', =>
           @div class: 'loading loading-spinner-tiny inline-block'
           @div outlet: 'searchedCountBlock', class: 'inline-block', =>
@@ -30,6 +34,12 @@ class ResultsPaneView extends ScrollView
     @model = @constructor.model
     @onFinishedSearching(@model.getResultsSummary())
     @on 'focus', @focused
+    @previewCollapse
+      .text('Collapse All')
+      .click(@collapseAllResults)
+    @previewExpand
+      .text('Expand All')
+      .click(@expandAllResults)
 
   attached: ->
     @model.setActive(true)
@@ -116,7 +126,6 @@ class ResultsPaneView extends ScrollView
   onFinishedSearching: (results) =>
     @hideOrShowNoResults(results)
     @previewCount.html(Util.getSearchResultsMessage(results))
-
     if results.searchErrors? or results.replacementErrors?
       errors = _.pluck(results.replacementErrors, 'message')
       errors = errors.concat _.pluck(results.searchErrors, 'message')
@@ -140,3 +149,19 @@ class ResultsPaneView extends ScrollView
       @removeClass('no-results')
     else
       @addClass('no-results')
+
+  collapseAllResults: =>
+    i=0
+    while i != @resultsView.lastRenderedResultIndex
+      @resultsView.collapseResult()
+      @resultsView.selectNextResult()
+      i++
+    @resultsView.selectFirstResult()
+
+  expandAllResults: =>
+    i=0
+    while i != @resultsView.lastRenderedResultIndex
+      @resultsView.expandResult()
+      @resultsView.selectNextResult()
+      i++
+    @resultsView.selectFirstResult()

--- a/lib/project/results-pane.coffee
+++ b/lib/project/results-pane.coffee
@@ -13,9 +13,9 @@ class ResultsPaneView extends ScrollView
       @header class: 'preview-header', =>
         @span outlet: 'previewCount', class: 'preview-count inline-block'
         @div class: 'preview-controls', =>
-            @div class: 'btn-group', =>
-                @button outlet: 'previewCollapse', class: 'btn'
-                @button outlet: 'previewExpand', class: 'btn'
+          @div class: 'btn-group', =>
+            @button outlet: 'previewCollapse', class: 'btn'
+            @button outlet: 'previewExpand', class: 'btn'
         @div outlet: 'loadingMessage', class: 'inline-block', =>
           @div class: 'loading loading-spinner-tiny inline-block'
           @div outlet: 'searchedCountBlock', class: 'inline-block', =>
@@ -152,7 +152,7 @@ class ResultsPaneView extends ScrollView
 
   collapseAllResults: =>
     i=0
-    while i != @resultsView.lastRenderedResultIndex
+    while i isnt @resultsView.lastRenderedResultIndex
       @resultsView.collapseResult()
       @resultsView.selectNextResult()
       i++
@@ -160,7 +160,7 @@ class ResultsPaneView extends ScrollView
 
   expandAllResults: =>
     i=0
-    while i != @resultsView.lastRenderedResultIndex
+    while i isnt @resultsView.lastRenderedResultIndex
       @resultsView.expandResult()
       @resultsView.selectNextResult()
       i++

--- a/lib/project/results-pane.coffee
+++ b/lib/project/results-pane.coffee
@@ -12,7 +12,7 @@ class ResultsPaneView extends ScrollView
     @div class: 'preview-pane pane-item', tabindex: -1, =>
       @header class: 'preview-header', =>
         @span outlet: 'previewCount', class: 'preview-count inline-block'
-        @div outlet: 'previewControlls', class: 'preview-controls', =>
+        @div outlet: 'previewControls', class: 'preview-controls', =>
           @div class: 'btn-group', =>
             @button outlet: 'collapseAll', class: 'btn'
             @button outlet: 'expandAll', class: 'btn'
@@ -35,7 +35,7 @@ class ResultsPaneView extends ScrollView
     @onFinishedSearching(@model.getResultsSummary())
     @on 'focus', @focused
 
-    @previewControlls.hide()
+    @previewControls.hide()
     @collapseAll
       .text('Collapse All')
       .click(@collapseAllResults)
@@ -98,9 +98,7 @@ class ResultsPaneView extends ScrollView
 
   clearErrors: ->
     @errorList.html('').hide()
-
   onSearch: (deferred) =>
-    @previewControlls.hide()
     @loadingMessage.show()
 
     @previewCount.text('Searching...')
@@ -128,8 +126,6 @@ class ResultsPaneView extends ScrollView
 
   onFinishedSearching: (results) =>
     @hideOrShowNoResults(results)
-    if @resultsView.lastRenderedResultIndex isnt 0 then @previewControlls.show()
-    else @previewControlls.hide()
     @previewCount.html(Util.getSearchResultsMessage(results))
     if results.searchErrors? or results.replacementErrors?
       errors = _.pluck(results.replacementErrors, 'message')
@@ -151,8 +147,10 @@ class ResultsPaneView extends ScrollView
 
   hideOrShowNoResults: (results) ->
     if results.pathCount
+      @previewControls.show()
       @removeClass('no-results')
     else
+      @previewControls.hide()
       @addClass('no-results')
 
   collapseAllResults: =>

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -14,6 +14,7 @@ class ResultsView extends ScrollView
 
     @pixelOverdraw = 100
     @lastRenderedResultIndex = 0
+    @allExpanded = true
 
     @on 'mousedown', '.path', (e) =>
       @find('.selected').removeClass('selected')
@@ -205,25 +206,22 @@ class ResultsView extends ScrollView
 
     resultView.addClass('selected')
 
-  collapseAllResults: ->
-    @find('.list-nested-item').views().forEach(
-      (view) -> view.expand(false)
-    )
-
   collapseResult: ->
     parent = @find('.selected').closest('.path').view()
     parent.expand(false) if parent instanceof ResultView
     @renderResults()
 
-  expandAllResults: ->
-    @find('.list-nested-item').views().forEach(
-      (view) -> view.expand(true)
-    )
-
   expandResult: ->
     selectedView = @find('.selected').view()
     selectedView.expand(true) if selectedView instanceof ResultView
     @renderResults()
+
+  toggleExpandedResults: ->
+    @allExpanded = not @allExpanded
+    @renderResults(renderAll: true) # without this, not all views will be affected
+    @find('.path').views().forEach(
+      (view) => view.expand(@allExpanded)
+    )
 
   getPathCount: ->
     @model.getPathCount()

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -14,7 +14,6 @@ class ResultsView extends ScrollView
 
     @pixelOverdraw = 100
     @lastRenderedResultIndex = 0
-    @allExpanded = true
 
     @on 'mousedown', '.path', (e) =>
       @find('.selected').removeClass('selected')
@@ -211,16 +210,21 @@ class ResultsView extends ScrollView
     parent.expand(false) if parent instanceof ResultView
     @renderResults()
 
+  collapseAllResults: ->
+    @renderResults(renderAll: true) # without this, not all views will be affected
+    @find('.path').views().forEach(
+      (view) -> view.expand(false)
+    )
+
   expandResult: ->
     selectedView = @find('.selected').view()
     selectedView.expand(true) if selectedView instanceof ResultView
     @renderResults()
 
-  toggleExpandedResults: ->
-    @allExpanded = not @allExpanded
+  expandAllResults: ->
     @renderResults(renderAll: true) # without this, not all views will be affected
     @find('.path').views().forEach(
-      (view) => view.expand(@allExpanded)
+      (view) -> view.expand(true)
     )
 
   getPathCount: ->

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -206,25 +206,19 @@ class ResultsView extends ScrollView
     resultView.addClass('selected')
 
   collapseAllResults: ->
-    i = 0
-    while i isnt @lastRenderedResultIndex
-      @collapseResult()
-      @selectNextResult()
-      i++
-    @selectFirstResult()
-
-  expandAllResults: ->
-    i = 0
-    while i isnt @lastRenderedResultIndex
-      @expandResult()
-      @selectNextResult()
-      i++
-    @selectFirstResult()
+    @find('.list-nested-item').views().forEach(
+      (view) -> view.expand(false)
+    )
 
   collapseResult: ->
     parent = @find('.selected').closest('.path').view()
     parent.expand(false) if parent instanceof ResultView
     @renderResults()
+
+  expandAllResults: ->
+    @find('.list-nested-item').views().forEach(
+      (view) -> view.expand(true)
+    )
 
   expandResult: ->
     selectedView = @find('.selected').view()

--- a/lib/project/results-view.coffee
+++ b/lib/project/results-view.coffee
@@ -205,6 +205,22 @@ class ResultsView extends ScrollView
 
     resultView.addClass('selected')
 
+  collapseAllResults: ->
+    i = 0
+    while i isnt @lastRenderedResultIndex
+      @collapseResult()
+      @selectNextResult()
+      i++
+    @selectFirstResult()
+
+  expandAllResults: ->
+    i = 0
+    while i isnt @lastRenderedResultIndex
+      @expandResult()
+      @selectNextResult()
+      i++
+    @selectFirstResult()
+
   collapseResult: ->
     parent = @find('.selected').closest('.path').view()
     parent.expand(false) if parent instanceof ResultView

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -603,7 +603,6 @@ describe 'ResultsView', ->
 
       it "collapses all results if collapse All button is pressed", ->
         collapseAll = resultsView.parentView.collapseAll
-        expandAll = resultsView.parentView.expandAll
         results = resultsView.find('.list-nested-item')
         collapseAll.click()
         expect(results).toHaveClass('collapsed')

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -586,6 +586,10 @@ describe 'ResultsView', ->
         waitsForPromise -> searchPromise
         runs -> resultsView = getResultsView()
 
+      it "shows the preview-controls", ->
+        previewControls = resultsView.parentView.previewControls
+        expect(previewControls.isVisible()).toBe(true)
+
       it "collapses the selected results view", ->
         # select item in first list
         resultsView.find('.selected').removeClass('selected')
@@ -597,6 +601,13 @@ describe 'ResultsView', ->
         expect(selectedItem).toHaveClass('collapsed')
         expect(selectedItem.element).toBe resultsView.find('.path:eq(0)').element
 
+      it "collapses all results if collapse All button is pressed", ->
+        collapseAll = resultsView.parentView.collapseAll
+        expandAll = resultsView.parentView.expandAll
+        results = resultsView.find('.list-nested-item')
+        collapseAll.click()
+        expect(results).toHaveClass('collapsed')
+
       it "expands the selected results view", ->
         # select item in first list
         resultsView.find('.selected').removeClass('selected')
@@ -607,6 +618,12 @@ describe 'ResultsView', ->
         selectedItem = resultsView.find('.selected')
         expect(selectedItem).toHaveClass('search-result')
         expect(selectedItem[0]).toBe resultsView.find('.path:eq(0) .search-result:first')[0]
+
+      it "expands all results if 'Expand All' button is pressed", ->
+        expandAll = resultsView.parentView.expandAll
+        results = resultsView.find('.list-nested-item')
+        expandAll.click()
+        expect(results).not.toHaveClass('collapsed')
 
       describe "when nothing is selected", ->
         it "doesnt error when the user arrows down", ->
@@ -655,6 +672,17 @@ describe 'ResultsView', ->
       runs ->
         resultsView = getResultsView()
         expect(-> atom.commands.dispatch resultsView.element, 'core:confirm').not.toThrow()
+
+    it "won't show the preview-controls", ->
+      projectFindView.findEditor.setText('thiswillnotmatchanythingintheproject')
+      atom.commands.dispatch projectFindView.element, 'core:confirm'
+
+      waitsForPromise ->
+        searchPromise
+
+      runs ->
+        previewControls = getResultsView().parentView.previewControls
+        expect(previewControls.isVisible()).toBe(false)
 
   describe "copying items with core:copy", ->
     [resultsView, openHandler] = []

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -230,7 +230,7 @@ atom-workspace.find-visible {
 
   .preview-header {
     display: flex;
-    padding: @component-padding;
+    padding: @component-padding/2 @component-padding;
     align-items: center;
     flex-wrap: nowrap;
     justify-content: space-between;

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -230,15 +230,12 @@ atom-workspace.find-visible {
 
   .preview-header {
     display: flex;
-    padding: @component-padding/2 @component-padding;
+    padding: @component-padding/2 @component-padding/2 @component-padding/2 @component-padding;
     align-items: center;
-    flex-wrap: nowrap;
     justify-content: space-between;
     font-weight: normal;
     border-bottom: 1px solid @panel-heading-border-color;
-    border-top: 1px solid fadein(@background-color-highlight, 10%);
-    background-color: transparent;
-    background-image: -webkit-linear-gradient(@panel-heading-background-color, darken(@panel-heading-background-color, 10%));
+    background-color: @panel-heading-background-color;
   }
 
   .preview-controls {

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -234,6 +234,11 @@ atom-workspace.find-visible {
     align-items: center;
     flex-wrap: nowrap;
     justify-content: space-between;
+    font-weight: normal;
+    border-bottom: 1px solid @panel-heading-border-color;
+    border-top: 1px solid fadein(@background-color-highlight, 10%);
+    background-color: transparent;
+    background-image: -webkit-linear-gradient(@panel-heading-background-color, darken(@panel-heading-background-color, 10%));
   }
 
   .preview-controls {

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -228,7 +228,15 @@ atom-workspace.find-visible {
   display: flex;
   flex-direction: column;
 
-  .panel-heading {
+  .preview-header {
+    display: flex;
+    padding: @component-padding;
+    align-items: center;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+  }
+
+  .preview-controls {
     flex-shrink: 0;
   }
 


### PR DESCRIPTION
I often find myself scrolling a big list of results just to find a specific file. Following the `styleguide` approach. I made this small UI change.

![collapse-expand](https://cloud.githubusercontent.com/assets/14871650/17757641/63400d68-64e0-11e6-9ee3-53caf447dfbf.gif)
