### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -2,8 +2,7 @@
 @import "syntax-variables";
 
 // result markers
-atom-text-editor,
-atom-text-editor::shadow {
+atom-text-editor {
   .find-result .region {
     background-color: transparent;
     border-radius: @component-border-radius;
@@ -26,8 +25,7 @@ atom-text-editor::shadow {
 }
 
 atom-workspace.find-visible {
-  atom-text-editor,
-  atom-text-editor::shadow {
+  atom-text-editor {
     .find-result,
     .current-result {
       display: block;
@@ -291,27 +289,27 @@ atom-workspace.find-visible {
   }
 }
 
-.find-container atom-text-editor::shadow, .replace-container atom-text-editor::shadow {
+.find-container atom-text-editor, .replace-container atom-text-editor {
   // Styles for regular expression highlighting
-  .regexp {
-    .escape {
+  .syntax--regexp {
+    .syntax--escape {
       color: @text-color-info;
     }
-    .range, .character-class, .wildcard {
+    .syntax--range, .syntax--character-class, .syntax--wildcard {
       color: @text-color-success;
     }
-    .wildcard {
+    .syntax--wildcard {
       font-weight: bold;
     }
-    .set {
+    .syntax--set {
       color: inherit;
     }
-    .keyword, .punctuation {
+    .syntax--keyword, .syntax--punctuation {
       color: @text-color-error;
       font-weight: normal;
     }
 
-    .replacement.variable {
+    .syntax--replacement.syntax--variable {
       color: @text-color-warning;
     }
   }


### PR DESCRIPTION
We are in the process of removing the shadow DOM boundary from `atom-text-editor` elements. This pull request upgrades existing selectors so that they:

* Stop using `:host`.
* Stop using `atom-text-editor::shadow`.
* Prepend syntax class names with `syntax--`.

/cc: @simurai