### PR TITLE
Use workspace center for all pane item interactions

### DIFF
--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -289,7 +289,7 @@ class FindView {
   }
 
   focusFindEditor() {
-    const activeEditor = atom.workspace.getActiveTextEditor()
+    const activeEditor = atom.workspace.getCenter().getActiveTextEditor()
     let selectedText = activeEditor && activeEditor.getSelectedText()
     if (selectedText && selectedText.indexOf('\n') < 0) {
       if (this.model.getFindOptions().useRegex) {
@@ -302,7 +302,7 @@ class FindView {
   }
 
   focusReplaceEditor() {
-    const activeEditor = atom.workspace.getActiveTextEditor()
+    const activeEditor = atom.workspace.getCenter().getActiveTextEditor()
     const selectedText = activeEditor && activeEditor.getSelectedText()
     if (selectedText && selectedText.indexOf('\n') < 0) {
       this.replaceEditor.setText(selectedText);

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -29,7 +29,7 @@ module.exports =
     @findModel = new BufferSearch(@findOptions)
     @resultsModel = new ResultsModel(@findOptions)
 
-    @subscriptions.add atom.workspace.observeActivePaneItem (paneItem) =>
+    @subscriptions.add atom.workspace.getCenter().observeActivePaneItem (paneItem) =>
       if paneItem?.getBuffer?()
         @findModel.setEditor(paneItem)
       else

--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -279,7 +279,7 @@ class ProjectFindView {
   }
 
   focusFindElement() {
-    const activeEditor = atom.workspace.getActiveTextEditor();
+    const activeEditor = atom.workspace.getCenter().getActiveTextEditor();
     let selectedText = activeEditor && activeEditor.getSelectedText()
     if (selectedText && selectedText.indexOf('\n') < 0) {
       if (this.model.getFindOptions().useRegex) {
@@ -368,7 +368,7 @@ class ProjectFindView {
       const pathElement = directoryElement.querySelector('[data-path]')
       return pathElement && pathElement.dataset.path;
     } else {
-      const activeEditor = atom.workspace.getActiveTextEditor();
+      const activeEditor = atom.workspace.getCenter().getActiveTextEditor();
       if (activeEditor) {
         const editorPath = activeEditor.getPath()
         if (editorPath) {
@@ -450,7 +450,7 @@ class ProjectFindView {
   }
 
   setSelectionAsFindPattern() {
-    const editor = atom.workspace.getActivePaneItem();
+    const editor = atom.workspace.getCenter().getActivePaneItem();
     if (editor && editor.getSelectedText) {
       let pattern = editor.getSelectedText() || editor.getWordUnderCursor();
       if (this.model.getFindOptions().useRegex) {

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -1,5 +1,5 @@
 _ = require 'underscore-plus'
-{Emitter} = require 'atom'
+{Emitter, TextEditor} = require 'atom'
 escapeHelper = require '../escape-helper'
 
 class Result
@@ -27,8 +27,9 @@ class ResultsModel
   constructor: (@findOptions) ->
     @emitter = new Emitter
 
-    atom.workspace.observeTextEditors (editor) =>
-      editor.onDidStopChanging => @onContentsModified(editor)
+    atom.workspace.getCenter().observeActivePaneItem (item) =>
+      if item instanceof TextEditor
+        item.onDidStopChanging => @onContentsModified(item)
 
     @clear()
 

--- a/spec/find-view-spec.js
+++ b/spec/find-view-spec.js
@@ -31,7 +31,7 @@ describe("FindView", () => {
     await atom.workspace.open("sample.js");
 
     jasmine.attachToDOM(workspaceElement);
-    editor = atom.workspace.getActiveTextEditor();
+    editor = atom.workspace.getCenter().getActiveTextEditor();
     editorView = editor.element;
 
     activationPromise = atom.packages.activatePackage("find-and-replace").then(function({mainModule}) {
@@ -207,7 +207,7 @@ describe("FindView", () => {
 
     describe("when core:cancel is triggered on an empty pane", () => {
       it("hides the find panel", () => {
-        const paneElement = atom.views.getView(atom.workspace.getActivePane());
+        const paneElement = atom.views.getView(atom.workspace.getCenter().getActivePane());
         paneElement.focus();
         atom.commands.dispatch(paneElement, "core:cancel");
         expect(getFindAtomPanel()).not.toBeVisible();
@@ -806,7 +806,7 @@ describe("FindView", () => {
       describe("when a new editor is activated", () => {
         it("reruns the search on the new editor", async () => {
           await atom.workspace.open("sample.coffee");
-          editor = atom.workspace.getActivePaneItem();
+          editor = atom.workspace.getCenter().getActivePaneItem();
           expect(findView.refs.resultCounter.textContent).toEqual("7 found");
           expect(editor.getSelectedBufferRange()).toEqual([[0, 0], [0, 0]]);
         });
@@ -817,7 +817,7 @@ describe("FindView", () => {
           await atom.workspace.open("sample.coffee");
           expect(getResultDecorations(editor, "find-result")).toHaveLength(0);
 
-          const newEditor = atom.workspace.getActiveTextEditor();
+          const newEditor = atom.workspace.getCenter().getActiveTextEditor();
           expect(getResultDecorations(newEditor, "find-result")).toHaveLength(7);
         });
 
@@ -825,7 +825,7 @@ describe("FindView", () => {
           await atom.workspace.open("sample.coffee");
 
           atom.commands.dispatch(findView.findEditor.element, "find-and-replace:find-next");
-          const newEditor = atom.workspace.getActiveTextEditor();
+          const newEditor = atom.workspace.getCenter().getActiveTextEditor();
           expect(getResultDecorations(newEditor, "find-result")).toHaveLength(6);
           expect(getResultDecorations(newEditor, "current-result")).toHaveLength(1);
         });
@@ -854,6 +854,16 @@ describe("FindView", () => {
         it("updates the result view", async () => {
           await atom.workspace.open("another");
           expect(findView.refs.resultCounter.textContent).toEqual("no results");
+        });
+      });
+
+      describe("when the active pane is in a dock", () => {
+        it("does nothing", async () => {
+          const dock = atom.workspace.getLeftDock()
+          dock.show()
+          dock.getActivePane().activateItem(document.createElement('div'))
+          dock.getActivePane().activate()
+          expect(findView.refs.resultCounter.textContent).not.toEqual("no results");
         });
       });
 
@@ -898,7 +908,7 @@ describe("FindView", () => {
 
           atom.commands.dispatch(editor.element, "core:close");
           editorView.focus();
-          expect(atom.workspace.getActiveTextEditor()).toBe(editor);
+          expect(atom.workspace.getCenter().getActiveTextEditor()).toBe(editor);
           expect(getResultDecorations(editor, "find-result")).toHaveLength(6);
         });
       });

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -365,35 +365,35 @@ describe('ProjectFindView', () => {
       });
 
       it("splits when option is right", async () => {
-        const initialPane = atom.workspace.getActivePane();
+        const initialPane = atom.workspace.getCenter().getActivePane();
         atom.config.set('find-and-replace.projectSearchResultsPaneSplitDirection', 'right');
         projectFindView.findEditor.setText('items');
 
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
         await searchPromise;
 
-        expect(atom.workspace.getActivePane()).not.toBe(initialPane);
+        expect(atom.workspace.getCenter().getActivePane()).not.toBe(initialPane);
       });
 
       it("splits when option is bottom", async () => {
-        const initialPane = atom.workspace.getActivePane();
+        const initialPane = atom.workspace.getCenter().getActivePane();
         atom.config.set('find-and-replace.projectSearchResultsPaneSplitDirection', 'down');
         projectFindView.findEditor.setText('items');
 
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
         await searchPromise;
 
-        expect(atom.workspace.getActivePane()).not.toBe(initialPane);
+        expect(atom.workspace.getCenter().getActivePane()).not.toBe(initialPane);
       });
 
       it("does not split when option is false", async () => {
-        const initialPane = atom.workspace.getActivePane();
+        const initialPane = atom.workspace.getCenter().getActivePane();
         projectFindView.findEditor.setText('items');
 
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
         await searchPromise;
 
-        expect(atom.workspace.getActivePane()).toBe(initialPane);
+        expect(atom.workspace.getCenter().getActivePane()).toBe(initialPane);
       });
 
       it("can be duplicated on the right", async () => {
@@ -404,11 +404,11 @@ describe('ProjectFindView', () => {
         await searchPromise;
 
         const resultsPaneView1 = atom.views.getView(getExistingResultsPane());
-        const pane1 = atom.workspace.getActivePane();
+        const pane1 = atom.workspace.getCenter().getActivePane();
         const resultsView1 = pane1.getItems()[0].refs.resultsView
         pane1.splitRight({copyActiveItem: true});
 
-        const pane2 = atom.workspace.getActivePane();
+        const pane2 = atom.workspace.getCenter().getActivePane();
         const resultsView2 = pane2.getItems()[0].refs.resultsView
         const resultsPaneView2 = atom.views.getView(pane2.itemForURI(ResultsPaneView.URI));
         expect(pane1).not.toBe(pane2);
@@ -429,11 +429,11 @@ describe('ProjectFindView', () => {
         await searchPromise;
 
         const resultsPaneView1 = atom.views.getView(getExistingResultsPane());
-        const pane1 = atom.workspace.getActivePane();
+        const pane1 = atom.workspace.getCenter().getActivePane();
         const resultsView1 = pane1.getItems()[0].refs.resultsView
 
         pane1.splitDown({copyActiveItem: true});
-        const pane2 = atom.workspace.getActivePane();
+        const pane2 = atom.workspace.getCenter().getActivePane();
         const resultsView2 = pane2.getItems()[0].refs.resultsView
         const resultsPaneView2 = atom.views.getView(pane2.itemForURI(ResultsPaneView.URI));
         expect(pane1).not.toBe(pane2);
@@ -1044,7 +1044,7 @@ describe('ProjectFindView', () => {
       // have to close the project before attempting to delete. Unfortunately,
       // Pathwatcher's close function is also not synchronous. Once
       // atom/node-pathwatcher#4 is implemented this should be alot cleaner.
-      let activePane = atom.workspace.getActivePane();
+      let activePane = atom.workspace.getCenter().getActivePane();
       if (activePane) {
         for (const item of activePane.getItems()) {
           if (item.shouldPromptToSave != null) {

--- a/spec/results-model-spec.js
+++ b/spec/results-model-spec.js
@@ -88,7 +88,7 @@ describe("ResultsModel", () => {
       await atom.workspace.open();
       await resultsModel.search("items", "*.js", "");
 
-      editor = atom.workspace.getActiveTextEditor();
+      editor = atom.workspace.getCenter().getActiveTextEditor();
       editor.setText("items\nitems");
       spyOn(editor, "scan").andCallThrough();
       advanceClock(editor.buffer.stoppedChangingDelay);

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -389,14 +389,14 @@ describe('ResultsView', () => {
       _.times(3, () => atom.commands.dispatch(resultsView.element, 'core:move-down'));
       atom.commands.dispatch(resultsView.element, 'core:confirm');
       await paneItemOpening()
-      expect(atom.workspace.getActivePaneItem().getPath()).toContain('sample.');
+      expect(atom.workspace.getCenter().getActivePaneItem().getPath()).toContain('sample.');
 
       // open something in sample.js
       resultsView.element.focus();
       _.times(6, () => atom.commands.dispatch(resultsView.element, 'core:move-down'));
       atom.commands.dispatch(resultsView.element, 'core:confirm');
       await paneItemOpening()
-      expect(atom.workspace.getActivePaneItem().getPath()).toContain('sample.');
+      expect(atom.workspace.getCenter().getActivePaneItem().getPath()).toContain('sample.');
     });
 
     it("opens the file containing the result in a non-pending state when the search result is double-clicked", async () => {
@@ -410,8 +410,8 @@ describe('ResultsView', () => {
       expect(click2.defaultPrevented).toBe(true);
 
       await paneItemOpening()
-      const editor = atom.workspace.getActiveTextEditor();
-      expect(atom.workspace.getActivePane().getPendingItem()).toBe(null);
+      const editor = atom.workspace.getCenter().getActiveTextEditor();
+      expect(atom.workspace.getCenter().getActivePane().getPendingItem()).toBe(null);
       expect(atom.views.getView(editor)).toHaveFocus();
     });
 
@@ -419,8 +419,8 @@ describe('ResultsView', () => {
       const pathNode = resultsView.refs.listView.element.querySelectorAll(".search-result")[0];
       pathNode.dispatchEvent(buildMouseEvent('mousedown', {target: pathNode, which: 1}));
       await paneItemOpening()
-      const editor = atom.workspace.getActiveTextEditor();
-      expect(atom.workspace.getActivePane().getPendingItem()).toBe(editor);
+      const editor = atom.workspace.getCenter().getActiveTextEditor();
+      expect(atom.workspace.getCenter().getActivePane().getPendingItem()).toBe(editor);
       expect(atom.views.getView(editor)).toHaveFocus();
     })
 


### PR DESCRIPTION
This restores the pre-docks behavior and fixes #901

/cc @iolsen @lee-dohm 