### PR TITLE
Fix typos

### DIFF
--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -100,7 +100,7 @@ class ProjectFindView {
             etch.dom(TextEditor, {
               ref: 'pathsEditor',
               mini: true,
-              placeholderText: 'File/directory pattern. eg. `src` to search in the "src" directory or `*.js` to search all javascript files.',
+              placeholderText: 'File/directory pattern. eg. `src` to search in the "src" directory or `*.js` to search all JavaScript files',
               buffer: this.pathsBuffer
             })
           )

--- a/lib/project/result-view.js
+++ b/lib/project/result-view.js
@@ -106,7 +106,7 @@ class ResultView {
             relativePath
           ),
           $.span({ref: 'description', className: 'path-match-number'},
-            `(${this.matches.length} matches)`
+            `(${this.matches.length} match${this.matches.length === 1 ? '' : 'es'})`
           )
         ),
 


### PR DESCRIPTION
### Description of the Change

This PR is a combination of pedantic fixes I picked up on while preparing #870:

* A solitary match is incorrectly pluralised in the project-view: `(1 matches)`
* "JavaScript" should be capitalised properly
* Full-stop removed from the project-search field, to be consistent with the preceding two fields

### Alternate Designs

N/A

### Benefits

It scratches my OCD itch (and also tidies stuff too trivial for many people to notice/care about).

### Possible Drawbacks

I look like a pedantic prick.

### Applicable Issues

I actually am a pedantic prick.
