### PR TITLE
increase default number of queries context lines

### DIFF
--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -264,13 +264,22 @@ class ResultsView {
       for (let j = 0; j < this.selectedMatchIndex; j++) {
         const match = selectedResult.matches[j];
         result += this.matchHeight;
-        if (match.leadingContextLines) result += this.contextLineHeight * match.leadingContextLines.length;
-        if (match.trailingContextLines) result += this.contextLineHeight * match.trailingContextLines.length;
+        if (match.leadingContextLines && this.model.getFindOptions().leadingContextLineCount) {
+          result += this.contextLineHeight * Math.min(
+            match.leadingContextLines.length, this.model.getFindOptions().leadingContextLineCount);
+        }
+        if (match.trailingContextLines && this.model.getFindOptions().trailingContextLineCount) {
+          result += this.contextLineHeight * Math.min(
+            match.trailingContextLines.length, this.model.getFindOptions().trailingContextLineCount);
+        }
       }
 
       if (selectedResult) {
         const selectedMatch = selectedResult.matches[this.selectedMatchIndex];
-        if (selectedMatch.leadingContextLines) result += this.contextLineHeight * selectedMatch.leadingContextLines.length;
+        if (selectedMatch.leadingContextLines && this.model.getFindOptions().leadingContextLineCount) {
+          result += this.contextLineHeight * Math.min(
+            selectedMatch.leadingContextLines.length, this.model.getFindOptions().leadingContextLineCount);
+        }
       }
     }
 
@@ -301,8 +310,14 @@ class ResultsView {
           for (let j = 0; j < searchResult.matches.length; j++) {
             const match = searchResult.matches[j];
             bottom = top + this.matchHeight;
-            if (match.leadingContextLines) bottom += this.contextLineHeight * match.leadingContextLines.length;
-            if (match.trailingContextLines) bottom += this.contextLineHeight * match.trailingContextLines.length;
+            if (match.leadingContextLines && this.model.getFindOptions().leadingContextLineCount) {
+              bottom += this.contextLineHeight * Math.min(
+                match.leadingContextLines.length, this.model.getFindOptions().leadingContextLineCount);
+            }
+            if (match.trailingContextLines && this.model.getFindOptions().trailingContextLineCount) {
+              bottom += this.contextLineHeight * Math.min(
+                match.trailingContextLines.length, this.model.getFindOptions().trailingContextLineCount);
+            }
 
             if (bottom > position) {
               this.selectedResultIndex = i;

--- a/package.json
+++ b/package.json
@@ -92,15 +92,15 @@
     },
     "searchContextLineCountBefore": {
       "type": "integer",
-      "default": 0,
+      "default": 3,
       "minimum": 0,
-      "description": "The number of extra lines of context to show before the match for project results"
+      "description": "The number of extra lines of context to query before the match for project results"
     },
     "searchContextLineCountAfter": {
       "type": "integer",
-      "default": 0,
+      "default": 3,
       "minimum": 0,
-      "description": "The number of extra lines of context to show after the match for project results"
+      "description": "The number of extra lines of context to query after the match for project results"
     },
     "showSearchWrapIcon": {
       "type": "boolean",


### PR DESCRIPTION
### Description of the Change

The patch increases the default values of queried context lines.

**Update:** this identified a regression in the scrolling behavior which has been fixed in the second commit. More details in the next comment.

### Alternate Designs

Every user would need to change the settings to benefit from the new functionality to show context lines around search results. With the default of zero non of these UI improvements implemented in #908 are available.

### Benefits

While the queried context lines are not shown by default the increased default values will make the UI elements to show context lines around search results on demand available to all users.

### Possible Drawbacks

Slightly more memory usage for search results since they store the additionally queried context lines.

### Applicable Issues

None afaik.
