### PR TITLE
Use multiline flag when replacing

### DIFF
--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -53,7 +53,7 @@ class FindOptions
       @emitter.emit('did-change', changedParams)
 
   getFindPatternRegex: ->
-    flags = 'g'
+    flags = 'gm'
     flags += 'i' unless @caseSensitive
 
     if @useRegex

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -1369,6 +1369,11 @@ describe('ProjectFindView', () => {
 
       describe("when the find field contains a ^ or a $ and the regex option is enabled", () => {
         it("correctly replaces all matches", async () => {
+          // TODO: Remove version check when Atom 1.21 reaches stable
+          if (parseFloat(atom.getVersion()) < 1.21) {
+            return;
+          }
+
           atom.commands.dispatch(projectFindView.element, 'project-find:toggle-regex-option');
           projectFindView.findEditor.setText(';$');
           atom.commands.dispatch(projectFindView.element, 'core:confirm');

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -564,7 +564,7 @@ describe('ProjectFindView', () => {
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
         await searchPromise;
 
-        expect(atom.workspace.scan.argsForCall[0][0]).toEqual(/i\(\\w\)ems\+/gi);
+        expect(atom.workspace.scan.argsForCall[0][0]).toEqual(/i\(\\w\)ems\+/gim);
       });
 
       it("shows an error when the regex pattern is invalid", async () => {
@@ -599,7 +599,7 @@ describe('ProjectFindView', () => {
           await searchPromise;
 
           expect(projectFindView.refs.regexOptionButton).toHaveClass('selected');
-          expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/i(\w)ems+/gi);
+          expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/i(\w)ems+/gim);
         });
 
         it("toggles regex option via a button and finds files matching the pattern", async () => {
@@ -609,7 +609,7 @@ describe('ProjectFindView', () => {
           await searchPromise;
 
           expect(projectFindView.refs.regexOptionButton).toHaveClass('selected');
-          expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/i(\w)ems+/gi);
+          expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/i(\w)ems+/gim);
         });
       });
     });
@@ -624,7 +624,7 @@ describe('ProjectFindView', () => {
         await searchPromise;
       });
 
-      it("runs a case insensitive search by default", () => expect(atom.workspace.scan.argsForCall[0][0]).toEqual(/ITEMS/gi));
+      it("runs a case insensitive search by default", () => expect(atom.workspace.scan.argsForCall[0][0]).toEqual(/ITEMS/gim));
 
       it("toggles case sensitive option via an event and finds files matching the pattern", async () => {
         expect(projectFindView.refs.caseOptionButton).not.toHaveClass('selected');
@@ -633,7 +633,7 @@ describe('ProjectFindView', () => {
         await searchPromise;
 
         expect(projectFindView.refs.caseOptionButton).toHaveClass('selected');
-        expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/ITEMS/g);
+        expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/ITEMS/gm);
       });
 
       it("toggles case sensitive option via a button and finds files matching the pattern", async () => {
@@ -643,7 +643,7 @@ describe('ProjectFindView', () => {
         await searchPromise;
 
         expect(projectFindView.refs.caseOptionButton).toHaveClass('selected');
-        expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/ITEMS/g);
+        expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/ITEMS/gm);
       });
     });
 
@@ -658,7 +658,7 @@ describe('ProjectFindView', () => {
       });
 
       it("does not run whole word search by default", () => {
-        expect(atom.workspace.scan.argsForCall[0][0]).toEqual(/wholeword/gi)
+        expect(atom.workspace.scan.argsForCall[0][0]).toEqual(/wholeword/gim)
       });
 
       it("toggles whole word option via an event and finds files matching the pattern", async () => {
@@ -667,7 +667,7 @@ describe('ProjectFindView', () => {
 
         await searchPromise;
         expect(projectFindView.refs.wholeWordOptionButton).toHaveClass('selected');
-        expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/\bwholeword\b/gi);
+        expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/\bwholeword\b/gim);
       });
 
       it("toggles whole word option via a button and finds files matching the pattern", async () => {
@@ -677,7 +677,7 @@ describe('ProjectFindView', () => {
         await searchPromise;
 
         expect(projectFindView.refs.wholeWordOptionButton).toHaveClass('selected');
-        expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/\bwholeword\b/gi);
+        expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/\bwholeword\b/gim);
       });
     });
 
@@ -1364,6 +1364,28 @@ describe('ProjectFindView', () => {
 
             expect(projectFindView.refs.descriptionLabel.textContent).toContain("13 results found");
           });
+        });
+      });
+
+      describe("when the find field contains a ^ or a $ and the regex option is enabled", () => {
+        it("correctly replaces all matches", async () => {
+          atom.commands.dispatch(projectFindView.element, 'project-find:toggle-regex-option');
+          projectFindView.findEditor.setText(';$');
+          atom.commands.dispatch(projectFindView.element, 'core:confirm');
+          await searchPromise;
+
+          spyOn(atom, 'confirm').andReturn(0);
+          projectFindView.replaceEditor.setText('sunshine');
+
+          expect(projectFindView.errorMessages).not.toBeVisible();
+          atom.commands.dispatch(projectFindView.element, 'project-find:replace-all');
+          await replacePromise;
+
+          expect(projectFindView.refs.descriptionLabel.textContent).toContain("Replaced ;$ with sunshine 9 times in 2 files");
+
+          let sampleJsContent = fs.readFileSync(sampleJs, 'utf8');
+          expect(sampleJsContent.match(/;$/gm)).toBeFalsy();
+          expect(sampleJsContent.match(/sunshine/g)).toHaveLength(8);
         });
       });
     });


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The multiline flag changes `^` and `$` to line-based rather than file-based.  

### Alternate Designs

None.

### Benefits

Replacing with `^` and `$` will work as expected.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #622
Refs atom/atom#15224

I believe the build will fail since atom/atom#15224 is only on Atom 1.21.0.