### PR TITLE
Spec cleanup

### DIFF
--- a/lib/project/results-model.coffee
+++ b/lib/project/results-model.coffee
@@ -256,16 +256,10 @@ class ResultsModel
     return unless editor.getPath()
 
     matches = []
-    # the following condition is pretty hacky
-    # it doesn't work correctly for e.g. version 1.2
-    if parseFloat(atom.getVersion()) >= 1.17
-      leadingContextLineCount = atom.config.get('find-and-replace.searchContextLineCountBefore')
-      trailingContextLineCount = atom.config.get('find-and-replace.searchContextLineCountAfter')
-      editor.scan @regex, {leadingContextLineCount, trailingContextLineCount}, (match) ->
-        matches.push(match)
-    else
-      editor.scan @regex, (match) ->
-        matches.push(match)
+    leadingContextLineCount = atom.config.get('find-and-replace.searchContextLineCountBefore')
+    trailingContextLineCount = atom.config.get('find-and-replace.searchContextLineCountAfter')
+    editor.scan @regex, {leadingContextLineCount, trailingContextLineCount}, (match) ->
+      matches.push(match)
 
     result = Result.create({filePath: editor.getPath(), matches})
     @setResult(editor.getPath(), result)

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -1,8 +1,7 @@
 /** @babel */
 
-const os = require('os');
 const path = require('path');
-const temp = require('temp');
+const temp = require('temp').track();
 const fs = require('fs-plus');
 const dedent = require('dedent');
 const {TextBuffer} = require('atom');
