### PR TITLE
Don't rely on destroyed markers preserving their ranges

### DIFF
--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -270,8 +270,9 @@ class BufferSearch {
   }
 
   recreateMarker(marker) {
+    const range = marker.getBufferRange()
     marker.destroy();
-    return this.createMarker(marker.getBufferRange());
+    return this.createMarker(range);
   }
 
   createMarker(range) {

--- a/spec/buffer-search-spec.coffee
+++ b/spec/buffer-search-spec.coffee
@@ -411,8 +411,11 @@ describe "BufferSearch", ->
         [[7, 8], [7, 11]]
       ]
 
-      editor.setSelectedBufferRange(markers[2].getBufferRange())
-      expect(currentResultListener).toHaveBeenCalledWith(markers[2])
+      markerToSelect = markers[2]
+      rangeToSelect = markerToSelect.getBufferRange()
+
+      editor.setSelectedBufferRange(rangeToSelect)
+      expect(currentResultListener).toHaveBeenCalledWith(markerToSelect)
       currentResultListener.reset()
 
       advanceClock(editor.buffer.stoppedChangingDelay)
@@ -430,7 +433,7 @@ describe "BufferSearch", ->
       ]
 
       expect(currentResultListener).toHaveBeenCalled()
-      expect(currentResultListener.mostRecentCall.args[0].getBufferRange()).toEqual markers[2].getBufferRange()
+      expect(currentResultListener.mostRecentCall.args[0].getBufferRange()).toEqual rangeToSelect
       expect(currentResultListener.mostRecentCall.args[0].isDestroyed()).toBe false
 
     it "replaces the marked text with the given string that contains escaped escape sequence", ->

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -691,7 +691,6 @@ describe 'FindView', ->
         atom.workspace.destroyActivePane()
         atom.commands.dispatch workspaceElement, 'find-and-replace:use-selection-as-find-pattern'
         expect(findView.findEditor.getText()).toBe 'sort'
-        expect(editor.getSelectedBufferRange()).toEqual [[8, 11], [8, 15]]
 
       it "places the word under the cursor into the find editor", ->
         editor.setSelectedBufferRange([[1, 8], [1, 8]])


### PR DESCRIPTION
When https://github.com/atom/text-buffer/pull/193 lands, we will no longer track the ranges of destroyed markers. This requires a minor tweak in this package to query markers' ranges *before* destroying them.

/cc @nathansobo I could imagine community package authors having to make similar changes 😬 