### PR TITLE
Fix copying `ResultsView` into a new pane after opening and closing a search result

### DIFF
--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -4,7 +4,18 @@ escapeHelper = require '../escape-helper'
 
 class Result
   @create: (result) ->
-    if result?.matches?.length then new Result(result) else null
+    if result?.matches?.length
+      matches = result.matches.map((m) ->
+        return {
+          matchText: m.matchText,
+          lineText: m.lineText,
+          lineTextOffset: m.lineTextOffset,
+          range: m.range
+        }
+      )
+      new Result({filePath: result.filePath, matches})
+    else
+      null
 
   constructor: (result) ->
     _.extend(this, result)

--- a/spec/results-model-spec.coffee
+++ b/spec/results-model-spec.coffee
@@ -107,6 +107,16 @@ describe 'ResultsModel', ->
         advanceClock(editor.buffer.stoppedChangingDelay)
         expect(editor.scan).not.toHaveBeenCalled()
 
+    it "contains valid match objects after destroying a buffer (regression)", ->
+      waitsForPromise ->
+        resultsModel.search('items', '*.js', '')
+
+      runs ->
+        advanceClock(editor.buffer.stoppedChangingDelay)
+        editor.getBuffer().destroy()
+        result = resultsModel.getResult(editor.getPath())
+        expect(result.matches[0].lineText).toBe("  var sort = function(items) {")
+
   describe "cancelling a search", ->
     cancelledSpy = null
     beforeEach ->


### PR DESCRIPTION
Fixes #841.

As a result of https://github.com/atom/text-buffer/pull/193, buffers are now emptied out after they get destroyed, although they can still be queried without throwing exceptions. This package was mistakenly assuming that queries to destroyed buffers would return valid answers. In particular, an error was being thrown after doing a workspace-wide search, opening a search result, then closing it and copying the current `ResultsView` into a new pane (as mentioned in https://github.com/atom/find-and-replace/issues/841#issuecomment-274886326).

This problem occurred because `ResultsModel` was storing references to the match objects created via `TextBuffer.prototype.scan`: these objects (e.g. https://github.com/atom/text-buffer/blob/master/src/match-iterator.coffee#L4) contain lazily computed properties (such as `lineText`) that perform queries to a `TextBuffer` instance. Hence, if someones tries to access such properties after destroying a buffer (as it happens when copying a `ResultsView` into a new pane), an exception is thrown.

With this pull request we will now copy the match objects, thus forcing the computation of those aforementioned lazily computed properties. Please note that this should introduce very little memory and CPU overhead, as we already access these properties (and thus compute them at least once) when rendering `ResultsView`'s contents.

/cc: @atom/maintainers 
