### PR TITLE
Toggle context lines

### DIFF
--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -9,6 +9,7 @@ Params = [
   'wholeWord'
   'caseSensitive'
   'inCurrentSelection'
+  'showContextLines'
 ]
 
 module.exports =
@@ -23,6 +24,7 @@ class FindOptions
     @caseSensitive = state.caseSensitive ? atom.config.get('find-and-replace.caseSensitive') ? false
     @wholeWord = state.wholeWord ? atom.config.get('find-and-replace.wholeWord') ? false
     @inCurrentSelection = state.inCurrentSelection ? atom.config.get('find-and-replace.inCurrentSelection') ? false
+    @showContextLines = state.showContextLines ? atom.config.get('find-and-replace.showContextLines') ? false
 
   onDidChange: (callback) ->
     @emitter.on('did-change', callback)

--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -9,7 +9,8 @@ Params = [
   'wholeWord'
   'caseSensitive'
   'inCurrentSelection'
-  'showContextLines'
+  'leadingContextLineCount'
+  'trailingContextLineCount'
 ]
 
 module.exports =
@@ -24,7 +25,8 @@ class FindOptions
     @caseSensitive = state.caseSensitive ? atom.config.get('find-and-replace.caseSensitive') ? false
     @wholeWord = state.wholeWord ? atom.config.get('find-and-replace.wholeWord') ? false
     @inCurrentSelection = state.inCurrentSelection ? atom.config.get('find-and-replace.inCurrentSelection') ? false
