### PR TITLE
Results pane direction option (#585, #597)

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -13,7 +13,7 @@ ResultsPaneView = require './project/results-pane'
 
 # To convert previous (and now unused) config setting "openProjectFindResultsInRightPane"
 if atom.config.get('find-and-replace.openProjectFindResultsInRightPane')
-  atom.config.set('find-and-replace.openProjectFindResultsInANewPane', 'right pane')
+  atom.config.set('find-and-replace.openProjectFindResultsDirection', 'right')
   atom.config.unset('find-and-replace.openProjectFindResultsInRightPane')
 
 module.exports =

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -302,9 +302,8 @@ class ProjectFindView extends View
 
   showResultPane: ->
     options = {searchAllPanes: true}
-    switch atom.config.get('find-and-replace.openProjectFindResultsInANewPane')
-      when 'right pane' then options.split = 'right'
-      when 'bottom pane' then options.split = 'down'
+    openDirection = atom.config.get('find-and-replace.openProjectFindResultsDirection')
+    options.split = openDirection unless openDirection is 'none'
     atom.workspace.open(ResultsPaneView.URI, options)
 
   onFinishedReplacing: (results) ->

--- a/lib/project/match-view.coffee
+++ b/lib/project/match-view.coffee
@@ -45,8 +45,8 @@ class MatchView extends View
   confirm: (options = {}) ->
     openInNewPane = atom.config.get('find-and-replace.openProjectFindResultsInANewPane')
     switch openInNewPane
-      when 'right pane' then options = {split: 'left'}
-      when 'bottom pane' then options = {split: 'up'}
+      when 'right pane' then options.split = 'left'
+      when 'bottom pane' then options.split = 'up'
     editorPromise = atom.workspace.open(@filePath, options)
     editorPromise.then (editor) =>
       editor.setSelectedBufferRange(@match.range, autoscroll: true)

--- a/lib/project/match-view.coffee
+++ b/lib/project/match-view.coffee
@@ -43,10 +43,13 @@ class MatchView extends View
       @matchText.removeClass('highlight-error').addClass('highlight-info')
 
   confirm: (options = {}) ->
-    openInNewPane = atom.config.get('find-and-replace.openProjectFindResultsInANewPane')
-    switch openInNewPane
-      when 'right pane' then options.split = 'left'
-      when 'bottom pane' then options.split = 'up'
+    reverseDirections =
+        left: 'right'
+        right: 'left'
+        up: 'down'
+        down: 'up'
+    openDirection = atom.config.get('find-and-replace.openProjectFindResultsDirection')
+    options.split = reverseDirections[openDirection] unless openDirection is 'none'
     editorPromise = atom.workspace.open(@filePath, options)
     editorPromise.then (editor) =>
       editor.setSelectedBufferRange(@match.range, autoscroll: true)

--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
       "default": false,
       "description": "Focus the editor and select the next match when a file search is executed. If no matches are found, the editor will not be focused."
     },
