### PR TITLE
Fix cmd-c cmd-f quick sequence from altering the text

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -313,9 +313,6 @@ class FindView extends View
     else
       @clearMessage()
 
-    if @model.getFindOptions().findPattern isnt @findEditor.getText()
-      @findEditor.setText(@model.getFindOptions().findPattern)
-
   findError: (error) =>
     @setErrorMessage(error.message)
 
@@ -426,7 +423,9 @@ class FindView extends View
     if editor?.getSelectedText?
       findPattern = editor.getSelectedText() or editor.getWordUnderCursor()
       findPattern = Util.escapeRegex(findPattern) if @model.getFindOptions().useRegex
-      @search(findPattern) if findPattern
+      if findPattern
+        @findEditor.setText(findPattern)
+        @search()
 
   findNextSelected: =>
     @setSelectionAsFindPattern()


### PR DESCRIPTION
There is currently a very annoying bug in atom where if you are quick to search, it will override the search with the previous value. See https://github.com/atom/find-and-replace/issues/758 for the bug report and repro steps.

Looking at the blame, it looks like the behavior to replace the text was there since the very early days but in 2014, a check was added to make sure that it doesn't override it if the text is the same as it would make the cursor jump ( https://github.com/atom/find-and-replace/issues/121 ).

I don't understand why when the result of a search comes back, you want to modify the input text. I do think this is a bug and the behavior should be to just leave the text as is and when that new text is finished searching it'll update the search results. So, this removes the entire update logic.

Test Plan:
Do the repro steps of https://github.com/atom/find-and-replace/issues/758

Before this commit:

![](http://g.recordit.co/01zDNyuFcN.gif)

After this commit:

![](http://g.recordit.co/EGwg0ZVaE0.gif)