-    @showContextLines = state.showContextLines ? atom.config.get('find-and-replace.showContextLines') ? false
+    @leadingContextLineCount = state.leadingContextLineCount ? atom.config.get('find-and-replace.leadingContextLineCount') ? 0
+    @trailingContextLineCount = state.trailingContextLineCount ? atom.config.get('find-and-replace.trailingContextLineCount') ? 0
 
   onDidChange: (callback) ->
     @emitter.on('did-change', callback)

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -145,7 +145,7 @@ class FindView {
             <rect x="3" y="6" width="8" height="2"></rect>
             <rect x="3" y="9" width="8" height="2"></rect>
             <path d="M12,3 L15,3 L15,11 L12,11 L12,10 L14,10 L14,4 L12,4  Z"></path>
-          </svg>
+          </symbol>
 
           <symbol id="find-and-replace-context-lines-after" viewBox="0 0 20 16" stroke="none" fill-rule="evenodd">
             <rect opacity="0.6" x="3" y="3" width="14" height="2"></rect>
@@ -153,7 +153,7 @@ class FindView {
             <rect x="3" y="9" width="8" height="2"></rect>
             <rect x="3" y="12" width="8" height="2"></rect>
             <path d="M12,6 L15,6 L15,14 L12,14 L12,13 L14,13 L14,7 L12,7  Z"></path>
-          </svg>
+          </symbol>
         `})
       )
     );

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -140,19 +140,15 @@ class FindView {
           </symbol>
 
           <symbol id="find-and-replace-context-lines-before" viewBox="0 0 20 16" stroke="none" fill-rule="evenodd">
-            <rect opacity="0.6" x="3" y="12" width="14" height="2"></rect>
-            <rect x="3" y="3" width="8" height="2"></rect>
-            <rect x="3" y="6" width="8" height="2"></rect>
-            <rect x="3" y="9" width="8" height="2"></rect>
-            <path d="M12,3 L15,3 L15,11 L12,11 L12,10 L14,10 L14,4 L12,4  Z"></path>
+            <rect opacity="0.6" x="2" y="11" width="16" height="2"></rect>
+            <rect x="2" y="7" width="10" height="2"></rect>
+            <rect x="2" y="3" width="10" height="2"></rect>
           </symbol>
 
           <symbol id="find-and-replace-context-lines-after" viewBox="0 0 20 16" stroke="none" fill-rule="evenodd">
-            <rect opacity="0.6" x="3" y="3" width="14" height="2"></rect>
-            <rect x="3" y="6" width="8" height="2"></rect>
-            <rect x="3" y="9" width="8" height="2"></rect>
-            <rect x="3" y="12" width="8" height="2"></rect>
-            <path d="M12,6 L15,6 L15,14 L12,14 L12,13 L14,13 L14,7 L12,7  Z"></path>
+            <rect x="2" y="11" width="10" height="2"></rect>
+            <rect x="2" y="7" width="10" height="2"></rect>
+            <rect opacity="0.6" x="2" y="3" width="16" height="2"></rect>
           </symbol>
         `})
       )

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -138,6 +138,22 @@ class FindView {
             <path d="M4,10.5 L4,12.5 L4,13 L5,13 L5,12.5 L5,10.5 L5,10 L4,10 L4,10.5 L4,10.5 Z"></path>
             <path d="M15,10.5 L15,12.5 L15,13 L16,13 L16,12.5 L16,10.5 L16,10 L15,10 L15,10.5 L15,10.5 Z"></path>
           </symbol>
+
+          <symbol id="find-and-replace-context-lines-before" viewBox="0 0 20 16" stroke="none" fill-rule="evenodd">
+            <rect opacity="0.6" x="3" y="12" width="14" height="2"></rect>
+            <rect x="3" y="3" width="8" height="2"></rect>
+            <rect x="3" y="6" width="8" height="2"></rect>
+            <rect x="3" y="9" width="8" height="2"></rect>
+            <path d="M12,3 L15,3 L15,11 L12,11 L12,10 L14,10 L14,4 L12,4  Z"></path>
+          </svg>
+
+          <symbol id="find-and-replace-context-lines-after" viewBox="0 0 20 16" stroke="none" fill-rule="evenodd">
+            <rect opacity="0.6" x="3" y="3" width="14" height="2"></rect>
+            <rect x="3" y="6" width="8" height="2"></rect>
+            <rect x="3" y="9" width="8" height="2"></rect>
+            <rect x="3" y="12" width="8" height="2"></rect>
+            <path d="M12,6 L15,6 L15,14 L12,14 L12,13 L14,13 L14,7 L12,7  Z"></path>
+          </svg>
         `})
       )
     );

--- a/lib/project/match-view.js
+++ b/lib/project/match-view.js
@@ -5,24 +5,26 @@ const $ = etch.dom;
 
 module.exports =
 class MatchView {
-  constructor({match, regex, replacePattern, isSelected, previewStyle, top}) {
+  constructor({match, regex, replacePattern, isSelected, previewStyle, top, showContextLines}) {
     this.match = match;
     this.regex = regex;
     this.replacePattern = replacePattern;
     this.previewStyle = previewStyle;
     this.isSelected = isSelected;
     this.top = top;
+    this.showContextLines = showContextLines;
     etch.initialize(this);
   }
 
-  update({match, regex, replacePattern, previewStyle, isSelected, top}) {
+  update({match, regex, replacePattern, previewStyle, isSelected, top, showContextLines}) {
     const changed =
       match !== this.match ||
       regex !== this.regex ||
       replacePattern !== this.replacePattern ||
       previewStyle !== this.previewStyle ||
       isSelected !== this.isSelected ||
-      top !== this.top;
+      top !== this.top ||
+      showContextLines !== this.showContextLines;
 
     if (changed) {
       this.match = match;
@@ -31,6 +33,7 @@ class MatchView {
       this.previewStyle = previewStyle;
       this.isSelected = isSelected;
       this.top = top;
+      this.showContextLines = showContextLines;
       etch.update(this);
     }
   }
@@ -65,7 +68,7 @@ class MatchView {
         },
 
         $.ul({className: 'list-tree'},
-          leadingContextLines ? leadingContextLines.map((line, index) =>
+          leadingContextLines && this.showContextLines ? leadingContextLines.map((line, index) =>
             $.li({className: 'list-item'},
               $.span({className: 'line-number text-subtle'}, range.start.row + 1 - leadingContextLines.length + index),
               $.span({className: 'preview'}, $.span({}, line.trimLeft()))
@@ -89,7 +92,7 @@ class MatchView {
             )
           ),
 
-          trailingContextLines ? trailingContextLines.map((line, index) =>
+          trailingContextLines && this.showContextLines ? trailingContextLines.map((line, index) =>
             $.li({className: 'list-item'},
               $.span({className: 'line-number text-subtle'}, range.end.row + 1 + index + 1),
               $.span({className: 'preview'}, $.span({}, line.trimLeft()))

--- a/lib/project/match-view.js
+++ b/lib/project/match-view.js
@@ -5,18 +5,19 @@ const $ = etch.dom;
 
 module.exports =
 class MatchView {
-  constructor({match, regex, replacePattern, isSelected, previewStyle, top, showContextLines}) {
+  constructor({match, regex, replacePattern, isSelected, previewStyle, top, leadingContextLineCount, trailingContextLineCount}) {
     this.match = match;
     this.regex = regex;
     this.replacePattern = replacePattern;
     this.previewStyle = previewStyle;
     this.isSelected = isSelected;
     this.top = top;
-    this.showContextLines = showContextLines;
+    this.leadingContextLineCount = leadingContextLineCount;
+    this.trailingContextLineCount = trailingContextLineCount;
     etch.initialize(this);
   }
 
-  update({match, regex, replacePattern, previewStyle, isSelected, top, showContextLines}) {
+  update({match, regex, replacePattern, previewStyle, isSelected, top, leadingContextLineCount, trailingContextLineCount}) {
     const changed =
       match !== this.match ||
       regex !== this.regex ||
@@ -24,7 +25,8 @@ class MatchView {
       previewStyle !== this.previewStyle ||
       isSelected !== this.isSelected ||
       top !== this.top ||
-      showContextLines !== this.showContextLines;
+      leadingContextLineCount !== this.leadingContextLineCount ||
+      trailingContextLineCount !== this.trailingContextLineCount;
 
     if (changed) {
       this.match = match;
@@ -33,7 +35,8 @@ class MatchView {
       this.previewStyle = previewStyle;
       this.isSelected = isSelected;
       this.top = top;
-      this.showContextLines = showContextLines;
+      this.leadingContextLineCount = leadingContextLineCount;
+      this.trailingContextLineCount = trailingContextLineCount;
       etch.update(this);
     }
   }
@@ -68,11 +71,12 @@ class MatchView {
         },
 
         $.ul({className: 'list-tree'},
-          leadingContextLines && this.showContextLines ? leadingContextLines.map((line, index) =>
-            $.li({className: 'list-item'},
-              $.span({className: 'line-number text-subtle'}, range.start.row + 1 - leadingContextLines.length + index),
-              $.span({className: 'preview'}, $.span({}, line.trimLeft()))
-            )
+          leadingContextLines && this.leadingContextLineCount ? leadingContextLines.map((line, index) =>
+            index >= leadingContextLines.length - this.leadingContextLineCount ?
+              $.li({className: 'list-item'},
+                $.span({className: 'line-number text-subtle'}, range.start.row + 1 - leadingContextLines.length + index),
+                $.span({className: 'preview'}, $.span({}, line.trimLeft()))
+              ) : null
           ) : null,
 
           $.li({className: `list-item match-line ${this.isSelected ? 'selected' : ''}`},
@@ -92,11 +96,12 @@ class MatchView {
             )
           ),
 
-          trailingContextLines && this.showContextLines ? trailingContextLines.map((line, index) =>
-            $.li({className: 'list-item'},
-              $.span({className: 'line-number text-subtle'}, range.end.row + 1 + index + 1),
-              $.span({className: 'preview'}, $.span({}, line.trimLeft()))
-            )
+          trailingContextLines && this.trailingContextLineCount ? trailingContextLines.map((line, index) =>
+            index < this.trailingContextLineCount ?
+              $.li({className: 'list-item'},
+                $.span({className: 'line-number text-subtle'}, range.end.row + 1 + index + 1),
+                $.span({className: 'preview'}, $.span({}, line.trimLeft()))
+              ) : null
           ) : null
         )
       )

--- a/lib/project/result-view.js
+++ b/lib/project/result-view.js
@@ -10,7 +10,7 @@ class ResultView {
     const {
       filePath, matches, isSelected, selectedMatchIndex, isExpanded, regex,
       replacePattern, previewStyle, pathDetailsHeight, matchHeight, contextLineHeight,
-      showContextLines
+      leadingContextLineCount, trailingContextLineCount
     } = item;
 
     this.top = top;
@@ -18,7 +18,8 @@ class ResultView {
     this.pathDetailsHeight = pathDetailsHeight;
     this.matchHeight = matchHeight;
     this.contextLineHeight = contextLineHeight;
-    this.showContextLines = showContextLines;
+    this.leadingContextLineCount = leadingContextLineCount;
+    this.trailingContextLineCount = trailingContextLineCount;
 
     this.filePath = filePath
     this.matches = matches
@@ -35,7 +36,7 @@ class ResultView {
     const {
       filePath, matches, isSelected, selectedMatchIndex, isExpanded, regex,
       replacePattern, previewStyle, pathDetailsHeight, matchHeight, contextLineHeight,
-      showContextLines
+      leadingContextLineCount, trailingContextLineCount
     } = item;
 
     const changed =
@@ -50,7 +51,8 @@ class ResultView {
       bottom !== this.bottom ||
       pathDetailsHeight !== this.pathDetailsHeight ||
       contextLineHeight !== this.contextLineHeight ||
-      showContextLines !== this.showContextLines ||
+      leadingContextLineCount !== this.leadingContextLineCount ||
+      trailingContextLineCount !== this.trailingContextLineCount ||
       matchHeight !== this.matchHeight;
 
     if (changed) {
@@ -67,7 +69,8 @@ class ResultView {
       this.pathDetailsHeight = pathDetailsHeight;
       this.matchHeight = matchHeight;
       this.contextLineHeight = contextLineHeight;
-      this.showContextLines = showContextLines;
+      this.leadingContextLineCount = leadingContextLineCount;
+      this.trailingContextLineCount = trailingContextLineCount;
       etch.update(this);
     }
   }
@@ -134,8 +137,8 @@ class ResultView {
     for (; i < this.matches.length; i++) {
       const match = this.matches[i];
       let itemBottomPosition = itemTopPosition + this.matchHeight;
-      if (match.leadingContextLines && this.showContextLines) itemBottomPosition += match.leadingContextLines.length * this.contextLineHeight;
-      if (match.trailingContextLines && this.showContextLines) itemBottomPosition += match.trailingContextLines.length * this.contextLineHeight;
+      if (match.leadingContextLines && this.leadingContextLineCount) itemBottomPosition += this.leadingContextLineCount * this.contextLineHeight;
+      if (match.trailingContextLines && this.trailingContextLineCount) itemBottomPosition += this.trailingContextLineCount * this.contextLineHeight;
 
       if (itemBottomPosition > top) break;
       itemTopPosition = itemBottomPosition;
@@ -144,8 +147,8 @@ class ResultView {
     for (; i < this.matches.length; i++) {
       const match = this.matches[i];
       let itemBottomPosition = itemTopPosition + this.matchHeight;
-      if (match.leadingContextLines && this.showContextLines) itemBottomPosition += match.leadingContextLines.length * this.contextLineHeight;
-      if (match.trailingContextLines && this.showContextLines) itemBottomPosition += match.trailingContextLines.length * this.contextLineHeight;
+      if (match.leadingContextLines && this.leadingContextLineCount) itemBottomPosition += this.leadingContextLineCount * this.contextLineHeight;
+      if (match.trailingContextLines && this.trailingContextLineCount) itemBottomPosition += this.trailingContextLineCount * this.contextLineHeight;
 
       children.push(
         etch.dom(MatchView, {
@@ -156,7 +159,8 @@ class ResultView {
           isSelected: (i === this.selectedMatchIndex),
           previewStyle: this.previewStyle,
           top: itemTopPosition,
-          showContextLines: this.showContextLines
+          leadingContextLineCount: this.leadingContextLineCount,
+          trailingContextLineCount: this.trailingContextLineCount
         })
       );
 

--- a/lib/project/result-view.js
+++ b/lib/project/result-view.js
@@ -9,7 +9,8 @@ class ResultView {
   constructor({item, top, bottom} = {}) {
     const {
       filePath, matches, isSelected, selectedMatchIndex, isExpanded, regex,
-      replacePattern, previewStyle, pathDetailsHeight, matchHeight, contextLineHeight
+      replacePattern, previewStyle, pathDetailsHeight, matchHeight, contextLineHeight,
+      showContextLines
     } = item;
 
     this.top = top;
@@ -17,6 +18,7 @@ class ResultView {
     this.pathDetailsHeight = pathDetailsHeight;
     this.matchHeight = matchHeight;
     this.contextLineHeight = contextLineHeight;
+    this.showContextLines = showContextLines;
 
     this.filePath = filePath
     this.matches = matches
@@ -32,7 +34,8 @@ class ResultView {
   update({item, top, bottom} = {}) {
     const {
       filePath, matches, isSelected, selectedMatchIndex, isExpanded, regex,
-      replacePattern, previewStyle, pathDetailsHeight, matchHeight, contextLineHeight
+      replacePattern, previewStyle, pathDetailsHeight, matchHeight, contextLineHeight,
+      showContextLines
     } = item;
 
     const changed =
@@ -47,6 +50,7 @@ class ResultView {
       bottom !== this.bottom ||
       pathDetailsHeight !== this.pathDetailsHeight ||
       contextLineHeight !== this.contextLineHeight ||
+      showContextLines !== this.showContextLines ||
       matchHeight !== this.matchHeight;
 
     if (changed) {
@@ -63,6 +67,7 @@ class ResultView {
       this.pathDetailsHeight = pathDetailsHeight;
       this.matchHeight = matchHeight;
       this.contextLineHeight = contextLineHeight;
+      this.showContextLines = showContextLines;
       etch.update(this);
     }
   }
@@ -129,8 +134,8 @@ class ResultView {
     for (; i < this.matches.length; i++) {
       const match = this.matches[i];
       let itemBottomPosition = itemTopPosition + this.matchHeight;
-      if (match.leadingContextLines) itemBottomPosition += match.leadingContextLines.length * this.contextLineHeight;
-      if (match.trailingContextLines) itemBottomPosition += match.trailingContextLines.length * this.contextLineHeight;
+      if (match.leadingContextLines && this.showContextLines) itemBottomPosition += match.leadingContextLines.length * this.contextLineHeight;
+      if (match.trailingContextLines && this.showContextLines) itemBottomPosition += match.trailingContextLines.length * this.contextLineHeight;
 
       if (itemBottomPosition > top) break;
       itemTopPosition = itemBottomPosition;
@@ -139,8 +144,8 @@ class ResultView {
     for (; i < this.matches.length; i++) {
       const match = this.matches[i];
       let itemBottomPosition = itemTopPosition + this.matchHeight;
-      if (match.leadingContextLines) itemBottomPosition += match.leadingContextLines.length * this.contextLineHeight;
-      if (match.trailingContextLines) itemBottomPosition += match.trailingContextLines.length * this.contextLineHeight;
+      if (match.leadingContextLines && this.showContextLines) itemBottomPosition += match.leadingContextLines.length * this.contextLineHeight;
+      if (match.trailingContextLines && this.showContextLines) itemBottomPosition += match.trailingContextLines.length * this.contextLineHeight;
 
       children.push(
         etch.dom(MatchView, {
@@ -150,7 +155,8 @@ class ResultView {
           replacePattern: this.replacePattern,
           isSelected: (i === this.selectedMatchIndex),
           previewStyle: this.previewStyle,
-          top: itemTopPosition
+          top: itemTopPosition,
+          showContextLines: this.showContextLines
         })
       );
 

--- a/lib/project/results-pane.js
+++ b/lib/project/results-pane.js
@@ -81,10 +81,16 @@ class ResultsPaneView {
               style: {visibility: matchCount > 0 ? 'visible' : 'hidden'}
             },
 
-            $.div({className: 'btn-group'},
-              $.button({ref: 'collapseAll', className: 'btn'}, 'Collapse All'),
-              $.button({ref: 'expandAll', className: 'btn'}, 'Expand All'),
-              hasContext ? $.button({ref: 'toggleContext', className: 'btn'}, 'Context Lines') : null
+            $.div({className: 'btn-toolbar'},
+              hasContext ?
+                $.div({className: 'btn-group'},
+                  $.button({ref: 'toggleContext', className: 'btn'}, 'Show Context')
+                ) : null,
+
+              $.div({className: 'btn-group'},
+                $.button({ref: 'collapseAll', className: 'btn'}, 'Collapse All'),
+                $.button({ref: 'expandAll', className: 'btn'}, 'Expand All')
+              )
             )
           ),
 

--- a/lib/project/results-pane.js
+++ b/lib/project/results-pane.js
@@ -15,6 +15,8 @@ class ResultsPaneView {
     this.searchResults = null;
     this.searchingIsSlow = false;
     this.numberOfPathsSearched = 0;
+    this.searchContextLineCountBefore = 0;
+    this.searchContextLineCountAfter = 0;
 
     etch.initialize(this);
 
@@ -28,8 +30,23 @@ class ResultsPaneView {
         case this.refs.expandAll:
           this.expandAllResults();
           break;
-        case this.refs.toggleContext:
-          this.toggleContextLines();
+        case this.refs.decrementLeadingContextLines:
+          this.decrementLeadingContextLines();
+          break;
+        case this.refs.toggleLeadingContextLines:
+          this.toggleLeadingContextLines();
+          break;
+        case this.refs.incrementLeadingContextLines:
+          this.incrementLeadingContextLines();
+          break;
+        case this.refs.decrementTrailingContextLines:
+          this.decrementTrailingContextLines();
+          break;
+        case this.refs.toggleTrailingContextLines:
+          this.toggleTrailingContextLines();
+          break;
+        case this.refs.incrementTrailingContextLines:
+          this.incrementTrailingContextLines();
           break;
       }
     })
@@ -40,7 +57,9 @@ class ResultsPaneView {
       this.model.onDidClear(this.onCleared.bind(this)),
       this.model.onDidClearReplacementState(this.onReplacementStateCleared.bind(this)),
       this.model.onDidSearchPaths(this.onPathsSearched.bind(this)),
-      this.model.onDidErrorForPath(error => this.appendError(error.message))
+      this.model.onDidErrorForPath(error => this.appendError(error.message)),
+      atom.config.observe('find-and-replace.searchContextLineCountBefore', this.searchContextLineCountChanged.bind(this)),
+      atom.config.observe('find-and-replace.searchContextLineCountAfter', this.searchContextLineCountChanged.bind(this))
     );
   }
 
@@ -53,10 +72,6 @@ class ResultsPaneView {
 
   render() {
     const matchCount = this.searchResults && this.searchResults.matchCount;
-
-    const leadingContextLineCount = atom.config.get('find-and-replace.searchContextLineCountBefore');
-    const trailingContextLineCount = atom.config.get('find-and-replace.searchContextLineCountAfter');
-    const hasContext = leadingContextLineCount > 0 || trailingContextLineCount > 0;
 
     return (
       $.div(
@@ -82,13 +97,42 @@ class ResultsPaneView {
             },
 
             $.div({className: 'btn-toolbar'},
-              hasContext ?
+              this.searchContextLineCountBefore > 0 ?
                 $.div({className: 'btn-group'},
                   $.button(
                     {
-                      ref: 'toggleContext',
-                      className: 'btn' + (this.model.getFindOptions().showContextLines ? ' selected' : '')
-                    }, 'Show Context')
+                      ref: 'decrementLeadingContextLines',
+                      className: 'btn' + (this.model.getFindOptions().leadingContextLineCount === 0 ? ' disabled' : '')
+                    }, '-'),
+                  $.button(
+                    {
+                      ref: 'toggleLeadingContextLines',
+                      className: 'btn'
+                    }, this.model.getFindOptions().leadingContextLineCount + ' before'),
+                  $.button(
+                    {
+                      ref: 'incrementLeadingContextLines',
+                      className: 'btn' + (this.model.getFindOptions().leadingContextLineCount >= this.searchContextLineCountBefore ? ' disabled' : '')
+                    }, '+')
+                ) : null,
+
+              this.searchContextLineCountAfter > 0 ?
+                $.div({className: 'btn-group'},
+                  $.button(
+                    {
+                      ref: 'decrementTrailingContextLines',
+                      className: 'btn' + (this.model.getFindOptions().trailingContextLineCount === 0 ? ' disabled' : '')
+                    }, '-'),
+                  $.button(
+                    {
+                      ref: 'toggleTrailingContextLines',
+                      className: 'btn'
+                    }, this.model.getFindOptions().trailingContextLineCount + ' after'),
+                  $.button(
+                    {
+                      ref: 'incrementTrailingContextLines',
+                      className: 'btn' + (this.model.getFindOptions().trailingContextLineCount >= this.searchContextLineCountAfter ? ' disabled' : '')
+                    }, '+')
                 ) : null,
 
               $.div({className: 'btn-group'},
@@ -226,14 +270,53 @@ class ResultsPaneView {
     this.refs.resultsView.element.focus();
   }
 
-  toggleContextLines() {
-    this.refs.resultsView.toggleContextLines();
-    if (this.model.getFindOptions().showContextLines) {
-      this.refs.toggleContext.classList.add('selected');
-    } else {
-      this.refs.toggleContext.classList.remove('selected');
+  decrementLeadingContextLines() {
+    this.refs.resultsView.decrementLeadingContextLines();
+    etch.update(this);
+  }
+
+  toggleLeadingContextLines() {
+    this.refs.resultsView.toggleLeadingContextLines();
+    etch.update(this);
+  }
+
+  incrementLeadingContextLines() {
+    this.refs.resultsView.incrementLeadingContextLines();
+    etch.update(this);
+  }
+
+  decrementTrailingContextLines() {
+    this.refs.resultsView.decrementTrailingContextLines();
+    etch.update(this);
+  }
+
+  toggleTrailingContextLines() {
+    this.refs.resultsView.toggleTrailingContextLines();
+    etch.update(this);
+  }
+
+  incrementTrailingContextLines() {
+    this.refs.resultsView.incrementTrailingContextLines();
+    etch.update(this);
+  }
+
+  searchContextLineCountChanged() {
+    this.searchContextLineCountBefore = atom.config.get('find-and-replace.searchContextLineCountBefore');
+    this.searchContextLineCountAfter = atom.config.get('find-and-replace.searchContextLineCountAfter');
+    // update the visible line count in the find options to not exceed the maximum available lines
+    let findOptionsChanged = false;
+    if (this.searchContextLineCountBefore < this.model.getFindOptions().leadingContextLineCount) {
+      this.model.getFindOptions().leadingContextLineCount = this.searchContextLineCountBefore;
+      findOptionsChanged = true;
     }
-    this.refs.resultsView.element.focus();
+    if (this.searchContextLineCountAfter < this.model.getFindOptions().trailingContextLineCount) {
+      this.model.getFindOptions().trailingContextLineCount = this.searchContextLineCountAfter;
+      findOptionsChanged = true;
+    }
+    etch.update(this);
+    if (findOptionsChanged) {
+      etch.update(this.refs.resultsView);
+    }
   }
 }
 

--- a/lib/project/results-pane.js
+++ b/lib/project/results-pane.js
@@ -84,7 +84,11 @@ class ResultsPaneView {
             $.div({className: 'btn-toolbar'},
               hasContext ?
                 $.div({className: 'btn-group'},
-                  $.button({ref: 'toggleContext', className: 'btn'}, 'Show Context')
+                  $.button(
+                    {
+                      ref: 'toggleContext',
+                      className: 'btn' + (this.model.getFindOptions().showContextLines ? ' selected' : '')
+                    }, 'Show Context')
                 ) : null,
 
               $.div({className: 'btn-group'},
@@ -224,7 +228,7 @@ class ResultsPaneView {
 
   toggleContextLines() {
     this.refs.resultsView.toggleContextLines();
-    if (this.refs.resultsView.showContextLines) {
+    if (this.model.getFindOptions().showContextLines) {
       this.refs.toggleContext.classList.add('selected');
     } else {
       this.refs.toggleContext.classList.remove('selected');

--- a/lib/project/results-pane.js
+++ b/lib/project/results-pane.js
@@ -28,6 +28,9 @@ class ResultsPaneView {
         case this.refs.expandAll:
           this.expandAllResults();
           break;
+        case this.refs.toggleContext:
+          this.toggleContextLines();
+          break;
       }
     })
 
@@ -50,6 +53,10 @@ class ResultsPaneView {
 
   render() {
     const matchCount = this.searchResults && this.searchResults.matchCount;
+
+    const leadingContextLineCount = atom.config.get('find-and-replace.searchContextLineCountBefore');
+    const trailingContextLineCount = atom.config.get('find-and-replace.searchContextLineCountAfter');
+    const hasContext = leadingContextLineCount > 0 || trailingContextLineCount > 0;
 
     return (
       $.div(
@@ -76,7 +83,8 @@ class ResultsPaneView {
 
             $.div({className: 'btn-group'},
               $.button({ref: 'collapseAll', className: 'btn'}, 'Collapse All'),
-              $.button({ref: 'expandAll', className: 'btn'}, 'Expand All')
+              $.button({ref: 'expandAll', className: 'btn'}, 'Expand All'),
+              hasContext ? $.button({ref: 'toggleContext', className: 'btn'}, 'Context Lines') : null
             )
           ),
 
@@ -205,6 +213,16 @@ class ResultsPaneView {
 
   expandAllResults() {
     this.refs.resultsView.expandAllResults();
+    this.refs.resultsView.element.focus();
+  }
+
+  toggleContextLines() {
+    this.refs.resultsView.toggleContextLines();
+    if (this.refs.resultsView.showContextLines) {
+      this.refs.toggleContext.classList.add('selected');
+    } else {
+      this.refs.toggleContext.classList.remove('selected');
+    }
     this.refs.resultsView.element.focus();
   }
 }

--- a/lib/project/results-pane.js
+++ b/lib/project/results-pane.js
@@ -108,7 +108,14 @@ class ResultsPaneView {
                     {
                       ref: 'toggleLeadingContextLines',
                       className: 'btn'
-                    }, this.model.getFindOptions().leadingContextLineCount + ' before'),
+                    },
+                    $.svg(
+                      {
+                        className: 'icon',
+                        innerHTML: '<use xlink:href="#find-and-replace-context-lines-before" />'
+                      }
+                    )
+                  ),
                   $.button(
                     {
                       ref: 'incrementLeadingContextLines',
@@ -127,7 +134,14 @@ class ResultsPaneView {
                     {
                       ref: 'toggleTrailingContextLines',
                       className: 'btn'
-                    }, this.model.getFindOptions().trailingContextLineCount + ' after'),
+                    },
+                    $.svg(
+                      {
+                        className: 'icon',
+                        innerHTML: '<use xlink:href="#find-and-replace-context-lines-after" />'
+                      }
+                    )
+                  ),
                   $.button(
                     {
                       ref: 'incrementTrailingContextLines',

--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -126,7 +126,8 @@ class ResultsView {
             pathDetailsHeight: this.pathDetailsHeight,
             matchHeight: this.matchHeight,
             contextLineHeight: this.contextLineHeight,
-            showContextLines: this.model.getFindOptions().showContextLines
+            leadingContextLineCount: this.model.getFindOptions().leadingContextLineCount,
+            trailingContextLineCount: this.model.getFindOptions().trailingContextLineCount
           }, this.model.results[filePath]);
         }),
       })
@@ -139,11 +140,11 @@ class ResultsView {
       for (let i = 0, n = searchResult.matches.length; i < n; i++) {
         const match = searchResult.matches[i];
         result += this.matchHeight;
-        if (match.leadingContextLines && this.model.getFindOptions().showContextLines) {
-          result += this.contextLineHeight * match.leadingContextLines.length;
+        if (match.leadingContextLines && this.model.getFindOptions().leadingContextLineCount) {
+          result += this.contextLineHeight * this.model.getFindOptions().leadingContextLineCount;
         }
-        if (match.trailingContextLines && this.model.getFindOptions().showContextLines) {
-          result += this.contextLineHeight * match.trailingContextLines.length;
+        if (match.trailingContextLines && this.model.getFindOptions().trailingContextLineCount) {
+          result += this.contextLineHeight * this.model.getFindOptions().trailingContextLineCount;
         }
       }
     }
@@ -445,8 +446,63 @@ class ResultsView {
     etch.update(this);
   }
 
-  toggleContextLines() {
-    this.model.getFindOptions().showContextLines = !this.model.getFindOptions().showContextLines;
+  decrementLeadingContextLines() {
+    if (this.model.getFindOptions().leadingContextLineCount > 0) {
+      this.model.getFindOptions().leadingContextLineCount--;
+      this.contextLinesChanged();
+    }
+  }
+
+  toggleLeadingContextLines() {
+    if (this.model.getFindOptions().leadingContextLineCount > 0) {
+      this.model.getFindOptions().leadingContextLineCount = 0;
+      this.contextLinesChanged();
+    } else {
+      const searchContextLineCountBefore = atom.config.get('find-and-replace.searchContextLineCountBefore');
+      if (this.model.getFindOptions().leadingContextLineCount < searchContextLineCountBefore) {
+        this.model.getFindOptions().leadingContextLineCount = searchContextLineCountBefore;
+        this.contextLinesChanged();
+      }
+    }
+  }
+
+  incrementLeadingContextLines() {
+    const searchContextLineCountBefore = atom.config.get('find-and-replace.searchContextLineCountBefore');
+    if (this.model.getFindOptions().leadingContextLineCount < searchContextLineCountBefore) {
+      this.model.getFindOptions().leadingContextLineCount++;
+      this.contextLinesChanged();
+    }
+  }
+
+  decrementTrailingContextLines() {
+    if (this.model.getFindOptions().trailingContextLineCount > 0) {
+      this.model.getFindOptions().trailingContextLineCount--;
+      this.contextLinesChanged();
+    }
+  }
+
+  toggleTrailingContextLines() {
+    if (this.model.getFindOptions().trailingContextLineCount > 0) {
+      this.model.getFindOptions().trailingContextLineCount = 0;
+      this.contextLinesChanged();
+    } else {
+      const searchContextLineCountAfter = atom.config.get('find-and-replace.searchContextLineCountAfter');
+      if (this.model.getFindOptions().trailingContextLineCount < searchContextLineCountAfter) {
+        this.model.getFindOptions().trailingContextLineCount = searchContextLineCountAfter;
+        this.contextLinesChanged();
+      }
+    }
+  }
+
+  incrementTrailingContextLines() {
+    const searchContextLineCountAfter = atom.config.get('find-and-replace.searchContextLineCountAfter');
+    if (this.model.getFindOptions().trailingContextLineCount < searchContextLineCountAfter) {
+      this.model.getFindOptions().trailingContextLineCount++;
+      this.contextLinesChanged();
+    }
+  }
+
+  contextLinesChanged() {
     this.setScrollTop(0);
     return etch.update(this);
   }

--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -20,6 +20,7 @@ class ResultsView {
     this.selectedResultIndex = 0;
     this.selectedMatchIndex = -1;
     this.collapsedResultIndices = [];
+    this.showContextLines = true;
     this.heightForSearchResult = this.heightForSearchResult.bind(this);
 
     this.resolveHeightInvalidationPromise = null
@@ -125,7 +126,8 @@ class ResultsView {
             previewStyle: this.previewStyle,
             pathDetailsHeight: this.pathDetailsHeight,
             matchHeight: this.matchHeight,
-            contextLineHeight: this.contextLineHeight
+            contextLineHeight: this.contextLineHeight,
+            showContextLines: this.showContextLines
           }, this.model.results[filePath]);
         }),
       })
@@ -138,8 +140,8 @@ class ResultsView {
       for (let i = 0, n = searchResult.matches.length; i < n; i++) {
         const match = searchResult.matches[i];
         result += this.matchHeight;
-        if (match.leadingContextLines) result += this.contextLineHeight * match.leadingContextLines.length;
-        if (match.trailingContextLines) result += this.contextLineHeight * match.trailingContextLines.length;
+        if (match.leadingContextLines && this.showContextLines) result += this.contextLineHeight * match.leadingContextLines.length;
+        if (match.trailingContextLines && this.showContextLines) result += this.contextLineHeight * match.trailingContextLines.length;
       }
     }
     return result;
@@ -438,6 +440,11 @@ class ResultsView {
     this.collapsedResultIndices.fill(true);
     this.setScrollTop(0);
     etch.update(this);
+  }
+
+  toggleContextLines() {
+    this.showContextLines = !this.showContextLines;
+    return etch.update(this);
   }
 
   scrollToSelectedMatch() {

--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -447,6 +447,7 @@ class ResultsView {
 
   toggleContextLines() {
     this.model.getFindOptions().showContextLines = !this.model.getFindOptions().showContextLines;
+    this.setScrollTop(0);
     return etch.update(this);
   }
 

--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -503,8 +503,7 @@ class ResultsView {
   }
 
   contextLinesChanged() {
-    this.setScrollTop(0);
-    return etch.update(this);
+    etch.update(this).then(() => { this.scrollToSelectedMatch(); });
   }
 
   scrollToSelectedMatch() {

--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -20,7 +20,6 @@ class ResultsView {
     this.selectedResultIndex = 0;
     this.selectedMatchIndex = -1;
     this.collapsedResultIndices = [];
-    this.showContextLines = true;
     this.heightForSearchResult = this.heightForSearchResult.bind(this);
 
     this.resolveHeightInvalidationPromise = null
@@ -127,7 +126,7 @@ class ResultsView {
             pathDetailsHeight: this.pathDetailsHeight,
             matchHeight: this.matchHeight,
             contextLineHeight: this.contextLineHeight,
-            showContextLines: this.showContextLines
+            showContextLines: this.model.getFindOptions().showContextLines
           }, this.model.results[filePath]);
         }),
       })
@@ -140,8 +139,12 @@ class ResultsView {
       for (let i = 0, n = searchResult.matches.length; i < n; i++) {
         const match = searchResult.matches[i];
         result += this.matchHeight;
-        if (match.leadingContextLines && this.showContextLines) result += this.contextLineHeight * match.leadingContextLines.length;
-        if (match.trailingContextLines && this.showContextLines) result += this.contextLineHeight * match.trailingContextLines.length;
+        if (match.leadingContextLines && this.model.getFindOptions().showContextLines) {
+          result += this.contextLineHeight * match.leadingContextLines.length;
+        }
+        if (match.trailingContextLines && this.model.getFindOptions().showContextLines) {
+          result += this.contextLineHeight * match.trailingContextLines.length;
+        }
       }
     }
     return result;
@@ -443,7 +446,7 @@ class ResultsView {
   }
 
   toggleContextLines() {
-    this.showContextLines = !this.showContextLines;
+    this.model.getFindOptions().showContextLines = !this.model.getFindOptions().showContextLines;
     return etch.update(this);
   }
 

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -767,8 +767,6 @@ describe('ResultsView', () => {
           expect(lineNodes[2].querySelector('.preview').textContent).toBe('return items if items.length <= 1');
           expect(lineNodes[3]).not.toHaveClass('match-line');
           expect(lineNodes[3].querySelector('.preview').textContent).toBe('');
-          // expect(lineNodes[4]).not.toHaveClass('match-line');
-          // expect(lineNodes[4].querySelector('.preview').textContent).toBe('pivot = items.shift()');
         }
 
         // show no leading context lines, show 3 trailing context lines

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -697,7 +697,7 @@ describe('ResultsView', () => {
   describe('search result context lines', () => {
     beforeEach(async () => {
       atom.config.set('find-and-replace.searchContextLineCountBefore', 2);
-      atom.config.set('find-and-replace.searchContextLineCountAfter', 1);
+      atom.config.set('find-and-replace.searchContextLineCountAfter', 3);
       atom.config.set('find-and-replace.leadingContextLineCount', 0);
       atom.config.set('find-and-replace.trailingContextLineCount', 0);
 
@@ -708,43 +708,39 @@ describe('ResultsView', () => {
       resultsView = getResultsView();
     });
 
+    function getLineNodesMatchFirstPath(resultsView, matchIndex) {
+      const pathNodes = resultsView.refs.listView.element.querySelectorAll('.path');
+      expect(pathNodes.length).not.toBeLessThan(1);
+      const pathNameNode = pathNodes[0].querySelector('.path-name');
+      expect(pathNameNode.textContent).toBe('sample.coffee');
+      // the second file is sample.js which we don't use
+      expect(pathNodes.length).not.toBeLessThan(matchIndex + 1);
+      const resultNode = pathNodes[matchIndex].querySelector('.search-result');
+      return resultNode.querySelectorAll('.list-item');
+    }
+
     it('shows the context lines', async () => {
       // the following condition is pretty hacky
       // it doesn't work correctly for e.g. version 1.2
       if (parseFloat(atom.getVersion()) >= 1.17) {
+        // show no context lines
         expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(0);
         expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(0);
-        await resultsView.toggleLeadingContextLines();
-        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(2);
-        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(0);
-
         {
-          const pathNodes = resultsView.refs.listView.element.querySelectorAll('.path');
-          expect(pathNodes.length).toBe(2);
-          const pathNameNode = pathNodes[0].querySelector('.path-name');
-          expect(pathNameNode.textContent).toBe('sample.coffee');
-          // the second file is sample.js which we don't use
-          const resultNode = pathNodes[0].querySelector('.search-result');
-          const lineNodes = resultNode.querySelectorAll('.list-item');
-          expect(lineNodes.length).toBe(2);
-          expect(lineNodes[0]).not.toHaveClass('match-line');
-          expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
-          expect(lineNodes[1]).toHaveClass('match-line');
-          expect(lineNodes[1].querySelector('.preview').textContent).toBe('sort: (items) ->');
+          const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
+          expect(lineNodes.length).toBe(1);
+          expect(lineNodes[0]).toHaveClass('match-line');
+          expect(lineNodes[0].querySelector('.preview').textContent).toBe('sort: (items) ->');
         }
 
-        await resultsView.toggleTrailingContextLines();
+        // show all leading context lines, show 1 trailing context line
+        await resultsView.toggleLeadingContextLines();
+        await resultsView.incrementTrailingContextLines();
         expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(2);
         expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(1);
 
         {
-          const pathNodes = resultsView.refs.listView.element.querySelectorAll('.path');
-          expect(pathNodes.length).toBe(2);
-          const pathNameNode = pathNodes[0].querySelector('.path-name');
-          expect(pathNameNode.textContent).toBe('sample.coffee');
-          // the second file is sample.js which we don't use
-          const resultNode = pathNodes[0].querySelector('.search-result');
-          const lineNodes = resultNode.querySelectorAll('.list-item');
+          const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
           expect(lineNodes.length).toBe(3);
           expect(lineNodes[0]).not.toHaveClass('match-line');
           expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
@@ -753,25 +749,82 @@ describe('ResultsView', () => {
           expect(lineNodes[2]).not.toHaveClass('match-line');
           expect(lineNodes[2].querySelector('.preview').textContent).toBe('return items if items.length <= 1');
         }
-      }
-    });
 
-    it('hides the context lines', async () => {
-      // the following condition is pretty hacky
-      // it doesn't work correctly for e.g. version 1.2
-      if (parseFloat(atom.getVersion()) >= 1.17) {
+        // show 1 leading context line, show 2 trailing context lines
+        await resultsView.decrementLeadingContextLines();
+        await resultsView.incrementTrailingContextLines();
+        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(1);
+        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(2);
+
+        {
+          const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
+          expect(lineNodes.length).toBe(4);
+          expect(lineNodes[0]).not.toHaveClass('match-line');
+          expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
+          expect(lineNodes[1]).toHaveClass('match-line');
+          expect(lineNodes[1].querySelector('.preview').textContent).toBe('sort: (items) ->');
+          expect(lineNodes[2]).not.toHaveClass('match-line');
+          expect(lineNodes[2].querySelector('.preview').textContent).toBe('return items if items.length <= 1');
+          expect(lineNodes[3]).not.toHaveClass('match-line');
+          expect(lineNodes[3].querySelector('.preview').textContent).toBe('');
+          // expect(lineNodes[4]).not.toHaveClass('match-line');
+          // expect(lineNodes[4].querySelector('.preview').textContent).toBe('pivot = items.shift()');
+        }
+
+        // show no leading context lines, show 3 trailing context lines
+        await resultsView.decrementLeadingContextLines();
+        await resultsView.incrementTrailingContextLines();
         expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(0);
+        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(3);
+
+        {
+          const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
+          expect(lineNodes.length).toBe(4);
+          expect(lineNodes[0]).toHaveClass('match-line');
+          expect(lineNodes[0].querySelector('.preview').textContent).toBe('sort: (items) ->');
+          expect(lineNodes[1]).not.toHaveClass('match-line');
+          expect(lineNodes[1].querySelector('.preview').textContent).toBe('return items if items.length <= 1');
+          expect(lineNodes[2]).not.toHaveClass('match-line');
+          expect(lineNodes[2].querySelector('.preview').textContent).toBe('');
+          expect(lineNodes[3]).not.toHaveClass('match-line');
+          expect(lineNodes[3].querySelector('.preview').textContent).toBe('pivot = items.shift()');
+        }
+
+        // show 1 leading context line, show 2 trailing context lines
+        await resultsView.incrementLeadingContextLines();
+        await resultsView.decrementTrailingContextLines();
+        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(1);
+        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(2);
+
+        {
+          const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
+          expect(lineNodes.length).toBe(4);
+          expect(lineNodes[0]).not.toHaveClass('match-line');
+          expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
+          expect(lineNodes[1]).toHaveClass('match-line');
+          expect(lineNodes[1].querySelector('.preview').textContent).toBe('sort: (items) ->');
+          expect(lineNodes[2]).not.toHaveClass('match-line');
+          expect(lineNodes[2].querySelector('.preview').textContent).toBe('return items if items.length <= 1');
+          expect(lineNodes[3]).not.toHaveClass('match-line');
+          expect(lineNodes[3].querySelector('.preview').textContent).toBe('');
+        }
+
+        // show 1 leading context line, show 2 trailing context lines
+        await resultsView.incrementTrailingContextLines();
+        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(3);
+        await resultsView.incrementLeadingContextLines();
+        await resultsView.toggleTrailingContextLines();
+        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(2);
         expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(0);
-        const pathNodes = resultsView.refs.listView.element.querySelectorAll('.path');
-        expect(pathNodes.length).toBe(2);
-        let pathNameNode = pathNodes[0].querySelector('.path-name');
-        expect(pathNameNode.textContent).toBe('sample.coffee');
-        // the second file is sample.js which we don't use
-        const resultNode = pathNodes[0].querySelector('.search-result');
-        const lineNodes = resultNode.querySelectorAll('.list-item');
-        expect(lineNodes.length).toBe(1);
-        expect(lineNodes[0]).toHaveClass('match-line');
-        expect(lineNodes[0].querySelector('.preview').textContent).toBe('sort: (items) ->');
+
+        {
+          const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
+          expect(lineNodes.length).toBe(2);
+          expect(lineNodes[0]).not.toHaveClass('match-line');
+          expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
+          expect(lineNodes[1]).toHaveClass('match-line');
+          expect(lineNodes[1].querySelector('.preview').textContent).toBe('sort: (items) ->');
+        }
       }
     });
   })

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -697,7 +697,7 @@ describe('ResultsView', () => {
   describe('search result context lines', () => {
     beforeEach(async () => {
       atom.config.set('find-and-replace.searchContextLineCountBefore', 2);
-      atom.config.set('find-and-replace.searchContextLineCountAfter', 3);
+      atom.config.set('find-and-replace.searchContextLineCountAfter', 1);
 
       projectFindView.findEditor.setText('items');
       atom.commands.dispatch(projectFindView.element, 'core:confirm');
@@ -710,23 +710,40 @@ describe('ResultsView', () => {
       // the following condition is pretty hacky
       // it doesn't work correctly for e.g. version 1.2
       if (parseFloat(atom.getVersion()) >= 1.17) {
+        expect(resultsView.showContextLines).toBe(true);
         const pathNodes = resultsView.refs.listView.element.querySelectorAll('.path');
-        expect(pathNodes.length).toBe(1)
+        expect(pathNodes.length).toBe(2);
         const pathNameNode = pathNodes[0].querySelector('.path-name');
         expect(pathNameNode.textContent).toBe('sample.coffee');
+        // the second file is sample.js which we don't use
         const resultNode = pathNodes[0].querySelector('.search-result');
         const lineNodes = resultNode.querySelectorAll('.list-item');
-        expect(lineNodes.length).toBe(5)
+        expect(lineNodes.length).toBe(3);
         expect(lineNodes[0]).not.toHaveClass('match-line');
         expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
         expect(lineNodes[1]).toHaveClass('match-line');
         expect(lineNodes[1].querySelector('.preview').textContent).toBe('sort: (items) ->');
         expect(lineNodes[2]).not.toHaveClass('match-line');
         expect(lineNodes[2].querySelector('.preview').textContent).toBe('return items if items.length <= 1');
-        expect(lineNodes[3]).not.toHaveClass('match-line');
-        expect(lineNodes[3].querySelector('.preview').textContent).toBe('');
-        expect(lineNodes[4]).not.toHaveClass('match-line');
-        expect(lineNodes[4].querySelector('.preview').textContent).toBe('pivot = items.shift()');
+      }
+    });
+
+    it('hides the context lines', async () => {
+      // the following condition is pretty hacky
+      // it doesn't work correctly for e.g. version 1.2
+      if (parseFloat(atom.getVersion()) >= 1.17) {
+        await resultsView.toggleContextLines();
+        expect(resultsView.showContextLines).toBe(false);
+        const pathNodes = resultsView.refs.listView.element.querySelectorAll('.path');
+        expect(pathNodes.length).toBe(2);
+        let pathNameNode = pathNodes[0].querySelector('.path-name');
+        expect(pathNameNode.textContent).toBe('sample.coffee');
+        // the second file is sample.js which we don't use
+        const resultNode = pathNodes[0].querySelector('.search-result');
+        const lineNodes = resultNode.querySelectorAll('.list-item');
+        expect(lineNodes.length).toBe(1);
+        expect(lineNodes[0]).toHaveClass('match-line');
+        expect(lineNodes[0].querySelector('.preview').textContent).toBe('sort: (items) ->');
       }
     });
   })

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -698,6 +698,7 @@ describe('ResultsView', () => {
     beforeEach(async () => {
       atom.config.set('find-and-replace.searchContextLineCountBefore', 2);
       atom.config.set('find-and-replace.searchContextLineCountAfter', 1);
+      atom.config.set('find-and-replace.showContextLines', false);
 
       projectFindView.findEditor.setText('items');
       atom.commands.dispatch(projectFindView.element, 'core:confirm');
@@ -710,7 +711,9 @@ describe('ResultsView', () => {
       // the following condition is pretty hacky
       // it doesn't work correctly for e.g. version 1.2
       if (parseFloat(atom.getVersion()) >= 1.17) {
-        expect(resultsView.showContextLines).toBe(true);
+        expect(resultsView.model.getFindOptions().showContextLines).toBe(false);
+        await resultsView.toggleContextLines();
+        expect(resultsView.model.getFindOptions().showContextLines).toBe(true);
         const pathNodes = resultsView.refs.listView.element.querySelectorAll('.path');
         expect(pathNodes.length).toBe(2);
         const pathNameNode = pathNodes[0].querySelector('.path-name');
@@ -732,8 +735,7 @@ describe('ResultsView', () => {
       // the following condition is pretty hacky
       // it doesn't work correctly for e.g. version 1.2
       if (parseFloat(atom.getVersion()) >= 1.17) {
-        await resultsView.toggleContextLines();
-        expect(resultsView.showContextLines).toBe(false);
+        expect(resultsView.model.getFindOptions().showContextLines).toBe(false);
         const pathNodes = resultsView.refs.listView.element.querySelectorAll('.path');
         expect(pathNodes.length).toBe(2);
         let pathNameNode = pathNodes[0].querySelector('.path-name');

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -698,7 +698,8 @@ describe('ResultsView', () => {
     beforeEach(async () => {
       atom.config.set('find-and-replace.searchContextLineCountBefore', 2);
       atom.config.set('find-and-replace.searchContextLineCountAfter', 1);
-      atom.config.set('find-and-replace.showContextLines', false);
+      atom.config.set('find-and-replace.leadingContextLineCount', 0);
+      atom.config.set('find-and-replace.trailingContextLineCount', 0);
 
       projectFindView.findEditor.setText('items');
       atom.commands.dispatch(projectFindView.element, 'core:confirm');
@@ -711,23 +712,47 @@ describe('ResultsView', () => {
       // the following condition is pretty hacky
       // it doesn't work correctly for e.g. version 1.2
       if (parseFloat(atom.getVersion()) >= 1.17) {
-        expect(resultsView.model.getFindOptions().showContextLines).toBe(false);
-        await resultsView.toggleContextLines();
-        expect(resultsView.model.getFindOptions().showContextLines).toBe(true);
-        const pathNodes = resultsView.refs.listView.element.querySelectorAll('.path');
-        expect(pathNodes.length).toBe(2);
-        const pathNameNode = pathNodes[0].querySelector('.path-name');
-        expect(pathNameNode.textContent).toBe('sample.coffee');
-        // the second file is sample.js which we don't use
-        const resultNode = pathNodes[0].querySelector('.search-result');
-        const lineNodes = resultNode.querySelectorAll('.list-item');
-        expect(lineNodes.length).toBe(3);
-        expect(lineNodes[0]).not.toHaveClass('match-line');
-        expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
-        expect(lineNodes[1]).toHaveClass('match-line');
-        expect(lineNodes[1].querySelector('.preview').textContent).toBe('sort: (items) ->');
-        expect(lineNodes[2]).not.toHaveClass('match-line');
-        expect(lineNodes[2].querySelector('.preview').textContent).toBe('return items if items.length <= 1');
+        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(0);
+        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(0);
+        await resultsView.toggleLeadingContextLines();
+        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(2);
+        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(0);
+
+        {
+          const pathNodes = resultsView.refs.listView.element.querySelectorAll('.path');
+          expect(pathNodes.length).toBe(2);
+          const pathNameNode = pathNodes[0].querySelector('.path-name');
+          expect(pathNameNode.textContent).toBe('sample.coffee');
+          // the second file is sample.js which we don't use
+          const resultNode = pathNodes[0].querySelector('.search-result');
+          const lineNodes = resultNode.querySelectorAll('.list-item');
+          expect(lineNodes.length).toBe(2);
+          expect(lineNodes[0]).not.toHaveClass('match-line');
+          expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
+          expect(lineNodes[1]).toHaveClass('match-line');
+          expect(lineNodes[1].querySelector('.preview').textContent).toBe('sort: (items) ->');
+        }
+
+        await resultsView.toggleTrailingContextLines();
+        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(2);
+        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(1);
+
+        {
+          const pathNodes = resultsView.refs.listView.element.querySelectorAll('.path');
+          expect(pathNodes.length).toBe(2);
+          const pathNameNode = pathNodes[0].querySelector('.path-name');
+          expect(pathNameNode.textContent).toBe('sample.coffee');
+          // the second file is sample.js which we don't use
+          const resultNode = pathNodes[0].querySelector('.search-result');
+          const lineNodes = resultNode.querySelectorAll('.list-item');
+          expect(lineNodes.length).toBe(3);
+          expect(lineNodes[0]).not.toHaveClass('match-line');
+          expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
+          expect(lineNodes[1]).toHaveClass('match-line');
+          expect(lineNodes[1].querySelector('.preview').textContent).toBe('sort: (items) ->');
+          expect(lineNodes[2]).not.toHaveClass('match-line');
+          expect(lineNodes[2].querySelector('.preview').textContent).toBe('return items if items.length <= 1');
+        }
       }
     });
 
@@ -735,7 +760,8 @@ describe('ResultsView', () => {
       // the following condition is pretty hacky
       // it doesn't work correctly for e.g. version 1.2
       if (parseFloat(atom.getVersion()) >= 1.17) {
-        expect(resultsView.model.getFindOptions().showContextLines).toBe(false);
+        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(0);
+        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(0);
         const pathNodes = resultsView.refs.listView.element.querySelectorAll('.path');
         expect(pathNodes.length).toBe(2);
         let pathNameNode = pathNodes[0].querySelector('.path-name');

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -81,6 +81,7 @@ atom-workspace.find-visible {
     vertical-align: middle;
     fill: currentColor;
     stroke: currentColor;
+    pointer-events: none;
   }
 
   .close-button {

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -35,6 +35,7 @@ atom-workspace.find-visible {
 
 // Both project and buffer FNR styles
 .find-and-replace,
+.preview-pane,
 .project-find {
   @min-width: 200px; // min width before it starts scrolling
 


### PR DESCRIPTION
### Description of the Change

The package has config settings for the number of context lines before and above each matched line. The default values are zero in order to not change previous behavior (and show no context by default). When any of these values is set to non-zero the view always shows the context lines.

This patch adds a button to the results pane to toggle between showing and hiding the context lines. If the config values for the context lines are both zero the button is not shown since it wouldn't do anything.

### Benefits

The user can toggle the context lines without the need to change the package settings and redo the query.

### Possible Drawbacks

Currently there is no option to hide the context lines by default (when non-zero values are in the config). Maybe the latest state can be made persistent to use it for the next search result?

### Applicable Issues

* The scroll position doesn't stay around the same matches when the context lines are being toggled.

### Future changes

As a consequence I think it would make sense to change the default values of the config from zero to e.g. three. If the context lines are hidden by default (and after being toggled remember the last state) that would maintain the previous behavior but make the context available to all users by default without requiring custom settings.