### PR TITLE
Keep search panel open when typing in replacement field

### DIFF
--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -204,9 +204,6 @@ class ProjectFindView {
     };
 
     let updateInterfaceForResults = results => {
-      if (atom.config.get('find-and-replace.closeFindPanelAfterSearch')) {
-        this.panel && this.panel.hide();
-      }
       if (results.matchCount === 0 && results.findPattern === '') {
         this.clearMessages();
       } else {
@@ -220,10 +217,22 @@ class ProjectFindView {
       this.updateReplaceAllButtonEnablement(null);
     };
 
+    let afterSearch = () => {
+      if (atom.config.get('find-and-replace.closeFindPanelAfterSearch')) {
+        this.panel && this.panel.hide();
+      }
+    }
+
+    let searchFinished = results => {
+      afterSearch();
+      updateInterfaceForResults(results);
+    };
+
     this.subscriptions.add(this.model.onDidClear(resetInterface));
     this.subscriptions.add(this.model.onDidClearReplacementState(updateInterfaceForResults));
     this.subscriptions.add(this.model.onDidStartSearching(updateInterfaceForSearching));
-    this.subscriptions.add(this.model.onDidFinishSearching(updateInterfaceForResults));
+    this.subscriptions.add(this.model.onDidNoopSearch(afterSearch));
+    this.subscriptions.add(this.model.onDidFinishSearching(searchFinished));
     this.subscriptions.add(this.model.getFindOptions().onDidChange(this.updateOptionViews.bind(this)));
 
     this.element.addEventListener('focus', () => this.findEditor.element.focus());

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -102,7 +102,7 @@ class ResultsModel
     @replacementErrors = null
     @emitter.emit 'did-clear-replacement-state', @getResultsSummary()
 
-  shoudldRerunSearch: (findPattern, pathsPattern, replacePattern, options={}) ->
+  shouldRerunSearch: (findPattern, pathsPattern, replacePattern, options={}) ->
     {onlyRunIfChanged} = options
     if onlyRunIfChanged and findPattern? and pathsPattern? and findPattern is @lastFindPattern and pathsPattern is @lastPathsPattern
       false
@@ -110,7 +110,7 @@ class ResultsModel
       true
 
   search: (findPattern, pathsPattern, replacePattern, options={}) ->
-    return Promise.resolve() unless @shoudldRerunSearch(findPattern, pathsPattern, replacePattern, options)
+    return Promise.resolve() unless @shouldRerunSearch(findPattern, pathsPattern, replacePattern, options)
 
     {keepReplacementState} = options
     if keepReplacementState

--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -48,6 +48,9 @@ class ResultsModel
   onDidErrorForPath: (callback) ->
     @emitter.on 'did-error-for-path', callback
 
+  onDidNoopSearch: (callback) ->
+    @emitter.on 'did-noop-search', callback
+
   onDidStartSearching: (callback) ->
     @emitter.on 'did-start-searching', callback
 
@@ -110,7 +113,9 @@ class ResultsModel
       true
 
   search: (findPattern, pathsPattern, replacePattern, options={}) ->
-    return Promise.resolve() unless @shouldRerunSearch(findPattern, pathsPattern, replacePattern, options)
+    unless @shouldRerunSearch(findPattern, pathsPattern, replacePattern, options)
+      @emitter.emit 'did-noop-search'
+      return Promise.resolve()
 
     {keepReplacementState} = options
     if keepReplacementState

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -348,14 +348,22 @@ describe('ProjectFindView', () => {
     });
 
     describe("when close option is true", () => {
-      it("closes the panel after search", async () => {
+      beforeEach(() => {
         atom.config.set('find-and-replace.closeFindPanelAfterSearch', true);
+      })
 
+      it("closes the panel after search", async () => {
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
         await searchPromise;
 
         expect(getAtomPanel()).not.toBeVisible();
       });
+
+      it("does not close the panel after the replacement text is altered", async () => {
+        projectFindView.replaceEditor.setText('something else');
+
+        expect(getAtomPanel()).toBeVisible();
+      })
     });
 
     describe("splitting into a second pane", () => {

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -353,26 +353,42 @@ describe('ProjectFindView', () => {
       })
 
       it("closes the panel after search", async () => {
-        projectFindView.findEditor.setText('something')
+        projectFindView.findEditor.setText('something');
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
         await searchPromise;
 
         expect(getAtomPanel()).not.toBeVisible();
       });
 
-      it("closes the panel after an empty search", async () => {
-        projectFindView.findEditor.setText('')
+      it("leaves the panel open after an empty search", async () => {
+        projectFindView.findEditor.setText('');
+        atom.commands.dispatch(projectFindView.element, 'core:confirm');
+        await searchPromise;
+
+        expect(getAtomPanel()).toBeVisible();
+      });
+
+      it("closes the panel after a no-op search", async () => {
+        projectFindView.findEditor.setText('something');
+        atom.commands.dispatch(projectFindView.element, 'core:confirm');
+        await searchPromise;
+
+        atom.commands.dispatch(workspaceElement, 'project-find:show');
+        await activationPromise;
+
+        expect(getAtomPanel()).toBeVisible();
+
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
         await searchPromise;
 
         expect(getAtomPanel()).not.toBeVisible();
-      })
+      });
 
       it("does not close the panel after the replacement text is altered", async () => {
         projectFindView.replaceEditor.setText('something else');
 
         expect(getAtomPanel()).toBeVisible();
-      })
+      });
     });
 
     describe("splitting into a second pane", () => {

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -353,11 +353,20 @@ describe('ProjectFindView', () => {
       })
 
       it("closes the panel after search", async () => {
+        projectFindView.findEditor.setText('something')
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
         await searchPromise;
 
         expect(getAtomPanel()).not.toBeVisible();
       });
+
+      it("closes the panel after an empty search", async () => {
+        projectFindView.findEditor.setText('')
+        atom.commands.dispatch(projectFindView.element, 'core:confirm');
+        await searchPromise;
+
+        expect(getAtomPanel()).not.toBeVisible();
+      })
 
       it("does not close the panel after the replacement text is altered", async () => {
         projectFindView.replaceEditor.setText('something else');


### PR DESCRIPTION
Fixes #612 by closing the project search panel only when a search has actually completed, _not_ including the handler for clearing replacement state (which is triggered each time a character is entered in the replace field).