@@ -1055,7 +1054,7 @@ describe('ProjectFindView', () => {
     let testDir, sampleJs, sampleCoffee, replacePromise;
 
     beforeEach(async () => {
-      testDir = path.join(os.tmpdir(), "atom-find-and-replace");
+      testDir = temp.mkdirSync('atom-find-and-replace');
       sampleJs = path.join(testDir, 'sample.js');
       sampleCoffee = path.join(testDir, 'sample.coffee');
 
@@ -1070,31 +1069,6 @@ describe('ProjectFindView', () => {
       const spy = spyOn(projectFindView, 'replaceAll').andCallFake(() => {
         replacePromise = spy.originalValue.call(projectFindView);
       });
-    });
-
-    afterEach(async () => {
-      // On Windows, you can not remove a watched directory/file, therefore we
-      // have to close the project before attempting to delete. Unfortunately,
-      // Pathwatcher's close function is also not synchronous. Once
-      // atom/node-pathwatcher#4 is implemented this should be alot cleaner.
-      let activePane = atom.workspace.getCenter().getActivePane();
-      if (activePane) {
-        for (const item of activePane.getItems()) {
-          if (item.shouldPromptToSave != null) {
-            spyOn(item, 'shouldPromptToSave').andReturn(false);
-          }
-          activePane.destroyItem(item);
-        }
-      }
-
-      for (;;) {
-        try {
-          fs.removeSync(testDir);
-          break
-        } catch (e) {
-          await new Promise(resolve => setTimeout(resolve, 50))
-        }
-      }
     });
 
     describe("when the replace string contains an escaped char", () => {

--- a/spec/results-model-spec.js
+++ b/spec/results-model-spec.js
@@ -35,18 +35,14 @@ describe("ResultsModel", () => {
       expect(resultsModel.getPathCount()).toBe(1);
       expect(resultsModel.getMatchCount()).toBe(6);
       expect(resultsModel.getPaths()).toEqual([editor.getPath()]);
-      // the following condition is pretty hacky
-      // it doesn't work correctly for e.g. version 1.2
-      if (parseFloat(atom.getVersion()) >= 1.17) {
-        expect(result.matches[0].leadingContextLines.length).toBe(1);
-        expect(result.matches[0].leadingContextLines[0]).toBe("var quicksort = function () {");
-        expect(result.matches[0].trailingContextLines.length).toBe(3);
-        expect(result.matches[0].trailingContextLines[0]).toBe("    if (items.length <= 1) return items;");
-        expect(result.matches[0].trailingContextLines[1]).toBe("    var pivot = items.shift(), current, left = [], right = [];");
-        expect(result.matches[0].trailingContextLines[2]).toBe("    while(items.length > 0) {");
-        expect(result.matches[5].leadingContextLines.length).toBe(2);
-        expect(result.matches[5].trailingContextLines.length).toBe(3);
-      }
+      expect(result.matches[0].leadingContextLines.length).toBe(1);
+      expect(result.matches[0].leadingContextLines[0]).toBe("var quicksort = function () {");
+      expect(result.matches[0].trailingContextLines.length).toBe(3);
+      expect(result.matches[0].trailingContextLines[0]).toBe("    if (items.length <= 1) return items;");
+      expect(result.matches[0].trailingContextLines[1]).toBe("    var pivot = items.shift(), current, left = [], right = [];");
+      expect(result.matches[0].trailingContextLines[2]).toBe("    while(items.length > 0) {");
+      expect(result.matches[5].leadingContextLines.length).toBe(2);
+      expect(result.matches[5].trailingContextLines.length).toBe(3);
 
       editor.setText("there are some items in here");
       advanceClock(editor.buffer.stoppedChangingDelay);
@@ -58,12 +54,8 @@ describe("ResultsModel", () => {
       expect(resultsModel.getMatchCount()).toBe(1);
       expect(resultsModel.getPaths()).toEqual([editor.getPath()]);
       expect(result.matches[0].lineText).toBe("there are some items in here");
-      // the following condition is pretty hacky
-      // it doesn't work correctly for e.g. version 1.2
-      if (parseFloat(atom.getVersion()) >= 1.17) {
-        expect(result.matches[0].leadingContextLines.length).toBe(0);
-        expect(result.matches[0].trailingContextLines.length).toBe(0);
-      }
+      expect(result.matches[0].leadingContextLines.length).toBe(0);
+      expect(result.matches[0].trailingContextLines.length).toBe(0);
 
       editor.setText("no matches in here");
       advanceClock(editor.buffer.stoppedChangingDelay);

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -745,109 +745,105 @@ describe('ResultsView', () => {
     }
 
     it('shows the context lines', async () => {
-      // the following condition is pretty hacky
-      // it doesn't work correctly for e.g. version 1.2
-      if (parseFloat(atom.getVersion()) >= 1.17) {
-        // show no context lines
-        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(0);
-        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(0);
-        {
-          const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
-          expect(lineNodes.length).toBe(1);
-          expect(lineNodes[0]).toHaveClass('match-line');
-          expect(lineNodes[0].querySelector('.preview').textContent).toBe('  sort: (items) ->');
-        }
+      // show no context lines
+      expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(0);
+      expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(0);
+      {
+        const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
+        expect(lineNodes.length).toBe(1);
+        expect(lineNodes[0]).toHaveClass('match-line');
+        expect(lineNodes[0].querySelector('.preview').textContent).toBe('  sort: (items) ->');
+      }
 
-        // show all leading context lines, show 1 trailing context line
-        await resultsView.toggleLeadingContextLines();
-        await resultsView.incrementTrailingContextLines();
-        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(2);
-        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(1);
+      // show all leading context lines, show 1 trailing context line
+      await resultsView.toggleLeadingContextLines();
+      await resultsView.incrementTrailingContextLines();
+      expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(2);
+      expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(1);
 
-        {
-          const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
-          expect(lineNodes.length).toBe(3);
-          expect(lineNodes[0]).not.toHaveClass('match-line');
-          expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
-          expect(lineNodes[1]).toHaveClass('match-line');
-          expect(lineNodes[1].querySelector('.preview').textContent).toBe('  sort: (items) ->');
-          expect(lineNodes[2]).not.toHaveClass('match-line');
-          expect(lineNodes[2].querySelector('.preview').textContent).toBe('    return items if items.length <= 1');
-        }
+      {
+        const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
+        expect(lineNodes.length).toBe(3);
+        expect(lineNodes[0]).not.toHaveClass('match-line');
+        expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
+        expect(lineNodes[1]).toHaveClass('match-line');
+        expect(lineNodes[1].querySelector('.preview').textContent).toBe('  sort: (items) ->');
+        expect(lineNodes[2]).not.toHaveClass('match-line');
+        expect(lineNodes[2].querySelector('.preview').textContent).toBe('    return items if items.length <= 1');
+      }
 
-        // show 1 leading context line, show 2 trailing context lines
-        await resultsView.decrementLeadingContextLines();
-        await resultsView.incrementTrailingContextLines();
-        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(1);
-        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(2);
+      // show 1 leading context line, show 2 trailing context lines
+      await resultsView.decrementLeadingContextLines();
+      await resultsView.incrementTrailingContextLines();
+      expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(1);
+      expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(2);
 
-        {
-          const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
-          expect(lineNodes.length).toBe(4);
-          expect(lineNodes[0]).not.toHaveClass('match-line');
-          expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
-          expect(lineNodes[1]).toHaveClass('match-line');
-          expect(lineNodes[1].querySelector('.preview').textContent).toBe('  sort: (items) ->');
-          expect(lineNodes[2]).not.toHaveClass('match-line');
-          expect(lineNodes[2].querySelector('.preview').textContent).toBe('    return items if items.length <= 1');
-          expect(lineNodes[3]).not.toHaveClass('match-line');
-          expect(lineNodes[3].querySelector('.preview').textContent).toBe('');
-        }
+      {
+        const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
+        expect(lineNodes.length).toBe(4);
+        expect(lineNodes[0]).not.toHaveClass('match-line');
+        expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
+        expect(lineNodes[1]).toHaveClass('match-line');
+        expect(lineNodes[1].querySelector('.preview').textContent).toBe('  sort: (items) ->');
+        expect(lineNodes[2]).not.toHaveClass('match-line');
+        expect(lineNodes[2].querySelector('.preview').textContent).toBe('    return items if items.length <= 1');
+        expect(lineNodes[3]).not.toHaveClass('match-line');
+        expect(lineNodes[3].querySelector('.preview').textContent).toBe('');
+      }
 
-        // show no leading context lines, show 3 trailing context lines
-        await resultsView.decrementLeadingContextLines();
-        await resultsView.incrementTrailingContextLines();
-        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(0);
-        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(3);
+      // show no leading context lines, show 3 trailing context lines
+      await resultsView.decrementLeadingContextLines();
+      await resultsView.incrementTrailingContextLines();
+      expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(0);
+      expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(3);
 
-        {
-          const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
-          expect(lineNodes.length).toBe(4);
-          expect(lineNodes[0]).toHaveClass('match-line');
-          expect(lineNodes[0].querySelector('.preview').textContent).toBe('  sort: (items) ->');
-          expect(lineNodes[1]).not.toHaveClass('match-line');
-          expect(lineNodes[1].querySelector('.preview').textContent).toBe('    return items if items.length <= 1');
-          expect(lineNodes[2]).not.toHaveClass('match-line');
-          expect(lineNodes[2].querySelector('.preview').textContent).toBe('');
-          expect(lineNodes[3]).not.toHaveClass('match-line');
-          expect(lineNodes[3].querySelector('.preview').textContent).toBe('    pivot = items.shift()');
-        }
+      {
+        const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
+        expect(lineNodes.length).toBe(4);
+        expect(lineNodes[0]).toHaveClass('match-line');
+        expect(lineNodes[0].querySelector('.preview').textContent).toBe('  sort: (items) ->');
+        expect(lineNodes[1]).not.toHaveClass('match-line');
+        expect(lineNodes[1].querySelector('.preview').textContent).toBe('    return items if items.length <= 1');
+        expect(lineNodes[2]).not.toHaveClass('match-line');
+        expect(lineNodes[2].querySelector('.preview').textContent).toBe('');
+        expect(lineNodes[3]).not.toHaveClass('match-line');
+        expect(lineNodes[3].querySelector('.preview').textContent).toBe('    pivot = items.shift()');
+      }
 
-        // show 1 leading context line, show 2 trailing context lines
-        await resultsView.incrementLeadingContextLines();
-        await resultsView.decrementTrailingContextLines();
-        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(1);
-        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(2);
+      // show 1 leading context line, show 2 trailing context lines
+      await resultsView.incrementLeadingContextLines();
+      await resultsView.decrementTrailingContextLines();
+      expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(1);
+      expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(2);
 
-        {
-          const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
-          expect(lineNodes.length).toBe(4);
-          expect(lineNodes[0]).not.toHaveClass('match-line');
-          expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
-          expect(lineNodes[1]).toHaveClass('match-line');
-          expect(lineNodes[1].querySelector('.preview').textContent).toBe('  sort: (items) ->');
-          expect(lineNodes[2]).not.toHaveClass('match-line');
-          expect(lineNodes[2].querySelector('.preview').textContent).toBe('    return items if items.length <= 1');
-          expect(lineNodes[3]).not.toHaveClass('match-line');
-          expect(lineNodes[3].querySelector('.preview').textContent).toBe('');
-        }
+      {
+        const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
+        expect(lineNodes.length).toBe(4);
+        expect(lineNodes[0]).not.toHaveClass('match-line');
+        expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
+        expect(lineNodes[1]).toHaveClass('match-line');
+        expect(lineNodes[1].querySelector('.preview').textContent).toBe('  sort: (items) ->');
+        expect(lineNodes[2]).not.toHaveClass('match-line');
+        expect(lineNodes[2].querySelector('.preview').textContent).toBe('    return items if items.length <= 1');
+        expect(lineNodes[3]).not.toHaveClass('match-line');
+        expect(lineNodes[3].querySelector('.preview').textContent).toBe('');
+      }
 
-        // show 1 leading context line, show 2 trailing context lines
-        await resultsView.incrementTrailingContextLines();
-        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(3);
-        await resultsView.incrementLeadingContextLines();
-        await resultsView.toggleTrailingContextLines();
-        expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(2);
-        expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(0);
+      // show 1 leading context line, show 2 trailing context lines
+      await resultsView.incrementTrailingContextLines();
+      expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(3);
+      await resultsView.incrementLeadingContextLines();
+      await resultsView.toggleTrailingContextLines();
+      expect(resultsView.model.getFindOptions().leadingContextLineCount).toBe(2);
+      expect(resultsView.model.getFindOptions().trailingContextLineCount).toBe(0);
 
-        {
-          const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
-          expect(lineNodes.length).toBe(2);
-          expect(lineNodes[0]).not.toHaveClass('match-line');
-          expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
-          expect(lineNodes[1]).toHaveClass('match-line');
-          expect(lineNodes[1].querySelector('.preview').textContent).toBe('  sort: (items) ->');
-        }
+      {
+        const lineNodes = getLineNodesMatchFirstPath(resultsView, 0);
+        expect(lineNodes.length).toBe(2);
+        expect(lineNodes[0]).not.toHaveClass('match-line');
+        expect(lineNodes[0].querySelector('.preview').textContent).toBe('class quicksort');
+        expect(lineNodes[1]).toHaveClass('match-line');
+        expect(lineNodes[1].querySelector('.preview').textContent).toBe('  sort: (items) ->');
       }
     });
   });


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Remove outdated 1.17 version checks
* Use `temp.track()` and `temp.mkdirSync()` rather than `os.tmpdir()`
* Clean up some ugly watcher code from 2013