### PR TITLE
Unfold on find

### DIFF
--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -558,6 +558,9 @@ class FindView {
     let ranges = (Array.from(this.markers).map((marker) => marker.getBufferRange()));
     let scrollMarker = this.markers[this.firstMarkerIndexAfterCursor().index];
     let editor = this.model.getEditor();
+    for(let range of ranges) {
+      editor.unfoldBufferRow(range.start.row);
+    }
     editor.setSelectedBufferRanges(ranges, {flash: true});
     editor.scrollToBufferPosition(scrollMarker.getStartBufferPosition(), {center: true});
   }
@@ -568,6 +571,7 @@ class FindView {
 
     if (marker = this.markers[markerIndex]) {
       let editor = this.model.getEditor();
+      let bufferRange = marker.getBufferRange();
       let screenRange = marker.getScreenRange();
 
       if (
@@ -584,7 +588,8 @@ class FindView {
         }
       }
 
-      editor.setSelectedScreenRange(screenRange, {flash: true});
+      editor.unfoldBufferRow(bufferRange.start.row);
+      editor.setSelectedBufferRange(bufferRange, {flash: true});
       editor.scrollToCursorPosition({center: true});
     }
   }

--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -452,7 +452,9 @@ class ResultsView {
               split: reverseDirections[atom.config.get('find-and-replace.projectSearchResultsPaneSplitDirection')]
             })
             .then(editor => {
-              editor.setSelectedBufferRange(match.range, {autoscroll: true})
+              editor.unfoldBufferRow(match.range[0][0]); // Equivalent to match.range.start.row
+              editor.setSelectedBufferRange(match.range, {flash: true});
+              editor.scrollToCursorPosition();
             });
         }
       } else {

--- a/spec/find-view-spec.js
+++ b/spec/find-view-spec.js
@@ -596,6 +596,16 @@ describe("FindView", () => {
       expect(findView.findEditor.element).toHaveFocus();
     });
 
+    describe("when the match is folded", () => {
+      it("unfolds the match", () => {
+        editor.foldAll();
+        atom.commands.dispatch(findView.findEditor.element, "core:confirm");
+        expect(editor.getSelectedBufferRange()).toEqual([[2, 34], [2, 39]]);
+        expect(editor.isFoldedAtBufferRow(2)).toBe(false);
+        expect(editor.getCursorBufferPosition()).toEqual([2, 39]);
+      })
+    })
+
     it("will re-run search if 'find-and-replace:find-next' is triggered after changing the findEditor's text", () => {
       findView.findEditor.setText("sort");
       atom.commands.dispatch(findView.findEditor.element, "find-and-replace:find-next");


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

If the match is folded, unfold it when it's searched for.

### Alternate Designs

None.

### Benefits

Being able to actually see what you were searching for instead of having to manually unfold.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #930