### PR TITLE
Don't show find panel when doing cmd-e

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -52,7 +52,6 @@ module.exports =
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:use-selection-as-find-pattern', =>
       return if @projectFindPanel?.isVisible() or @findPanel?.isVisible()
       @createViews()
-      showPanel @findPanel, @projectFindPanel, => @findView.focusFindEditor()
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'find-and-replace:toggle', =>
       @createViews()


### PR DESCRIPTION
There's a long standing issue where cmd-e shows the find panel where it shouldn't: https://github.com/atom/find-and-replace/issues/332

This pull request prevents the find panel from showing.

Test Plan:

1) Click on `new`
2) Press `cmd-e`, note that there is no visual feedback
3) Press `cmd-g` multiple times to go through occurrences

See the behavior in Sublime:
![](http://g.recordit.co/Iwt3rimsQM.gif)

In Atom with this pull request:
![](http://g.recordit.co/HMtN1TiJGr.gif)

It even works the same way in Chrome!
![](http://g.recordit.co/teDy4kCMYi.gif)