### PR TITLE
Context lines styling

### DIFF
--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -294,7 +294,8 @@ atom-workspace.find-visible {
     }
 
     .search-result {
-      border-top: 1px solid @base-border-color;
+      // box-shadow over a border is used to not affect height calculation
+      box-shadow: inset 0 1px 0 @base-border-color;
     }
 
     .preview {

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -301,7 +301,16 @@ atom-workspace.find-visible {
       word-break: break-all;
       font-family: @find-and-replace-font;
       white-space: pre;
+      color: @text-color-subtle;
     }
+
+    .match-line .preview {
+      color: @text-color-highlight;
+    }
+    .match-line.selected .preview {
+      color: @text-color-selected;
+    }
+
 
     .selected {
       .highlight-info {

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -295,7 +295,10 @@ atom-workspace.find-visible {
 
     .search-result {
       // box-shadow over a border is used to not affect height calculation
-      box-shadow: inset 0 1px 0 @base-border-color;
+      box-shadow: inset 0 -1px 0 @base-border-color;
+      &:first-child {
+        box-shadow: inset 0 -1px 0 @base-border-color, inset 0 1px 0 @base-border-color;
+      }
     }
 
     .preview {

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -1,6 +1,8 @@
 @import "ui-variables";
 @import "syntax-variables";
 
+@find-and-replace-font: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+
 // result markers
 atom-text-editor {
   .find-result .region {
@@ -280,6 +282,7 @@ atom-workspace.find-visible {
       margin-right: 1ex;
       text-align: right;
       display: inline-block;
+      font-family: @find-and-replace-font;
     }
     .selected .line-number {
       color: @text-color-selected;
@@ -296,7 +299,7 @@ atom-workspace.find-visible {
 
     .preview {
       word-break: break-all;
-      font-family: monospace;
+      font-family: @find-and-replace-font;
       white-space: pre;
     }
 

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -290,6 +290,10 @@ atom-workspace.find-visible {
       color: @text-color-subtle;
     }
 
+    .search-result {
+      border-top: 1px solid @base-border-color;
+    }
+
     .preview {
       word-break: break-all;
       font-family: monospace;

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -284,7 +284,7 @@ atom-workspace.find-visible {
       display: inline-block;
       font-family: @find-and-replace-font;
     }
-    .selected .line-number {
+    .match-line.selected .line-number {
       color: @text-color-selected;
     }
 


### PR DESCRIPTION
### Description of the Change

This styles the context lines a bit more:

Before | After
--- | ---
![screen shot 2017-07-12 at 10 55 54 am](https://user-images.githubusercontent.com/378023/28098346-ba579784-66f0-11e7-8fd6-d5c1f62743b8.png) | ![screen shot 2017-07-12 at 10 55 03 am](https://user-images.githubusercontent.com/378023/28098345-ba4eb696-66f0-11e7-89bb-df86ed2b59eb.png)

### Alternate Designs

It would be nice if the context lines and line numbers would also have the same font family as the `.match-line`. It could be done by inlining the font-family to a parent element, maybe `ol.matches`? But I couldn't figure out how. 😞  

### Benefits

It should make it easier to see where new matches start.

### Possible Drawbacks

Context lines are now more subtle and might not have enough contrast. Also, depends on the theme used.

### Applicable Issues

Continues from #908

/cc @dirk-thomas 