### PR TITLE
Trigger project-find:show-in-current-directory with hotkey

### DIFF
--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -354,7 +354,7 @@ class ProjectFindView {
   }
 
   directoryPathForElement(element) {
-    const directoryElement = element.closest('.directory');
+    const directoryElement = element.closest('.directory') || element.querySelector('.selected.directory');
     if (directoryElement) {
       const pathElement = directoryElement.querySelector('[data-path]')
       return pathElement && pathElement.dataset.path;

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -181,33 +181,34 @@ describe('ProjectFindView', () => {
       projectPath = temp.mkdirSync("atom");
       atom.project.setPaths([projectPath]);
 
-      tree = document.createElement('div');
-      tree.className = 'directory';
+      tree = document.createElement('ol');
       tree.innerHTML = dedent`
-        <div>
-          <span class='name' data-path='${escapePath(projectPath)}'>${projectPath}</span>
-          <ul class='files'>
-            <li class='file' data-path='${escapePath(path.join(projectPath, 'one.js'))}'>
-              <span class='name'>one.js</span>
-            </li>
-            <li class='file' data-path='${escapePath(path.join(projectPath, 'two.js'))}'>
-              <span class='name'>two.js</span>
-            </li>
-            <div class='directory'>
-              <div>
-                <span class='name' data-path='${escapePath(path.join(projectPath, 'nested'))}'>nested</span>
-                <ul class='file'>
-                  <li class='file' data-path='${escapePath(path.join(projectPath, 'three.js'))}'>
-                    <span class='name'>three.js</span>
-                  </li>
-                </ul>
+        <div class="directory">
+          <div>
+            <span class='name' data-path='${escapePath(projectPath)}'>${projectPath}</span>
+            <ul class='files'>
+              <li class='file' data-path='${escapePath(path.join(projectPath, 'one.js'))}'>
+                <span class='name'>one.js</span>
+              </li>
+              <li class='file' data-path='${escapePath(path.join(projectPath, 'two.js'))}'>
+                <span class='name'>two.js</span>
+              </li>
+              <div class='selected directory'>
+                <div>
+                  <span class='name' data-path='${escapePath(path.join(projectPath, 'nested'))}'>nested</span>
+                  <ul class='file'>
+                    <li class='file' data-path='${escapePath(path.join(projectPath, 'three.js'))}'>
+                      <span class='name'>three.js</span>
+                    </li>
+                  </ul>
+                </div>
               </div>
-            </div>
-          </ul>
+            </ul>
+          </div>
         </div>
       `;
 
-      nested = tree.querySelector('.directory');
+      nested = tree.querySelector('.selected.directory');
 
       workspaceElement.appendChild(tree);
     });
@@ -263,6 +264,16 @@ describe('ProjectFindView', () => {
 
         expect(getAtomPanel()).toBeVisible();
         expect(projectFindView.pathsEditor.getText()).toBe(path.join(path.basename(projectPath), 'nested'));
+      });
+    });
+
+    describe('when it is triggered with a hotkey', () => {
+      it('should use selected directory from tree-view as search path', async () => {
+        atom.commands.dispatch(tree, 'project-find:show-in-current-directory');
+        await activationPromise;
+
+        expect(getAtomPanel()).toBeVisible();
+        expect(projectFindView.pathsEditor.getText()).toBe('nested');
       });
     });
   });


### PR DESCRIPTION
### Description of the Change
When `project-find:show-in-current-directory` is triggered with a mouse click the element we get is span, therefore searching for ancestor with `closest('.directory')` works.
But when it's triggered with a hotkey we get main `ol .tree-view`, thus we need to search for selected directory in descendants.
### Alternate Designs
None that i can think of.
### Benefits
Bug fixed :)
### Possible Drawbacks
None that i can think of.
### Applicable Issues
#592 
