### PR TITLE
keep selection indices valid when adding / removing results

### DIFF
--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -222,8 +222,10 @@ class ResultsModel
 
   addResult: (filePath, result) ->
     filePathInsertedIndex = null
+    filePathUpdatedIndex = null
     if @results[filePath]
       @matchCount -= @results[filePath].matches.length
+      filePathUpdatedIndex = @paths.indexOf(filePath)
     else
       @pathCount++
       filePathInsertedIndex = binaryIndex(@paths, filePath, stringCompare)
@@ -232,16 +234,17 @@ class ResultsModel
     @matchCount += result.matches.length
 
     @results[filePath] = result
-    @emitter.emit 'did-add-result', {filePath, result, filePathInsertedIndex}
+    @emitter.emit 'did-add-result', {filePath, result, filePathInsertedIndex, filePathUpdatedIndex}
 
   removeResult: (filePath) ->
     if @results[filePath]
       @pathCount--
       @matchCount -= @results[filePath].matches.length
 
+      filePathRemovedIndex = @paths.indexOf(filePath)
       @paths = _.without(@paths, filePath)
       delete @results[filePath]
-      @emitter.emit 'did-remove-result', {filePath}
+      @emitter.emit 'did-remove-result', {filePath, filePathRemovedIndex}
 
   onContentsModified: (editor) =>
     return unless @active and @regex

--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -61,8 +61,13 @@ class ResultsView {
   }
 
   didClearSearchState() {
-    this.selectedResultIndex = 0;
-    this.selectedMatchIndex = 0;
+    if (this.model.getPaths().length > 0) {
+      this.selectedResultIndex = 0;
+      this.selectedMatchIndex = 0;
+    } else {
+      this.selectedResultIndex = -1;
+      this.selectedMatchIndex = -1;
+    }
     this.collapsedResultIndices.length = 0;
     etch.update(this);
   }
@@ -171,11 +176,40 @@ class ResultsView {
     }
   }
 
-  didAddResult() {
+  didAddResult({filePathInsertedIndex, filePathUpdatedIndex}) {
+    if (this.selectedResultIndex == -1) {
+      // if no result was selected before select the first one
+      this.selectedResultIndex = 0;
+      this.selectedMatchIndex = 0;
+    } else if (filePathInsertedIndex !== null && filePathInsertedIndex <= this.selectedResultIndex) {
+      // if a result is inserted before the current selection
+      // update the selection information to still reference the same result
+      this.selectedResultIndex++;
+    } else if (filePathUpdatedIndex !== null && filePathUpdatedIndex == this.selectedResultIndex) {
+      // if the current result is updated
+      // ensure that the match index still exists or select the last one
+      const selectedResult = this.model.getResultAt(this.selectedResultIndex);
+      if (this.selectedMatchIndex >= selectedResult.matches.length) {
+        this.selectedMatchIndex = selectedResult.matches.length - 1;
+      }
+    }
     etch.update(this);
   }
 
-  didRemoveResult() {
+  didRemoveResult({filePathRemovedIndex}) {
+    if (filePathRemovedIndex < this.selectedResultIndex) {
+      // if a result is removed before the current selection
+      // update the selection information to still reference the same result
+      this.selectedResultIndex--;
+    } else if (filePathRemovedIndex == this.selectedResultIndex) {
+      // if the result of the current selection is removed
+      // update the selection information to reference the next result
+      // if the last result is removed select the previous result
+      if (this.selectedResultIndex >= this.model.getPaths().length) {
+        this.selectedResultIndex = this.model.getPaths().length - 1;
+      }
+      this.selectedMatchIndex = -1;
+    }
     etch.update(this);
   }
 

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -850,6 +850,61 @@ describe('ResultsView', () => {
         }
       }
     });
+  });
+
+  describe('selected result and match index', () => {
+    beforeEach(async () => {
+      projectFindView.findEditor.setText('push');
+      atom.commands.dispatch(projectFindView.element, 'core:confirm');
+      await searchPromise;
+
+      resultsView = getResultsView();
+    });
+
+    it('maintains selected result when adding and removing results', async () => {
+      {
+        const matchLines = resultsView.refs.listView.element.querySelectorAll('.match-line');
+        expect(matchLines.length).toBe(4);
+
+        resultsView.moveDown();
+        resultsView.moveDown();
+        resultsView.moveDown();
+        resultsView.moveDown();
+        expect(matchLines[3]).toHaveClass('selected');
+        expect(matchLines[3].querySelector('.preview').textContent).toBe('      current < pivot ? left.push(current) : right.push(current);');
+        expect(resultsView.selectedResultIndex).toBe(1);
+        expect(resultsView.selectedMatchIndex).toBe(1);
+      }
+
+      // remove the first result
+      const firstPath = resultsView.model.getPaths()[0];
+      const firstResult = resultsView.model.getResult(firstPath);
+      resultsView.model.removeResult(firstPath);
+
+      // check that the same match is still selected
+      {
+        const matchLines = resultsView.refs.listView.element.querySelectorAll('.match-line');
+        expect(matchLines.length).toBe(2);
+        expect(matchLines[1]).toHaveClass('selected');
+        expect(matchLines[1].querySelector('.preview').textContent).toBe('      current < pivot ? left.push(current) : right.push(current);');
+        expect(resultsView.selectedResultIndex).toBe(0);
+        expect(resultsView.selectedMatchIndex).toBe(1);
+
+      }
+
+      // re-add the first result
+      resultsView.model.addResult(firstPath, firstResult);
+
+      // check that the same match is still selected
+      {
+        const matchLines = resultsView.refs.listView.element.querySelectorAll('.match-line');
+        expect(matchLines.length).toBe(4);
+        expect(matchLines[3]).toHaveClass('selected');
+        expect(matchLines[3].querySelector('.preview').textContent).toBe('      current < pivot ? left.push(current) : right.push(current);');
+        expect(resultsView.selectedResultIndex).toBe(1);
+        expect(resultsView.selectedMatchIndex).toBe(1);
+      }
+    });
   })
 });
 


### PR DESCRIPTION
### Description of the Change

Fixes #909.

The result view stores the result and match index to identify the currently selected result and match within the result. When results are being removed from the model (as described in #909) (or added) the view doesn't update those indices and therefore might either reference the "wrong" result/match or even an invalid one.

This patch ensures that the view updates those indices when the model changes.

### Alternate Designs

All the internal calculations operating on the result and match index work on the assumption that the indices are valid. A lot of code parts would need to be updated to add additional checks before using and changing the indices. Therefore I think the proposed patch to ensure that indices stay valid is the better approach.

### Benefits

The result and match indices stay valid with allows the remaining code to continue relying on that precondition. Since the indices stay valid the error described in the referenced ticket doesn't happen anymore.

### Possible Drawbacks

None afaik.

### Applicable Issues

None afaik.