### PR TITLE
Add preserve case option for buffer replace. References #165.

### DIFF
--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -1,6 +1,7 @@
 const { Point, Range, Emitter, CompositeDisposable, TextBuffer } = require('atom');
 const FindOptions = require('./find-options');
 const escapeHelper = require('./escape-helper');
+const Util = require('./project/util');
 
 const ResultsMarkerLayersByEditor = new WeakMap;
 
@@ -92,6 +93,7 @@ class BufferSearch {
     if (!markers || markers.length === 0) return;
 
     this.findOptions.set({replacePattern});
+    const preserveCaseOnReplace = atom.config.get('find-and-replace.preserveCaseOnReplace')
 
     this.editor.transact(() => {
       let findRegex = null
@@ -104,9 +106,10 @@ class BufferSearch {
       for (let i = 0, n = markers.length; i < n; i++) {
         const marker = markers[i]
         const bufferRange = marker.getBufferRange();
-        const replacementText = findRegex ?
+        let replacementText = findRegex ?
           this.editor.getTextInBufferRange(bufferRange).replace(findRegex, replacePattern) :
           replacePattern;
+        replacementText = preserveCaseOnReplace ? Util.preserveCase(replacementText, this.editor.getTextInBufferRange(bufferRange)): replacementText
         this.editor.setTextInBufferRange(bufferRange, replacementText);
 
         marker.destroy();

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -106,10 +106,9 @@ class BufferSearch {
       for (let i = 0, n = markers.length; i < n; i++) {
         const marker = markers[i]
         const bufferRange = marker.getBufferRange();
-        let replacementText = findRegex ?
-          this.editor.getTextInBufferRange(bufferRange).replace(findRegex, replacePattern) :
-          replacePattern;
-        replacementText = preserveCaseOnReplace ? Util.preserveCase(replacementText, this.editor.getTextInBufferRange(bufferRange)): replacementText
+        const replacedText = this.editor.getTextInBufferRange(bufferRange)
+        let replacementText = findRegex ? replacedText.replace(findRegex, replacePattern) : replacePattern;
+        replacementText = preserveCaseOnReplace ? Util.preserveCase(replacementText, replacedText): replacementText
         this.editor.setTextInBufferRange(bufferRange, replacementText);
 
         marker.destroy();

--- a/lib/project/util.coffee
+++ b/lib/project/util.coffee
@@ -36,7 +36,21 @@ showIf = (condition) ->
   else
     {display: 'none'}
 
+capitalize = (str) -> str.replace(/(?:^|\s)\S/g, (capital) -> capital.toUpperCase())
+
+preserveCase = (text, reference) ->
+  # If replaced text is capitalized (strict), capitalize replacement
+  if reference is capitalize(reference.toLowerCase())
+    capitalize(text)
+
+  # If replaced text is uppercase, uppercase replacement
+  else if reference is reference.toUpperCase()
+    text.toUpperCase()
+  else
+    text
+
+
 module.exports = {
   escapeHtml, escapeRegex, sanitizePattern, getReplacementResultsMessage,
-  getSearchResultsMessage, showIf
+  getSearchResultsMessage, showIf, preserveCase
 }

--- a/lib/project/util.coffee
+++ b/lib/project/util.coffee
@@ -36,16 +36,25 @@ showIf = (condition) ->
   else
     {display: 'none'}
 
-capitalize = (str) -> str.replace(/(?:^|\s)\S/g, (capital) -> capital.toUpperCase())
+capitalize = (str) -> str[0].toUpperCase() + str.toLowerCase().slice(1)
+titleize = (str) -> str.toLowerCase().replace(/(?:^|\s)\S/g, (capital) -> capital.toUpperCase())
 
 preserveCase = (text, reference) ->
-  # If replaced text is capitalized (strict), capitalize replacement
+  # If replaced text is capitalized (strict) like a sentence, capitalize replacement
   if reference is capitalize(reference.toLowerCase())
     capitalize(text)
+
+  # If replaced text is titleized (i.e., each word start with an uppercase), titleize replacement
+  else if reference is titleize(reference.toLowerCase())
+    titleize(text)
 
   # If replaced text is uppercase, uppercase replacement
   else if reference is reference.toUpperCase()
     text.toUpperCase()
+
+  # If replaced text is lowercase, lowercase replacement
+  else if reference is reference.toLowerCase()
+    text.toLowerCase()
   else
     text
 

--- a/package.json
+++ b/package.json
@@ -118,6 +118,12 @@
       "default": false,
       "title": "Autocomplete Search",
       "description": "Autocompletes entries in the find search field."
+    },
+    "preserveCaseOnReplace": {
+      "type": "boolean",
+      "default": false,
+      "title": "Preserve case during replace.",
+      "description": "Keep the replaced text case during replace: replacing 'user' with 'person' will replace 'User' with 'Person' and 'USER' with 'PERSON'."
     }
   }
 }

--- a/spec/buffer-search-spec.js
+++ b/spec/buffer-search-spec.js
@@ -621,12 +621,12 @@ describe("BufferSearch", () => {
       expect(editor.getText()).toBe(dedent`
         -----------
         foo bar bbb ccc
-        ddd Foo Bar bbb
+        ddd Foo bar bbb
         CCC DDD foo bar
         -----------
         FOO BAR Bbb cCc
-        Ddd Foo Bar Bbb
-        ccc DDD Foo Bar
+        Ddd Foo bar Bbb
+        ccc DDD Foo bar
         -----------
       `);
     });
@@ -645,7 +645,7 @@ describe("BufferSearch", () => {
       expect(editor.getText()).toBe(dedent`
         -----------
         foo ccc
-        ddd foo
+        ddd Foo
         CCC DDD aaa
         -----------
         foo cCc
@@ -690,14 +690,48 @@ describe("BufferSearch", () => {
 
       expect(editor.getText()).toBe(dedent`
         -----------
-        FoO bbb ccc
-        ddd FoO bbb
-        CCC DDD FoO
+        foo bbb ccc
+        ddd Foo bbb
+        CCC DDD foo
         -----------
         FOO Bbb cCc
-        Ddd FoO Bbb
-        ccc DDD FoO
+        Ddd Foo Bbb
+        ccc DDD Foo
         -----------
+      `);
+    });
+    it("preserves case of sentence, title, upper and lower case.", () => {
+      editor.setText(dedent`
+        x aaa bbb x
+        x Aaa bbb x
+        x aaa Bbb x
+        x Aaa Bbb x
+        x AAA BBB x
+        x aaA bbb x
+        x aaa bbB x
+        x aaA bbB x
+      `);
+      advanceClock(editor.buffer.stoppedChangingDelay);
+
+      model.search("aAa bBb", {
+        caseSensitive: false,
+        useRegex: false,
+        wholeWord: false
+      });
+      const markers = markersListener.mostRecentCall.args[0];
+      markersListener.reset();
+
+      model.replace(markers, "xxX yYy");
+
+      expect(editor.getText()).toBe(dedent`
+        x xxx yyy x
+        x Xxx yyy x
+        x xxX yYy x
+        x Xxx Yyy x
+        x XXX YYY x
+        x xxX yYy x
+        x xxX yYy x
+        x xxX yYy x
       `);
     });
   });


### PR DESCRIPTION
### Description of the Change

This PR adds a `preserveCaseOnReplace` option (off by default) which keeps the replaced text case. For exemple, when replacing `test` with `case`:
`test Test TEST` will be replaced with: `case Case CASE`.

This is made by swapping the replacement right before putting it in the buffer in `buffer-search.js`. The `preserveCase` algorithm is trivial and defined in `project/util.coffee`.

**This only works in buffer search. The project replace is done in atom core and should be addressed in a separate ticket.**

### Alternate Designs

One could have added a button for this option, but a plugin configuration was chosen since it concerns only replacing (not searching) and it might not be toggled very often.

### Benefits

Huge benefits arise when replacing variables name that are in different case, for instance replacing in one pass `client`, `getClient` and `MAX_CLIENT` with `person`, `getPerson`, `MAX_PERSON`.

### Possible Drawbacks

This adds a boolean check for each replace, low performance impact though.

### Applicable Issues
#165 