### PR TITLE
Added prev button

### DIFF
--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -73,10 +73,12 @@ class FindView {
           ),
 
           $.div({className: 'input-block-item'},
+		    $.div({className: 'btn-group btn-group-find-previous'},
+			  $.button({ref: 'previousButton', className: 'btn btn-previous'}, 'Find prev')
+		    ),
             $.div({className: 'btn-group btn-group-find'},
               $.button({ref: 'nextButton', className: 'btn btn-next'}, 'Find')
             ),
-
             $.div({className: 'btn-group btn-group-find-all'},
               $.button({ref: 'findAllButton', className: 'btn btn-all'}, 'Find All')
             )
@@ -190,6 +192,11 @@ class FindView {
         keyBindingCommand: 'find-and-replace:find-next',
         keyBindingTarget: this.findEditor.element
       }),
+	  atom.tooltips.add(this.refs.previousButton, {
+        title: "Find Previous",
+        keyBindingCommand: 'find-and-replace:find-previous',
+        keyBindingTarget: this.findEditor.element
+      }),
       atom.tooltips.add(this.refs.findAllButton, {
         title: "Find All",
         keyBindingCommand: 'find-and-replace:find-all',
@@ -258,6 +265,8 @@ class FindView {
   handleFindEvents() {
     this.findEditor.onDidStopChanging(() => this.liveSearch());
     this.refs.nextButton.addEventListener('click', e => e.shiftKey ? this.findPrevious({focusEditorAfter: true}) : this.findNext({focusEditorAfter: true}));
+	this.refs.previousButton.addEventListener('click', e => this.findPrevious({focusEditorAfter: true}));
+
     this.refs.findAllButton.addEventListener('click', this.findAll.bind(this));
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'find-and-replace:find-next': () => this.findNext({focusEditorAfter: true}),


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Simply added the Find prev button back into the find and replace view.

### Alternate Designs

No other alternate designs. People want the button.

### Benefits

A new button called "Find prev" will be added before the Find button.

### Possible Drawbacks

A change in UI that might stump people used to having the "Find" button first. I added the "Find prev" button before because it's the logical location.

### Applicable Issues

None. 