### PR TITLE
Introduce "Find All" button

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -39,15 +39,15 @@ class FindView extends View
         @div class: 'input-block-item', =>
           @div class: 'btn-group btn-group-find', =>
             @button outlet: 'nextButton', class: 'btn', 'Find'
+          @div class: 'btn-group btn-group-find-all', =>
+            @button outlet: 'findAllButton', class: 'btn', 'Find All'
+
+        @div class: 'input-block-item option-block', =>
           @div class: 'btn-group btn-toggle btn-group-options', =>
             @button outlet: 'regexOptionButton', class: 'btn', =>
               @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-regex" /></svg>'
             @button outlet: 'caseOptionButton', class: 'btn', =>
               @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-case" /></svg>'
-            @button outlet: 'selectionOptionButton', class: 'btn option-selection', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-selection" /></svg>'
-            @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-word" /></svg>'
 
       @section class: 'input-block replace-container', =>
         @div class: 'input-block-item input-block-item--flex editor-container', =>
@@ -58,6 +58,13 @@ class FindView extends View
             @button outlet: 'replaceNextButton', class: 'btn btn-next', 'Replace'
           @div class: 'btn-group btn-group-replace-all', =>
             @button outlet: 'replaceAllButton', class: 'btn btn-all', 'Replace All'
+
+        @div class: 'input-block-item option-block', =>
+          @div class: 'btn-group btn-toggle btn-group-options', =>
+            @button outlet: 'selectionOptionButton', class: 'btn option-selection', =>
+              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-selection" /></svg>'
+            @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', =>
+              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-word" /></svg>'
 
       @raw '<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
         <symbol id="find-and-replace-icon-regex" viewBox="0 0 20 16" stroke="none" fill-rule="evenodd">
@@ -138,6 +145,10 @@ class FindView extends View
       title: "Find Next",
       keyBindingCommand: 'find-and-replace:find-next',
       keyBindingTarget: @findEditor.element
+    subs.add atom.tooltips.add @findAllButton,
+      title: "Find All",
+      keyBindingCommand: 'find-and-replace:find-all',
+      keyBindingTarget: @findEditor.element
 
   didHide: ->
     @hideAllTooltips()
@@ -190,9 +201,11 @@ class FindView extends View
   handleFindEvents: ->
     @findEditor.getModel().onDidStopChanging => @liveSearch()
     @nextButton.on 'click', (e) => if e.shiftKey then @findPrevious(focusEditorAfter: true) else @findNext(focusEditorAfter: true)
+    @findAllButton.on 'click', @findAll
     @subscriptions.add atom.commands.add 'atom-workspace',
       'find-and-replace:find-next': => @findNext(focusEditorAfter: true)
       'find-and-replace:find-previous': => @findPrevious(focusEditorAfter: true)
+      'find-and-replace:find-all': => @findAll(focusEditorAfter: true)
       'find-and-replace:find-next-selected': @findNextSelected
       'find-and-replace:find-previous-selected': @findPreviousSelected
       'find-and-replace:use-selection-as-find-pattern': @setSelectionAsFindPattern

--- a/menus/find-and-replace.cson
+++ b/menus/find-and-replace.cson
@@ -10,6 +10,7 @@
     { 'label': 'Find in Project', 'command': 'project-find:show'}
     { 'label': 'Toggle Find in Project', 'command': 'project-find:toggle'}
     { 'type': 'separator' }
+    { 'label': 'Find All', 'command': 'find-and-replace:find-all'}
     { 'label': 'Find Next', 'command': 'find-and-replace:find-next'}
     { 'label': 'Find Previous', 'command': 'find-and-replace:find-previous'}
     { 'label': 'Replace Next', 'command': 'find-and-replace:replace-next'}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
       "project-find:show-in-current-directory",
       "find-and-replace:show",
       "find-and-replace:toggle",
+      "find-and-replace:find-all",
       "find-and-replace:find-next",
       "find-and-replace:find-previous",
       "find-and-replace:find-next-selected",

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -120,8 +120,8 @@ atom-workspace.find-visible {
 
 // Buffer find and replace
 .find-and-replace {
-  @button-width: 120px;        // Find + Replace buttons
-  @option-button-width: 200px; // Replace All + option buttons
+  @button-width: 120px;        // Find + Replace + Find All + Replace All buttons
+  @option-button-width: 100px;  // option buttons
   @item-width: 260px;          // wrap block width
 
   .input-block-item {
@@ -130,17 +130,20 @@ atom-workspace.find-visible {
   .input-block-item--flex {
     flex: 100 1 @item-width;
   }
-
-  .btn-group-find,
-  .btn-group-replace {
-    flex: 1 1 @button-width;
-  }
-  .btn-group-replace-all,
-  .btn-group-options {
+  
+  .option-block {
     flex: 1 1 @option-button-width;
   }
 
+  .btn-group-find,
+  .btn-group-replace,
+  .btn-group-find-all,
+  .btn-group-replace-all, {
+    flex: 1 1 @button-width;
+  }
+
   .btn-group-options {
+    flex: 1 1 @option-button-width;
     .btn {
       flex: 1 1 25%;
       padding: 0;


### PR DESCRIPTION
These changes address issue [#568](https://github.com/atom/find-and-replace/issues/568) by adding a "Find All" button to the file-view find and replace as well as to the Find menu.

![38aeac60-3f8f-11e6-9bac-1a96702b9a9c](https://cloud.githubusercontent.com/assets/8633174/18796330/596b8842-818e-11e6-818f-a3c3385e5c65.png)

![screenshot from 2016-09-23 13 07 34](https://cloud.githubusercontent.com/assets/8633174/18796518/4d1bb78c-818f-11e6-84fb-3ad6222f9ee8.png)