-    "openProjectFindResultsInANewPane": {
+    "openProjectFindResultsDirection": {
       "type": "string",
-      "default": "no",
-      "enum": ["no", "right pane", "bottom pane"],
-      "title": "Open Results in a new pane",
+      "default": "none",
+      "enum": ["none", "right", "down"],
+      "title": "Direction to open results pane",
       "description": "When a project-wide search is executed, open the results in a split pane instead of a tab in the same pane."
     },
     "closeFindPanelAfterSearch": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": "https://github.com/atom/find-and-replace",
   "engines": {
-    "atom": ">=1.2.0"
+    "atom": "*"
   },
   "dependencies": {
     "atom-space-pen-views": "^2.1.0",

--- a/spec/project-find-view-spec.coffee
+++ b/spec/project-find-view-spec.coffee
@@ -28,7 +28,7 @@ describe 'ProjectFindView', ->
     atom.project.setPaths([path.join(__dirname, 'fixtures')])
     jasmine.attachToDOM(workspaceElement)
 
-    atom.config.set('find-and-replace.openProjectFindResultsInANewPane', 'no')
+    atom.config.set('find-and-replace.openProjectFindResultsDirection', 'none')
     activationPromise = atom.packages.activatePackage("find-and-replace").then (options) ->
       mainModule = options.mainModule
       mainModule.createViews()
@@ -368,7 +368,7 @@ describe 'ProjectFindView', ->
 
       it "splits when option is right", ->
         initialPane = atom.workspace.getActivePane()
-        atom.config.set('find-and-replace.openProjectFindResultsInANewPane', 'right pane')
+        atom.config.set('find-and-replace.openProjectFindResultsDirection', 'right')
         projectFindView.findEditor.setText('items')
         atom.commands.dispatch(projectFindView[0], 'core:confirm')
 
@@ -381,7 +381,7 @@ describe 'ProjectFindView', ->
 
       it "splits when option is bottom", ->
         initialPane = atom.workspace.getActivePane()
-        atom.config.set('find-and-replace.openProjectFindResultsInANewPane', 'bottom pane')
+        atom.config.set('find-and-replace.openProjectFindResultsDirection', 'down')
         projectFindView.findEditor.setText('items')
         atom.commands.dispatch(projectFindView[0], 'core:confirm')
 
@@ -405,7 +405,7 @@ describe 'ProjectFindView', ->
           expect(pane1).toBe initialPane
 
       it "can be duplicated on the right", ->
-        atom.config.set('find-and-replace.openProjectFindResultsInANewPane', 'right pane')
+        atom.config.set('find-and-replace.openProjectFindResultsDirection', 'right')
         projectFindView.findEditor.setText('items')
         atom.commands.dispatch(projectFindView[0], 'core:confirm')
 
@@ -430,7 +430,7 @@ describe 'ProjectFindView', ->
           expect(resultsPaneView2.querySelector('.preview-count').innerHTML).toEqual resultsPaneView1.querySelector('.preview-count').innerHTML
 
       it "can be duplicated at the bottom", ->
-        atom.config.set('find-and-replace.openProjectFindResultsInANewPane', 'bottom pane')
+        atom.config.set('find-and-replace.openProjectFindResultsDirection', 'down')
         projectFindView.findEditor.setText('items')
         atom.commands.dispatch(projectFindView[0], 'core:confirm')
 
@@ -1452,7 +1452,7 @@ describe 'ProjectFindView', ->
   describe "panel opening", ->
     describe "when a panel is already open on the right", ->
       beforeEach ->
-        atom.config.set('find-and-replace.openProjectFindResultsInANewPane', 'right pane')
+        atom.config.set('find-and-replace.openProjectFindResultsDirection', 'right')
 
         waitsForPromise ->
           atom.workspace.open('sample.js')
@@ -1485,7 +1485,7 @@ describe 'ProjectFindView', ->
 
     describe "when a panel is already open at the bottom", ->
       beforeEach ->
-        atom.config.set('find-and-replace.openProjectFindResultsInANewPane', 'bottom pane')
+        atom.config.set('find-and-replace.openProjectFindResultsDirection', 'down')
 
         waitsForPromise ->
           atom.workspace.open('sample.js')

--- a/spec/results-view-spec.coffee
+++ b/spec/results-view-spec.coffee
@@ -441,9 +441,9 @@ describe 'ResultsView', ->
       runs ->
         expect(atom.views.getView(editor)).toHaveFocus()
 
-    describe "when `openProjectFindResultsInANewPane` option is no", ->
+    describe "when `openProjectFindResultsDirection` option is none", ->
       beforeEach ->
-        atom.config.set('find-and-replace.openProjectFindResultsInANewPane', 'no')
+        atom.config.set('find-and-replace.openProjectFindResultsDirection', 'none')
 
       it "does not specify a pane to split", ->
         spyOn(atom.workspace, 'open').andCallThrough()
@@ -451,9 +451,9 @@ describe 'ResultsView', ->
         atom.commands.dispatch resultsView.element, 'core:confirm'
         expect(atom.workspace.open.mostRecentCall.args[1]).toEqual {}
 
-    describe "when `openProjectFindResultsInANewPane` option is right pane", ->
+    describe "when `openProjectFindResultsDirection` option is right", ->
       beforeEach ->
-        atom.config.set('find-and-replace.openProjectFindResultsInANewPane', 'right pane')
+        atom.config.set('find-and-replace.openProjectFindResultsDirection', 'right')
 
       it "always opens the file in the left pane", ->
         spyOn(atom.workspace, 'open').andCallThrough()
@@ -474,9 +474,9 @@ describe 'ResultsView', ->
           runs ->
             expect(atom.views.getView(editor)).toHaveFocus()
 
-    describe "when `openProjectFindResultsInANewPane` option is bottom pane", ->
+    describe "when `openProjectFindResultsDirection` option is down", ->
       beforeEach ->
-        atom.config.set('find-and-replace.openProjectFindResultsInANewPane', 'bottom pane')
+        atom.config.set('find-and-replace.openProjectFindResultsDirection', 'down')
 
       it "always opens the file in the up pane", ->
         spyOn(atom.workspace, 'open').andCallThrough()


### PR DESCRIPTION
It would be great to be able to open project-find results in a downward pane as per #585, so I'm attempting to update and address the comments on #597 by @bencolon. Changes from that PR:

- Resolved the conflict in one of the spec files
- Now using a none/down/right schema to match atom/markdown-preview#368 as per review comment by @acontreras89 (allows for future support of left/up if desired)
- A fix for a problem with single-click pending mode that the specs were catching