### PR TITLE
keep leading whitespace

### DIFF
--- a/lib/project/match-view.js
+++ b/lib/project/match-view.js
@@ -45,7 +45,7 @@ class MatchView {
     const range = Range.fromObject(this.match.range);
     const matchStart = range.start.column - this.match.lineTextOffset;
     const matchEnd = range.end.column - this.match.lineTextOffset;
-    const prefix = this.match.lineText.slice(0, matchStart).trimLeft();
+    const prefix = this.match.lineText.slice(0, matchStart);
     const suffix = this.match.lineText.slice(matchEnd);
     const {leadingContextLines, trailingContextLines} = this.match;
 
@@ -75,7 +75,7 @@ class MatchView {
             index >= leadingContextLines.length - this.leadingContextLineCount ?
               $.li({className: 'list-item'},
                 $.span({className: 'line-number text-subtle'}, range.start.row + 1 - leadingContextLines.length + index),
-                $.span({className: 'preview'}, $.span({}, line.trimLeft()))
+                $.span({className: 'preview'}, $.span({}, line))
               ) : null
           ) : null,
 
@@ -100,7 +100,7 @@ class MatchView {
             index < this.trailingContextLineCount ?
               $.li({className: 'list-item'},
                 $.span({className: 'line-number text-subtle'}, range.end.row + 1 + index + 1),
-                $.span({className: 'preview'}, $.span({}, line.trimLeft()))
+                $.span({className: 'preview'}, $.span({}, line))
               ) : null
           ) : null
         )

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -755,7 +755,7 @@ describe('ResultsView', () => {
           const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
           expect(lineNodes.length).toBe(1);
           expect(lineNodes[0]).toHaveClass('match-line');
-          expect(lineNodes[0].querySelector('.preview').textContent).toBe('sort: (items) ->');
+          expect(lineNodes[0].querySelector('.preview').textContent).toBe('  sort: (items) ->');
         }
 
         // show all leading context lines, show 1 trailing context line
@@ -770,9 +770,9 @@ describe('ResultsView', () => {
           expect(lineNodes[0]).not.toHaveClass('match-line');
           expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
           expect(lineNodes[1]).toHaveClass('match-line');
-          expect(lineNodes[1].querySelector('.preview').textContent).toBe('sort: (items) ->');
+          expect(lineNodes[1].querySelector('.preview').textContent).toBe('  sort: (items) ->');
           expect(lineNodes[2]).not.toHaveClass('match-line');
-          expect(lineNodes[2].querySelector('.preview').textContent).toBe('return items if items.length <= 1');
+          expect(lineNodes[2].querySelector('.preview').textContent).toBe('    return items if items.length <= 1');
         }
 
         // show 1 leading context line, show 2 trailing context lines
@@ -787,9 +787,9 @@ describe('ResultsView', () => {
           expect(lineNodes[0]).not.toHaveClass('match-line');
           expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
           expect(lineNodes[1]).toHaveClass('match-line');
-          expect(lineNodes[1].querySelector('.preview').textContent).toBe('sort: (items) ->');
+          expect(lineNodes[1].querySelector('.preview').textContent).toBe('  sort: (items) ->');
           expect(lineNodes[2]).not.toHaveClass('match-line');
-          expect(lineNodes[2].querySelector('.preview').textContent).toBe('return items if items.length <= 1');
+          expect(lineNodes[2].querySelector('.preview').textContent).toBe('    return items if items.length <= 1');
           expect(lineNodes[3]).not.toHaveClass('match-line');
           expect(lineNodes[3].querySelector('.preview').textContent).toBe('');
         }
@@ -804,13 +804,13 @@ describe('ResultsView', () => {
           const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
           expect(lineNodes.length).toBe(4);
           expect(lineNodes[0]).toHaveClass('match-line');
-          expect(lineNodes[0].querySelector('.preview').textContent).toBe('sort: (items) ->');
+          expect(lineNodes[0].querySelector('.preview').textContent).toBe('  sort: (items) ->');
           expect(lineNodes[1]).not.toHaveClass('match-line');
-          expect(lineNodes[1].querySelector('.preview').textContent).toBe('return items if items.length <= 1');
+          expect(lineNodes[1].querySelector('.preview').textContent).toBe('    return items if items.length <= 1');
           expect(lineNodes[2]).not.toHaveClass('match-line');
           expect(lineNodes[2].querySelector('.preview').textContent).toBe('');
           expect(lineNodes[3]).not.toHaveClass('match-line');
-          expect(lineNodes[3].querySelector('.preview').textContent).toBe('pivot = items.shift()');
+          expect(lineNodes[3].querySelector('.preview').textContent).toBe('    pivot = items.shift()');
         }
 
         // show 1 leading context line, show 2 trailing context lines
@@ -825,9 +825,9 @@ describe('ResultsView', () => {
           expect(lineNodes[0]).not.toHaveClass('match-line');
           expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
           expect(lineNodes[1]).toHaveClass('match-line');
-          expect(lineNodes[1].querySelector('.preview').textContent).toBe('sort: (items) ->');
+          expect(lineNodes[1].querySelector('.preview').textContent).toBe('  sort: (items) ->');
           expect(lineNodes[2]).not.toHaveClass('match-line');
-          expect(lineNodes[2].querySelector('.preview').textContent).toBe('return items if items.length <= 1');
+          expect(lineNodes[2].querySelector('.preview').textContent).toBe('    return items if items.length <= 1');
           expect(lineNodes[3]).not.toHaveClass('match-line');
           expect(lineNodes[3].querySelector('.preview').textContent).toBe('');
         }
@@ -846,7 +846,7 @@ describe('ResultsView', () => {
           expect(lineNodes[0]).not.toHaveClass('match-line');
           expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
           expect(lineNodes[1]).toHaveClass('match-line');
-          expect(lineNodes[1].querySelector('.preview').textContent).toBe('sort: (items) ->');
+          expect(lineNodes[1].querySelector('.preview').textContent).toBe('  sort: (items) ->');
         }
       }
     });

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -293,6 +293,7 @@ atom-workspace.find-visible {
     .preview {
       word-break: break-all;
       font-family: monospace;
+      white-space: pre;
     }
 
     .selected {


### PR DESCRIPTION
### Description of the Change

Currently each line shown in the result view has the leading spaces stripped. For some context / languages whitespace is critical. Especially when also showing context line the relative indentation can be very important.

This patch keep the leading whitespace and makes sure it is rendered correctly (not collapsing multiple spaces into a single visual space).

### Alternate Designs

If the new behavior is not considered desired an option could be introduced to toggle the two possible behaviors (hide leading whitespace vs. showing them).

### Benefits

Context awareness.

### Possible Drawbacks

The additional indentation will move the text of the line further to the right.

### Applicable Issues

None, as far as I know.