### PR TITLE
Move options into the header

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -28,6 +28,15 @@ class FindView extends View
         @span class: 'header-item options-label pull-right', =>
           @span 'Finding with Options: '
           @span outlet: 'optionsLabel', class: 'options'
+          @span class: 'btn-group btn-toggle btn-group-options', =>
+            @button outlet: 'regexOptionButton', class: 'btn', =>
+              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-regex" /></svg>'
+            @button outlet: 'caseOptionButton', class: 'btn', =>
+              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-case" /></svg>'
+            @button outlet: 'selectionOptionButton', class: 'btn option-selection', =>
+              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-selection" /></svg>'
+            @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', =>
+              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-word" /></svg>'
 
       @section class: 'input-block find-container', =>
         @div class: 'input-block-item input-block-item--flex editor-container', =>
@@ -37,16 +46,9 @@ class FindView extends View
 
         @div class: 'input-block-item', =>
           @div class: 'btn-group btn-group-find', =>
-            @button outlet: 'nextButton', class: 'btn', 'Find'
+            @button outlet: 'nextButton', class: 'btn btn-next', 'Find'
           @div class: 'btn-group btn-group-find-all', =>
-            @button outlet: 'findAllButton', class: 'btn', 'Find All'
-
-        @div class: 'input-block-item option-block', =>
-          @div class: 'btn-group btn-toggle btn-group-options', =>
-            @button outlet: 'regexOptionButton', class: 'btn', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-regex" /></svg>'
-            @button outlet: 'caseOptionButton', class: 'btn', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-case" /></svg>'
+            @button outlet: 'findAllButton', class: 'btn btn-all', 'Find All'
 
       @section class: 'input-block replace-container', =>
         @div class: 'input-block-item input-block-item--flex editor-container', =>
@@ -57,13 +59,6 @@ class FindView extends View
             @button outlet: 'replaceNextButton', class: 'btn btn-next', 'Replace'
           @div class: 'btn-group btn-group-replace-all', =>
             @button outlet: 'replaceAllButton', class: 'btn btn-all', 'Replace All'
-
-        @div class: 'input-block-item option-block', =>
-          @div class: 'btn-group btn-toggle btn-group-options', =>
-            @button outlet: 'selectionOptionButton', class: 'btn option-selection', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-selection" /></svg>'
-            @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-word" /></svg>'
 
       @raw '<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
         <symbol id="find-and-replace-icon-regex" viewBox="0 0 20 16" stroke="none" fill-rule="evenodd">

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -41,6 +41,13 @@ class ProjectFindView extends View
         @span class: 'header-item options-label pull-right', =>
           @span 'Finding with Options: '
           @span outlet: 'optionsLabel', class: 'options'
+          @span class: 'btn-group btn-toggle btn-group-options', =>
+            @button outlet: 'regexOptionButton', class: 'btn option-regex', =>
+              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-regex" /></svg>'
+            @button outlet: 'caseOptionButton', class: 'btn option-case-sensitive', =>
+              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-case" /></svg>'
+            @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', =>
+              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-word" /></svg>'
 
       @section outlet: 'replacmentInfoBlock', class: 'input-block', =>
         @progress outlet: 'replacementProgress', class: 'inline-block'
@@ -52,13 +59,6 @@ class ProjectFindView extends View
         @div class: 'input-block-item', =>
           @div class: 'btn-group btn-group-find', =>
             @button outlet: 'findAllButton', class: 'btn', 'Find'
-          @div class: 'btn-group btn-toggle btn-group-options', =>
-            @button outlet: 'regexOptionButton', class: 'btn option-regex', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-regex" /></svg>'
-            @button outlet: 'caseOptionButton', class: 'btn option-case-sensitive', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-case" /></svg>'
-            @button outlet: 'wholeWordOptionButton', class: 'btn option-whole-word', =>
-              @raw '<svg class="icon"><use xlink:href="#find-and-replace-icon-word" /></svg>'
 
       @section class: 'input-block replace-container', =>
         @div class: 'input-block-item input-block-item--flex editor-container', =>

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -58,7 +58,7 @@ class ProjectFindView extends View
           @subview 'findEditor', new TextEditorView(editor: findEditor)
         @div class: 'input-block-item', =>
           @div class: 'btn-group btn-group-find', =>
-            @button outlet: 'findAllButton', class: 'btn', 'Find'
+            @button outlet: 'findAllButton', class: 'btn', 'Find All'
 
       @section class: 'input-block replace-container', =>
         @div class: 'input-block-item input-block-item--flex editor-container', =>

--- a/spec/find-view-spec.coffee
+++ b/spec/find-view-spec.coffee
@@ -1334,7 +1334,7 @@ describe 'FindView', ->
     describe "replace all", ->
       describe "when the replace all button is pressed", ->
         it "replaces all matched text", ->
