### PR TITLE
Added "Open in New Tab" and "Open in New Window" right-click context menu options

### DIFF
--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -90,8 +90,7 @@ class ResultsView {
         'core:confirm': this.confirmResult.bind(this),
         'core:copy': this.copyResult.bind(this),
         'find-and-replace:copy-path': this.copyPath.bind(this),
-        'find-and-replace:open-in-tab': this.openInTab.bind(this),
-        'find-and-replace:open-in-window': this.openInWindow.bind(this)
+        'find-and-replace:open-in-new-tab': this.openInNewTab.bind(this),
       })
     );
   }
@@ -529,7 +528,7 @@ class ResultsView {
     atom.clipboard.write(relativePath);
   }
 
-  async openInTab() {
+  async openInNewTab() {
     if (this.selectedRowIndex !== -1) {
       const result = this.selectedRow();
 
@@ -558,18 +557,6 @@ class ResultsView {
           }
         }
       }
-    }
-  }
-
-  openInWindow() {
-    const result = this.selectedRow();
-    if (result) {
-      atom.open({
-        pathsToOpen: [result.group.result.filePath],
-        newWindow: true,
-        devMode: atom.inDevMode(), // open tab/window in current dev&safe mode state
-        safeMode: atom.inSafeMode()
-      });
     }
   }
 

--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -14,6 +14,7 @@ const resizeDetector = require('element-resize-detector');
 const binarySearch = require('binary-search')
 
 const path = require('path');
+const _ = require('underscore-plus');
 const $ = etch.dom;
 
 const reverseDirections = {
@@ -88,7 +89,9 @@ class ResultsView {
         'core:move-to-bottom': this.moveToBottom.bind(this),
         'core:confirm': this.confirmResult.bind(this),
         'core:copy': this.copyResult.bind(this),
-        'find-and-replace:copy-path': this.copyPath.bind(this)
+        'find-and-replace:copy-path': this.copyPath.bind(this),
+        'find-and-replace:open-in-tab': this.openInTab.bind(this),
+        'find-and-replace:open-in-window': this.openInWindow.bind(this)
       })
     );
   }
@@ -308,7 +311,7 @@ class ResultsView {
     }
 
     // Only apply confirmResult (open editor, collapse group) on left click
-    if (!event.ctrlKey && event.button === 0) {
+    if (!event.ctrlKey && event.button === 0 && event.which !== 3) {
       this.confirmResult({pending: event.detail === 1});
       event.preventDefault();
     }
@@ -524,6 +527,50 @@ class ResultsView {
       relativePath = path.join(path.basename(projectPath), relativePath);
     }
     atom.clipboard.write(relativePath);
+  }
+
+  async openInTab() {
+    if (this.selectedRowIndex !== -1) {
+      const result = this.selectedRow();
+
+      if (result) {
+        let editor;
+        const editors = atom.workspace.getTextEditors();
+        const filepath = result.group.result.filePath;
+        const exists = _.some(editors, (editor) => editor.getPath() == filepath);
+
+        if (!exists) {
+          editor = await atom.workspace.open(filepath, {
+                                             activatePane: false,
+                                             activateItem: false
+          });
+        }
+        else {
+          editor = await atom.workspace.open(filepath);
+        }
+        if (result.data.matches) {
+          const match = result.data.matches[0];
+
+          if (match && editor) {
+            editor.unfoldBufferRow(match.range.start.selectedRow);
+            editor.setSelectedBufferRange(match.range, {flash: true});
+            editor.scrollToCursorPosition();
+          }
+        }
+      }
+    }
+  }
+
+  openInWindow() {
+    const result = this.selectedRow();
+    if (result) {
+      atom.open({
+        pathsToOpen: [result.group.result.filePath],
+        newWindow: true,
+        devMode: atom.inDevMode(), // open tab/window in current dev&safe mode state
+        safeMode: atom.inSafeMode()
+      });
+    }
   }
 
   expandAllResults() {

--- a/menus/find-and-replace.cson
+++ b/menus/find-and-replace.cson
@@ -26,8 +26,12 @@
     { 'label': 'Search in Directory', 'command': 'project-find:show-in-current-directory' }
   ]
   '.list-item.match-row': [
+    { 'label': 'Open in New Tab', 'command': 'find-and-replace:open-in-tab' }
     { 'label': 'Copy', 'command': 'core:copy' }
+    { 'label': 'Copy Path', 'command': 'find-and-replace:copy-path' }
   ]
