### PR TITLE
Remap/remove keybindings to avoid i8n key conflicts

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -44,8 +44,6 @@
   'alt-enter': 'find-and-replace:find-all'
   'ctrl-alt-/': 'find-and-replace:toggle-regex-option'
   'ctrl-shift-c': 'find-and-replace:toggle-case-option'
-  'ctrl-shift-e': 'find-and-replace:toggle-selection-option'
-  'ctrl-shift-.': 'find-and-replace:toggle-whole-word-option'
 
 '.platform-darwin .project-find':
   'cmd-enter': 'project-find:confirm'
@@ -57,8 +55,7 @@
   'ctrl-enter': 'project-find:confirm'
   'ctrl-alt-/': 'project-find:toggle-regex-option'
   'ctrl-shift-c': 'find-and-replace:toggle-case-option'
-  'ctrl-shift-.': 'find-and-replace:toggle-whole-word-option'
-
+  
 '.find-and-replace, .project-find, .project-find .results-view':
   'tab': 'find-and-replace:focus-next'
   'shift-tab': 'find-and-replace:focus-previous'

--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -6,7 +6,6 @@
 '.platform-win32, .platform-linux':
   'ctrl-F': 'project-find:show'
   'ctrl-f': 'find-and-replace:show'
-  'ctrl-alt-f': 'find-and-replace:show-replace'
 
 '.platform-darwin atom-text-editor':
   'cmd-g': 'find-and-replace:find-next'
@@ -44,9 +43,9 @@
   'ctrl-enter': 'find-and-replace:confirm'
   'alt-enter': 'find-and-replace:find-all'
   'ctrl-alt-/': 'find-and-replace:toggle-regex-option'
-  'ctrl-alt-c': 'find-and-replace:toggle-case-option'
-  'ctrl-alt-s': 'find-and-replace:toggle-selection-option'
-  'ctrl-alt-w': 'find-and-replace:toggle-whole-word-option'
+  'ctrl-shift-c': 'find-and-replace:toggle-case-option'
+  'ctrl-shift-e': 'find-and-replace:toggle-selection-option'
+  'ctrl-shift-.': 'find-and-replace:toggle-whole-word-option'
 
 '.platform-darwin .project-find':
   'cmd-enter': 'project-find:confirm'
@@ -57,8 +56,8 @@
 '.platform-win32 .project-find, .platform-linux .project-find':
   'ctrl-enter': 'project-find:confirm'
   'ctrl-alt-/': 'project-find:toggle-regex-option'
-  'ctrl-alt-c': 'project-find:toggle-case-option'
-  'ctrl-alt-w': 'project-find:toggle-whole-word-option'
+  'ctrl-shift-c': 'find-and-replace:toggle-case-option'
+  'ctrl-shift-.': 'find-and-replace:toggle-whole-word-option'
 
 '.find-and-replace, .project-find, .project-find .results-view':
   'tab': 'find-and-replace:focus-next'


### PR DESCRIPTION
As part of our efforts to support international keyboards we are remapping various ctrl-alt keybindings. This change makes the following adjusments to find and replace keybindings on Windows and Linux only;

- `show-replace` keybinding is removed
- `toggle-case-option` changes to <kbd>ctrl</kbd><kbd>shift</kbd><kbd>c</kbd>
- `toggle-selection-option` keybinding is removed
- `toggle-whole-word-option` keybinding is removed