-          $('.find-and-replace .btn-all').click()
+          findView.replaceAllButton.click()
           expect(findView.resultCounter.text()).toEqual('no results')
           expect(editor.getText()).not.toMatch /items/
           expect(editor.getText().match(/\bcats\b/g)).toHaveLength 6

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -74,9 +74,9 @@ atom-workspace.find-visible {
   }
 
   .btn-group-options {
-    .btn {
-      line-height: 1;
-    }
+    display: inline-flex;
+    width: 140px;
+    margin-left: .5em;
   }
 
   .btn > .icon {
@@ -118,34 +118,21 @@ atom-workspace.find-visible {
 
 // Buffer find and replace
 .find-and-replace {
-  @button-width: 120px;        // Find + Replace + Find All + Replace All buttons
-  @option-button-width: 100px;  // option buttons
-  @item-width: 260px;          // wrap block width
-
-  .input-block-item {
-    flex: 1 1 @item-width;
-  }
-  .input-block-item--flex {
-    flex: 100 1 @item-width;
-  }
-
-  .input-block-item.option-block {
-    flex-basis: @option-button-width;
-  }
 
   .btn-group-find,
-  .btn-group-replace,
+  .btn-group-replace {
+    flex: 1;
+  }
+
   .btn-group-find-all,
-  .btn-group-replace-all, {
-    flex: 1 1 @button-width;
+  .btn-group-replace-all {
+    flex: 2;
   }
 
   .btn-group-options {
-    flex: 1 1 @option-button-width;
     .btn {
-      flex: 1 1 25%;
-      padding: 0;
-      text-align: center;
+    margin-top: -.1em;
+      line-height: 1.75;
     }
   }
 

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -45,6 +45,7 @@ atom-workspace.find-visible {
   .header {
     padding: @component-padding/4 @component-padding/2;
     min-width: @min-width;
+    line-height: 1.75;
   }
   .header-item {
     margin: @component-padding/4 0;
@@ -73,12 +74,6 @@ atom-workspace.find-visible {
     }
   }
 
-  .btn-group-options {
-    display: inline-flex;
-    width: 140px;
-    margin-left: .5em;
-  }
-
   .btn > .icon {
     width: 20px;
     height: 16px;
@@ -103,7 +98,19 @@ atom-workspace.find-visible {
     color: @text-color-subtle;
     position: relative;
     .options {
+      margin-right: .5em;
       color: @text-color;
+    }
+  }
+
+  .btn-group-options {
+    display: inline-flex;
+    margin-top: -.1em;
+
+    .btn {
+      width: 36px;
+      padding: 0;
+      line-height: 1.75;
     }
   }
 
@@ -118,6 +125,15 @@ atom-workspace.find-visible {
 
 // Buffer find and replace
 .find-and-replace {
+  @input-width: 260px;
+  @block-width: 260px;
+
+  .input-block-item {
+    flex: 1 1 @block-width;
+  }
+  .input-block-item--flex {
+    flex: 100 1 @input-width;
+  }
 
   .btn-group-find,
   .btn-group-replace {
@@ -127,13 +143,6 @@ atom-workspace.find-visible {
   .btn-group-find-all,
   .btn-group-replace-all {
     flex: 2;
-  }
-
-  .btn-group-options {
-    .btn {
-    margin-top: -.1em;
-      line-height: 1.75;
-    }
   }
 
   .find-container atom-text-editor {
@@ -190,17 +199,13 @@ atom-workspace.find-visible {
 // Project find and replace
 .project-find {
   @project-input-width: 260px;
-  @project-block-width: 220px;
+  @project-block-width: 160px;
 
   .input-block-item {
     flex: 1 1 @project-block-width;
   }
   .input-block-item--flex {
     flex: 100 1 @project-input-width;
-  }
-
-  .btn-group-find {
-    flex: .6;
   }
 
   .loading,


### PR DESCRIPTION
### Description of the Change

This moves the option buttons into the header.

#### Before

![screen shot 2017-01-10 at 9 21 46 pm](https://cloud.githubusercontent.com/assets/378023/21806074/dc27a288-d77a-11e6-864f-e072933e685c.png)

#### After

![screen shot 2017-01-10 at 9 18 03 pm](https://cloud.githubusercontent.com/assets/378023/21806090/e8bca836-d77a-11e6-89f5-566c44315636.png)

Also the "Find in project" options got are moved to stay consistent:

![screen shot 2017-01-10 at 9 33 39 pm](https://cloud.githubusercontent.com/assets/378023/21806423/877c0d76-d77c-11e6-9ba2-f8a49ad1c107.png)

Note: The buttons are a bit large, but that's an issue with the One themes.


### Benefits

Keeps the options button grouped together in a row and doesn't give the impression that the bottom two are part of "replace".

### Possible Drawbacks

- The header text starts wrapping earlier
- Initially will mess with people's muscle/visual memory.

### Applicable Issues

This is a follow up to: https://github.com/atom/find-and-replace/pull/785#issuecomment-270996274

And an alternative to: https://github.com/atom/find-and-replace/pull/839