### PR TITLE
Change "Search in Directory" to "Search in Folder"

### DIFF
--- a/menus/find-and-replace.cson
+++ b/menus/find-and-replace.cson
@@ -23,7 +23,7 @@
 
 'context-menu':
   '.tree-view li.directory': [
-    { 'label': 'Search in Directory', 'command': 'project-find:show-in-current-directory' }
+    { 'label': 'Search in Folder', 'command': 'project-find:show-in-current-directory' }
   ]
   '.path-details.list-item': [
     { 'label': 'Copy Path', 'command': 'find-and-replace:copy-path' }


### PR DESCRIPTION

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

There is some inconsistency between us and [tree-view](https://github.com/atom/tree-view/blob/master/menus/tree-view.cson) in choosing the term "folder" or "directory" in the context menu. The "Search in Directory" context menu item is shown alongside tree-view's "New Folder" item. This PR changes our item to "Search in Folder" for consistency.

![screenshot](http://i.imgur.com/F3KKfiT.png)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
Alternatively, we could have tree-view change its "Folder" items to say "Directory". But they have several, and we have one.

### Benefits

<!-- What benefits will be realized by the code change? -->
It makes the resulting context menu more pleasing to read.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
It looks like most of the internal code uses the word "directory", so the user-visible label will not match the internals, which is always unfortunate.

### Applicable Issues

<!-- Enter any applicable Issues here -->
None.
