### PR TITLE
[WIP] Fix wrapping on narrow windows

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -40,8 +40,6 @@ class FindView extends View
             @button outlet: 'nextButton', class: 'btn', 'Find'
           @div class: 'btn-group btn-group-find-all', =>
             @button outlet: 'findAllButton', class: 'btn', 'Find All'
-
-        @div class: 'input-block-item option-block', =>
           @div class: 'btn-group btn-toggle btn-group-options', =>
             @button outlet: 'regexOptionButton', class: 'btn', =>
               @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-regex" /></svg>'
@@ -57,8 +55,6 @@ class FindView extends View
             @button outlet: 'replaceNextButton', class: 'btn btn-next', 'Replace'
           @div class: 'btn-group btn-group-replace-all', =>
             @button outlet: 'replaceAllButton', class: 'btn btn-all', 'Replace All'
-
-        @div class: 'input-block-item option-block', =>
           @div class: 'btn-group btn-toggle btn-group-options', =>
             @button outlet: 'selectionOptionButton', class: 'btn option-selection', =>
               @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-selection" /></svg>'

--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -29,37 +29,37 @@ class FindView extends View
           @span 'Finding with Options: '
           @span outlet: 'optionsLabel', class: 'options'
 
-      @section class: 'input-block find-container', =>
-        @div class: 'input-block-item input-block-item--flex editor-container', =>
-          @subview 'findEditor', new TextEditorView(editor: findEditor)
-          @div class: 'find-meta-container', =>
-            @span outlet: 'resultCounter', class: 'text-subtle result-counter', ''
+      @main class: 'find-wrapper', =>
+        @section class: 'find-wrapper-item find-wrapper-item--flex', =>
+          @div class: 'input-block-item editor-container', =>
+            @subview 'findEditor', new TextEditorView(editor: findEditor)
+            @div class: 'find-meta-container', =>
+              @span outlet: 'resultCounter', class: 'text-subtle result-counter', ''
+          @div class: 'input-block-item editor-container', =>
+            @subview 'replaceEditor', new TextEditorView(editor: replaceEditor)
 
-        @div class: 'input-block-item', =>
-          @div class: 'btn-group btn-group-find', =>
-            @button outlet: 'nextButton', class: 'btn', 'Find'
-          @div class: 'btn-group btn-group-find-all', =>
-            @button outlet: 'findAllButton', class: 'btn', 'Find All'
-          @div class: 'btn-group btn-toggle btn-group-options', =>
-            @button outlet: 'regexOptionButton', class: 'btn', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-regex" /></svg>'
-            @button outlet: 'caseOptionButton', class: 'btn', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-case" /></svg>'
+        @section class: 'find-wrapper-item', =>
+          @div class: 'input-block-item', =>
+            @div class: 'btn-group btn-group-find', =>
+              @button outlet: 'nextButton', class: 'btn', 'Find'
+            @div class: 'btn-group btn-group-find-all', =>
+              @button outlet: 'findAllButton', class: 'btn', 'Find All'
+            @div class: 'btn-group btn-toggle btn-group-options', =>
+              @button outlet: 'regexOptionButton', class: 'btn', =>
+                @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-regex" /></svg>'
+              @button outlet: 'caseOptionButton', class: 'btn', =>
+                @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-case" /></svg>'
 
-      @section class: 'input-block replace-container', =>
-        @div class: 'input-block-item input-block-item--flex editor-container', =>
-          @subview 'replaceEditor', new TextEditorView(editor: replaceEditor)
-
-        @div class: 'input-block-item', =>
-          @div class: 'btn-group btn-group-replace', =>
-            @button outlet: 'replaceNextButton', class: 'btn btn-next', 'Replace'
-          @div class: 'btn-group btn-group-replace-all', =>
-            @button outlet: 'replaceAllButton', class: 'btn btn-all', 'Replace All'
-          @div class: 'btn-group btn-toggle btn-group-options', =>
-            @button outlet: 'selectionOptionButton', class: 'btn option-selection', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-selection" /></svg>'
-            @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-word" /></svg>'
+          @div class: 'input-block-item', =>
+            @div class: 'btn-group btn-group-replace', =>
+              @button outlet: 'replaceNextButton', class: 'btn btn-next', 'Replace'
+            @div class: 'btn-group btn-group-replace-all', =>
+              @button outlet: 'replaceAllButton', class: 'btn btn-all', 'Replace All'
+            @div class: 'btn-group btn-toggle btn-group-options', =>
+              @button outlet: 'selectionOptionButton', class: 'btn option-selection', =>
+                @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-selection" /></svg>'
+              @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', =>
+                @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-word" /></svg>'
 
       @raw '<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
         <symbol id="find-and-replace-icon-regex" viewBox="0 0 20 16" stroke="none" fill-rule="evenodd">

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -45,6 +45,13 @@ atom-workspace.find-visible {
   .header {
     padding: @component-padding/4 @component-padding/2;
     min-width: @min-width;
+
+    // clearfix for .pull-right
+    &:after {
+      content: "";
+      display: table;
+      clear: both;
+    }
   }
   .header-item {
     margin: @component-padding/4 0;
@@ -122,10 +129,15 @@ atom-workspace.find-visible {
   @option-button-width: 100px;  // option buttons
   @item-width: 300px;          // wrap block width
 
-  .input-block-item {
+  .find-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .find-wrapper-item {
     flex: 1 1 @item-width;
   }
-  .input-block-item--flex {
+  .find-wrapper-item--flex {
     flex: 100 1 @item-width;
   }
 

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -120,17 +120,13 @@ atom-workspace.find-visible {
 .find-and-replace {
   @button-width: 120px;        // Find + Replace + Find All + Replace All buttons
   @option-button-width: 100px;  // option buttons
-  @item-width: 260px;          // wrap block width
+  @item-width: 300px;          // wrap block width
 
   .input-block-item {
     flex: 1 1 @item-width;
   }
   .input-block-item--flex {
     flex: 100 1 @item-width;
-  }
-
-  .input-block-item.option-block {
-    flex-basis: @option-button-width;
   }
 
   .btn-group-find,


### PR DESCRIPTION
### Description of the Change

Fixes the wrapping when the window gets narrow.

Before | After
--- | ---
![wrapped](https://cloud.githubusercontent.com/assets/326587/21731683/646c54b4-d40a-11e6-967c-7e7f35b43b12.png) | ![screen shot 2017-01-08 at 8 04 04 pm](https://cloud.githubusercontent.com/assets/378023/21749227/040eee62-d5de-11e6-8f24-3c6dadb9183b.png)

### Benefits

Keeps the options button grouped together on narrow windows.

### Possible Drawbacks

It's now a bit different than the project search. Also markup/css don't share as much anymore.

### Applicable Issues

This is a follow up to: https://github.com/atom/find-and-replace/pull/785#issuecomment-270996274
