### PR TITLE
Enable autocompletion in the find editor

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -122,6 +122,20 @@ module.exports =
     new Disposable ->
       FileIcons.resetService()
 
+  requestAutocompletions: ->
+    disposable = @autocompleteWatchEditor?(@findView.findEditor, ['default'])
+    if disposable?
+      @autocompleteSubscriptions.add(disposable)
+
+  consumeAutocompleteWatchEditor: (watchEditor) ->
+    @autocompleteSubscriptions = new CompositeDisposable
+    @autocompleteWatchEditor = watchEditor
+    if @findView?
+      requestAutocompletions()
+    new Disposable =>
+      @autocompleteSubscriptions.dispose()
+      @autocompleteWatchEditor = null
+
   provideService: ->
     resultsMarkerLayerForTextEditor: @findModel.resultsMarkerLayerForTextEditor.bind(@findModel)
 
@@ -139,6 +153,7 @@ module.exports =
     options = {findBuffer, replaceBuffer, pathsBuffer, findHistoryCycler, replaceHistoryCycler, pathsHistoryCycler}
 
     @findView = new FindView(@findModel, options)
+
     @projectFindView = new ProjectFindView(@resultsModel, options)
 
     @findPanel = atom.workspace.addBottomPanel(item: @findView, visible: false, className: 'tool-panel panel-bottom')
@@ -160,6 +175,8 @@ module.exports =
     # See https://github.com/atom/find-and-replace/issues/63
     ResultsPaneView.model = @resultsModel
 
+    @requestAutocompletions()
+
   deactivate: ->
     @findPanel?.destroy()
     @findPanel = null
@@ -176,6 +193,8 @@ module.exports =
     ResultsPaneView.model = null
     @resultsModel = null
 
+    @autocompleteSubscriptions?.dispose()
+    @autocompleteManagerService = null
     @subscriptions?.dispose()
     @subscriptions = null
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
       "versions": {
         "1.0.0": "consumeFileIcons"
       }
+    },
+    "autocomplete.watchEditor": {
+      "versions": {
+        "1.0.0": "consumeAutocompleteWatchEditor"
+      }
     }
   },
   "providedServices": {


### PR DESCRIPTION
### Description of the Change

This pull request is a continuation of #710 after addressing comments by @as-cii.

> This PR enables autocompletion in the find editor by:
> - Registering the find editor so it's observable by autocomplete-plus
> - Adding a corresponding CSS selector to the default provider so it knows to provide completions for that editor.

Depends on atom/autocomplete-plus#864.

### Benefits

This will provide autocompletion when searching.

### Applicable Issues

Fixes atom/find-and-replace#92.