-  '.list-item.match-row, .list-item.path-row': [
+  '.list-item.path-row': [
+    { 'label': 'Open in New Tab', 'command': 'find-and-replace:open-in-tab' }
+    { 'label': 'Open in New Window', 'command': 'find-and-replace:open-in-window' }
     { 'label': 'Copy Path', 'command': 'find-and-replace:copy-path' }
   ]

--- a/menus/find-and-replace.cson
+++ b/menus/find-and-replace.cson
@@ -26,12 +26,11 @@
     { 'label': 'Search in Directory', 'command': 'project-find:show-in-current-directory' }
   ]
   '.list-item.match-row': [
-    { 'label': 'Open in New Tab', 'command': 'find-and-replace:open-in-tab' }
+    { 'label': 'Open in New Tab', 'command': 'find-and-replace:open-in-new-tab' }
     { 'label': 'Copy', 'command': 'core:copy' }
     { 'label': 'Copy Path', 'command': 'find-and-replace:copy-path' }
   ]
   '.list-item.path-row': [
-    { 'label': 'Open in New Tab', 'command': 'find-and-replace:open-in-tab' }
-    { 'label': 'Open in New Window', 'command': 'find-and-replace:open-in-window' }
+    { 'label': 'Open in New Tab', 'command': 'find-and-replace:open-in-new-tab' }
     { 'label': 'Copy Path', 'command': 'find-and-replace:copy-path' }
   ]

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -498,10 +498,10 @@ describe('ResultsView', () => {
       expect(atom.views.getView(editor)).toHaveFocus();
     });
 
-    it("opens the file in a new non-active tab on 'find-and-replace:open-in-tab'", async () => {
+    it("opens the file in a new non-active tab on 'find-and-replace:open-in-new-tab'", async () => {
       const resultsPane = atom.workspace.paneForURI(ResultsPaneView.URI);
       const preEditors = atom.workspace.getTextEditors(); // keep track of editor list before command execution
-      atom.commands.dispatch(resultsView.element, 'find-and-replace:open-in-tab');
+      atom.commands.dispatch(resultsView.element, 'find-and-replace:open-in-new-tab');
       await paneItemOpening();
       const postEditors = atom.workspace.getTextEditors(); // editors after command execution
       const found = _.find(postEditors, (editor) => {
@@ -515,24 +515,13 @@ describe('ResultsView', () => {
       expect(postEditors.length).toBe(preEditors.length + 1);
     });
 
-    it("brings an already opened tab into focus on 'find-and-replace:open-in-tab'", async () => {
-      atom.commands.dispatch(resultsView.element, 'find-and-replace:open-in-tab');
+    it("brings an already opened tab into focus on 'find-and-replace:open-in-new-tab'", async () => {
+      atom.commands.dispatch(resultsView.element, 'find-and-replace:open-in-new-tab');
       await paneItemOpening();
-      atom.commands.dispatch(resultsView.element, 'find-and-replace:open-in-tab');
+      atom.commands.dispatch(resultsView.element, 'find-and-replace:open-in-new-tab');
       await paneItemOpening();
       expect(atom.workspace.getCenter().getActivePaneItem().getPath()).toContain('sample.');
     })
-
-    it("opens the file in a new window on 'find-and-replace:open-in-window'", async () => {
-      spyOn(atom, 'open');
-      atom.commands.dispatch(resultsView.element, 'find-and-replace:open-in-window');
-      expect(atom.open).toHaveBeenCalledWith({
-        pathsToOpen: [resultsView.model.getPaths()[0]],
-        newWindow: true,
-        devMode: atom.inDevMode(),
-        safeMode: atom.inSafeMode()
-      });
-    });
 
     describe("the `projectSearchResultsPaneSplitDirection` option", () => {
       beforeEach(() => {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Added two context-menu options to right clicking on the paths of search results, "Open in New Tab" ~~and "Open in New Window".~~

![image](https://user-images.githubusercontent.com/8674362/28488012-f966c2aa-6e5d-11e7-84d0-9e496f7a98b3.png)

Can also open new tabs on specific line matches, and already opened tabs will becomes focused after subsequent open attempts:

![image](https://user-images.githubusercontent.com/8674362/44323027-602ea580-a40d-11e8-8f94-8902be78cdfd.png)

~~Note: Open in New Window not implemented for specific line matches as this does not appear to be easily accomplished within the current API.~~

Includes tests to guarantee that the context menu commands call the
correct functions with the intended parameters, as well as ensure that
right-clicks have no unexpected consequences with the new functionality (such as
expanding and contracting of selected results). But it should be noted that I'm still familiarizing myself with the API and tests, so it's possible that the tests may not be entirely accurate due to that lack of familiarity.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

None.

### Benefits

Ability to open multiple results from directory searches without being required to navigate back to search results view. Allows for some nice ~~window and~~ tab organization and facilitates workflows that involve opening and editing multiple files matching certain search criteria.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

People who frequently use "Copy" and "Copy Path" might accidentally click on the newly added menu options.

### Applicable Issues

N/A. This was just a feature I'd wanted myself in the past, ideally others find it useful.