### PR TITLE
add close button

### DIFF
--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -469,7 +469,7 @@ class FindView {
 
   clearMessage() {
     this.element.classList.remove('has-results', 'has-no-results');
-    this.refs.descriptionLabel.innerHTML = 'Find in Current Buffer <span class="subtle-info-message">Close this panel with the <span class="highlight">esc</span> key</span>'
+    this.refs.descriptionLabel.innerHTML = 'Find in Current Buffer'
     this.refs.descriptionLabel.classList.remove('text-error');
   }
 

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -31,6 +31,10 @@ class FindView {
     return (
       $.div({tabIndex: -1, className: 'find-and-replace'},
         $.header({className: 'header'},
+          $.span({ref: 'closeButton', className: 'header-item close-button pull-right'},
+            $.i({className: "icon icon-x clickable"})
+          ),
+
           $.span({ref: 'descriptionLabel', className: 'header-item description'},
             'Find in Current Buffer'
           ),
@@ -164,6 +168,10 @@ class FindView {
     if (this.tooltipSubscriptions) return;
 
     this.tooltipSubscriptions = new CompositeDisposable(
+      atom.tooltips.add(this.refs.closeButton, {
+        title: 'Close Panel <span class="keystroke">Esc</span>',
+        html: true
+      }),
       atom.tooltips.add(this.refs.regexOptionButton, {
         title: "Use Regex",
         keyBindingCommand: 'find-and-replace:toggle-regex-option',
@@ -241,6 +249,7 @@ class FindView {
     this.subscriptions.add(this.model.onDidChangeCurrentResult(this.updateResultCounter.bind(this)));
     this.subscriptions.add(this.model.getFindOptions().onDidChange(this.updateOptionViews.bind(this)));
 
+    this.refs.closeButton.addEventListener('click', () => this.panel && this.panel.hide());
     this.refs.regexOptionButton.addEventListener('click', this.toggleRegexOption.bind(this));
     this.refs.caseOptionButton.addEventListener('click', this.toggleCaseOption.bind(this));
     this.refs.selectionOptionButton.addEventListener('click', this.toggleSelectionOption.bind(this));

--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -411,7 +411,7 @@ class ProjectFindView {
 
   clearMessages() {
     this.element.classList.remove('has-results', 'has-no-results');
-    this.setInfoMessage('Find in Project <span class="subtle-info-message">Close this panel with the <span class="highlight">esc</span> key</span>');
+    this.setInfoMessage('Find in Project');
     this.refs.replacmentInfoBlock.style.display = 'none';
   }
 

--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -40,6 +40,9 @@ class ProjectFindView {
     return (
       $.div({tabIndex: -1, className: 'project-find padded'},
         $.header({className: 'header'},
+          $.span({ref: 'closeButton', className: 'header-item close-button pull-right'},
+            $.i({className: "icon icon-x clickable"})
+          ),
           $.span({ref: 'descriptionLabel', className: 'header-item description'}),
           $.span({className: 'header-item options-label pull-right'},
             $.span({}, 'Finding with Options: '),
@@ -135,6 +138,11 @@ class ProjectFindView {
 
     this.updateReplaceAllButtonEnablement();
     this.tooltipSubscriptions = new CompositeDisposable(
+      atom.tooltips.add(this.refs.closeButton, {
+        title: 'Close Panel <span class="keystroke">Esc</span>',
+        html: true
+      }),
+
       atom.tooltips.add(this.refs.regexOptionButton, {
         title: "Use Regex",
         keyBindingCommand: 'project-find:toggle-regex-option',
@@ -219,6 +227,7 @@ class ProjectFindView {
     this.subscriptions.add(this.model.getFindOptions().onDidChange(this.updateOptionViews.bind(this)));
 
     this.element.addEventListener('focus', () => this.findEditor.element.focus());
+    this.refs.closeButton.addEventListener('click', () => this.panel && this.panel.hide());
     this.refs.regexOptionButton.addEventListener('click', () => this.toggleRegexOption());
     this.refs.caseOptionButton.addEventListener('click', () => this.toggleCaseOption());
     this.refs.wholeWordOptionButton.addEventListener('click', () => this.toggleWholeWordOption());

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -82,6 +82,11 @@ atom-workspace.find-visible {
     stroke: currentColor;
   }
 
+  .close-button {
+    padding-left: 10px;
+    cursor: pointer;
+  }
+
   .description {
     display: inline-block;
     .subtle-info-message {

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -83,8 +83,17 @@ atom-workspace.find-visible {
   }
 
   .close-button {
-    padding-left: 10px;
+    margin-left: @component-padding;
     cursor: pointer;
+    color: @text-color-subtle;
+    &:hover {
+      color: @text-color-highlight;
+    }
+    .icon::before {
+      margin-right: 0;
+      text-align: center;
+      vertical-align: middle;
+    }
   }
 
   .description {


### PR DESCRIPTION

### Description of the Change

Add a close button to the Find in Current Buffer panel and the Find in Project panel

![image](https://cloud.githubusercontent.com/assets/97994/25116159/9215ac2e-23d0-11e7-973b-3e49bb7bf948.png)


<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

Could be on the left

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

People with a 2016 Macbook pro can finally close the find-and-replace panel

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Takes up screen real estate. Might need to consider a setting to enable/disable it.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

#164
#204
#219
#347
#683

<!-- Enter any applicable Issues here -->
