### PR TITLE
Feature: Javascript Function mode for replace

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -38,6 +38,7 @@
   'cmd-alt-c': 'find-and-replace:toggle-case-option'
   'cmd-alt-s': 'find-and-replace:toggle-selection-option'
   'cmd-alt-w': 'find-and-replace:toggle-whole-word-option'
+  'cmd-alt-f': 'find-and-replace:toggle-function-option'
 
 '.platform-win32 .find-and-replace, .platform-linux .find-and-replace':
   'shift-enter': 'find-and-replace:show-previous'
@@ -51,12 +52,13 @@
   'cmd-alt-/': 'project-find:toggle-regex-option'
   'cmd-alt-c': 'project-find:toggle-case-option'
   'cmd-alt-w': 'project-find:toggle-whole-word-option'
+  'cmd-alt-f': 'find-and-replace:toggle-function-option'
 
 '.platform-win32 .project-find, .platform-linux .project-find':
   'ctrl-enter': 'project-find:confirm'
   'ctrl-alt-/': 'project-find:toggle-regex-option'
   'ctrl-shift-c': 'find-and-replace:toggle-case-option'
-  
+
 '.find-and-replace, .project-find, .project-find .results-view':
   'tab': 'find-and-replace:focus-next'
   'shift-tab': 'find-and-replace:focus-previous'

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -94,21 +94,51 @@ class BufferSearch {
 
     this.findOptions.set({replacePattern});
     var useFunction = this.findOptions.useFunction;
+    var replaceMap;
 
     if(useFunction){
+      var err;
       var replaceFcn;
       try {
         replaceFcn = vm.runInThisContext(replacePattern);
-      } catch(err) {
+      } catch(error) {
+        err = error;
         err.message = "Function didn't compile: " + err.message;
         return this.emitter.emit('did-error', err);
       }
       if(replaceFcn && typeof replaceFcn === "function") {
+        let findRegex = null
+        if (this.findOptions.useRegex) {
+          findRegex = this.getFindPatternRegex();
+          if (!useFunction){
+            replacePattern = escapeHelper.unescapeEscapeSequence(replacePattern);
+          }
+        }
         replacePattern = replaceFcn;
+        replaceMap = markers.map(marker=>{
+          const bufferRange = marker.getBufferRange();
+          const currentText = this.editor.getTextInBufferRange(bufferRange);
+          let replacementText;
+          try {
+            replacementText = currentText.replace(findRegex || currentText,
+              replacePattern);
+          } catch(error) {
+            err = error
+          }
+          if(!replacementText){
+            err = {
+              message: "Function returned " + (replacementText
+                && replacementText.toString ? replacementText.toString() : replacementText)
+            };
+          }
+          return { marker, bufferRange, replacementText};
+        });
       } else {
-        var err = {
-          message: "Function had type: " + typeof replaceFcn
+        err = {
+          message: "Function was " + typeof replaceFcn
         };
+      }
+      if(err){
         return this.emitter.emit('did-error', err);
       }
     }
@@ -116,38 +146,34 @@ class BufferSearch {
     this.editor.transact(() => {
       let findRegex = null
 
-      if (this.findOptions.useRegex) {
-        findRegex = this.getFindPatternRegex();
-        if (!useFunction){
-          replacePattern = escapeHelper.unescapeEscapeSequence(replacePattern);
-        }
-      }
-
-      for (let i = 0, n = markers.length; i < n; i++) {
-        const marker = markers[i]
-        const bufferRange = marker.getBufferRange();
-        let replacementText;
-        if(useFunction){
-          const currentText = this.editor.getTextInBufferRange(bufferRange);
-          try {
-            replacementText = currentText.replace(findRegex || currentText, replacePattern);
-          } catch(err) {
-            console.log(err)
-            return this.emitter.emit('did-error', err);
+      if(!useFunction){
+        if (this.findOptions.useRegex) {
+          findRegex = this.getFindPatternRegex();
+          if (!useFunction){
+            replacePattern = escapeHelper.unescapeEscapeSequence(replacePattern);
           }
-        } else {
-          replacementText = findRegex ?
-            this.editor.getTextInBufferRange(bufferRange).replace(findRegex, replacePattern) :
-            replacePattern;
         }
-        this.editor.setTextInBufferRange(bufferRange, replacementText);
 
-        marker.destroy();
-        this.markers.splice(this.markers.indexOf(marker), 1);
+        for (let i = 0, n = markers.length; i < n; i++) {
+          const marker = markers[i]
+          const bufferRange = marker.getBufferRange();
+          const replacementText = findRegex ?
+              this.editor.getTextInBufferRange(bufferRange).replace(findRegex, replacePattern) :
+              replacePattern;
+          this.editor.setTextInBufferRange(bufferRange, replacementText);
+          marker.destroy();
+          this.markers.splice(this.markers.indexOf(marker), 1);
+        }
+      } else if(replaceMap) {
+        replaceMap.map(({marker, bufferRange, replacementText})=>{
+          this.editor.setTextInBufferRange(bufferRange, replacementText);
+          marker.destroy();
+          this.markers.splice(this.markers.indexOf(marker), 1);
+        });
       }
-    });
 
-    return this.emitter.emit('did-update', this.markers.slice());
+      return this.emitter.emit('did-update', this.markers.slice());
+    });
   }
 
   destroy() {

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -104,7 +104,8 @@ class BufferSearch {
       } catch(error) {
         err = error;
         err.message = "Function didn't compile: " + err.message;
-        return this.emitter.emit('did-error', err);
+        this.emitter.emit('did-error', err);
+        return err;
       }
       if(replaceFcn && typeof replaceFcn === "function") {
         let findRegex = null
@@ -143,7 +144,8 @@ class BufferSearch {
         };
       }
       if(err){
-        return this.emitter.emit('did-error', err);
+        this.emitter.emit('did-error', err);
+        return err;
       }
     }
 

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -178,8 +178,8 @@ class BufferSearch {
           this.markers.splice(this.markers.indexOf(marker), 1);
         });
       }
-
     });
+    
     return this.emitter.emit('did-update', this.markers.slice());
   }
 

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -114,7 +114,17 @@ class BufferSearch {
             replacePattern = escapeHelper.unescapeEscapeSequence(replacePattern);
           }
         }
-        replacePattern = replaceFcn;
+        // compose the function with a check to make sure it returns a string
+        // cast explicitly with String() to override
+        replacePattern = (...args) => {
+          const result = replaceFcn(...args);
+          if(typeof result !== "string"){
+            err = {
+              message: "Function returned " + typeof result
+            };
+          }
+        };
+        // precompute the changes in case there is a function error
         replaceMap = markers.map(marker=>{
           const bufferRange = marker.getBufferRange();
           const currentText = this.editor.getTextInBufferRange(bufferRange);
@@ -124,12 +134,6 @@ class BufferSearch {
               replacePattern);
           } catch(error) {
             err = error
-          }
-          if(!replacementText){
-            err = {
-              message: "Function returned " + (replacementText
-                && replacementText.toString ? replacementText.toString() : replacementText)
-            };
           }
           return { marker, bufferRange, replacementText};
         });
@@ -164,7 +168,7 @@ class BufferSearch {
           marker.destroy();
           this.markers.splice(this.markers.indexOf(marker), 1);
         }
-      } else if(replaceMap) {
+      } else {
         replaceMap.map(({marker, bufferRange, replacementText})=>{
           this.editor.setTextInBufferRange(bufferRange, replacementText);
           marker.destroy();

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -93,12 +93,12 @@ class BufferSearch {
     if (!markers || markers.length === 0) return;
 
     this.findOptions.set({replacePattern});
-    var useFunction = this.findOptions.useFunction;
-    var replaceMap;
+    let useFunction = this.findOptions.useFunction;
+    let replaceMap;
 
     if(useFunction){
-      var err;
-      var replaceFcn;
+      let err;
+      let replaceFcn;
       try {
         replaceFcn = vm.runInThisContext(replacePattern);
       } catch(error) {
@@ -127,7 +127,7 @@ class BufferSearch {
           return result;
         };
         // precompute the changes in case there is a function error
-        replaceMap = markers.map(marker=>{
+        replaceMap = markers.map(marker => {
           const bufferRange = marker.getBufferRange();
           const currentText = this.editor.getTextInBufferRange(bufferRange);
           let replacementText;
@@ -172,15 +172,15 @@ class BufferSearch {
           this.markers.splice(this.markers.indexOf(marker), 1);
         }
       } else {
-        replaceMap.map(({marker, bufferRange, replacementText})=>{
+        replaceMap.map(({marker, bufferRange, replacementText}) => {
           this.editor.setTextInBufferRange(bufferRange, replacementText);
           marker.destroy();
           this.markers.splice(this.markers.indexOf(marker), 1);
         });
       }
 
-      return this.emitter.emit('did-update', this.markers.slice());
     });
+    return this.emitter.emit('did-update', this.markers.slice());
   }
 
   destroy() {

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -121,7 +121,7 @@ class BufferSearch {
           const result = replaceFcn(...args);
           if(typeof result !== "string"){
             err = {
-              message: "Function returned " + typeof result + ": cast to string "
+              message: "Function returned " + typeof result + (result ? ": cast to string" : "")
             };
           }
           return result;

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -121,9 +121,10 @@ class BufferSearch {
           const result = replaceFcn(...args);
           if(typeof result !== "string"){
             err = {
-              message: "Function returned " + typeof result
+              message: "Function returned " + typeof result + ": cast to string "
             };
           }
+          return result;
         };
         // precompute the changes in case there is a function error
         replaceMap = markers.map(marker=>{

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -100,15 +100,16 @@ class BufferSearch {
       try {
         replaceFcn = vm.runInThisContext(replacePattern);
       } catch(err) {
-        console.log(err);
-        replacePattern = err.message || ''; // TODO: remove this line
+        err.message = "Function didn't compile: " + err.message;
+        return this.emitter.emit('did-error', err);
       }
       if(replaceFcn && typeof replaceFcn === "function") {
         replacePattern = replaceFcn;
       } else {
-        var err = "Replace function was of type " + typeof replaceFcn;
-        console.log(err);
-        replacePattern = err; // TODO: remove this line
+        var err = {
+          message: "Function had type: " + typeof replaceFcn
+        };
+        return this.emitter.emit('did-error', err);
       }
     }
 
@@ -127,8 +128,13 @@ class BufferSearch {
         const bufferRange = marker.getBufferRange();
         let replacementText;
         if(useFunction){
-          const currentText = this.shmeditor.getTextInBufferRange(bufferRange);
-          replacementText = currentText.replace(findRegex || currentText, replacePattern);
+          const currentText = this.editor.getTextInBufferRange(bufferRange);
+          try {
+            replacementText = currentText.replace(findRegex || currentText, replacePattern);
+          } catch(err) {
+            console.log(err)
+            return this.emitter.emit('did-error', err);
+          }
         } else {
           replacementText = findRegex ?
             this.editor.getTextInBufferRange(bufferRange).replace(findRegex, replacePattern) :

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -1,3 +1,4 @@
+const vm = require('vm');
 const { Point, Range, Emitter, CompositeDisposable, TextBuffer } = require('atom');
 const FindOptions = require('./find-options');
 const escapeHelper = require('./escape-helper');
@@ -92,21 +93,47 @@ class BufferSearch {
     if (!markers || markers.length === 0) return;
 
     this.findOptions.set({replacePattern});
+    var useFunction = this.findOptions.useFunction;
+
+    if(useFunction){
+      var replaceFcn;
+      try {
+        replaceFcn = vm.runInThisContext(replacePattern);
+      } catch(err) {
+        console.log(err);
+        replacePattern = err.message || ''; // TODO: remove this line
+      }
+      if(replaceFcn && typeof replaceFcn === "function") {
+        replacePattern = replaceFcn;
+      } else {
+        var err = "Replace function was of type " + typeof replaceFcn;
+        console.log(err);
+        replacePattern = err; // TODO: remove this line
+      }
+    }
 
     this.editor.transact(() => {
       let findRegex = null
 
       if (this.findOptions.useRegex) {
         findRegex = this.getFindPatternRegex();
-        replacePattern = escapeHelper.unescapeEscapeSequence(replacePattern);
+        if (!useFunction){
+          replacePattern = escapeHelper.unescapeEscapeSequence(replacePattern);
+        }
       }
 
       for (let i = 0, n = markers.length; i < n; i++) {
         const marker = markers[i]
         const bufferRange = marker.getBufferRange();
-        const replacementText = findRegex ?
-          this.editor.getTextInBufferRange(bufferRange).replace(findRegex, replacePattern) :
-          replacePattern;
+        let replacementText;
+        if(useFunction){
+          const currentText = this.shmeditor.getTextInBufferRange(bufferRange);
+          replacementText = currentText.replace(findRegex || currentText, replacePattern);
+        } else {
+          replacementText = findRegex ?
+            this.editor.getTextInBufferRange(bufferRange).replace(findRegex, replacePattern) :
+            replacePattern;
+        }
         this.editor.setTextInBufferRange(bufferRange, replacementText);
 
         marker.destroy();

--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -8,6 +8,7 @@ Params = [
   'useRegex'
   'wholeWord'
   'caseSensitive'
+  'useFunction'
   'inCurrentSelection'
   'leadingContextLineCount'
   'trailingContextLineCount'
@@ -24,6 +25,7 @@ class FindOptions
     @useRegex = state.useRegex ? atom.config.get('find-and-replace.useRegex') ? false
     @caseSensitive = state.caseSensitive ? atom.config.get('find-and-replace.caseSensitive') ? false
     @wholeWord = state.wholeWord ? atom.config.get('find-and-replace.wholeWord') ? false
+    @useFunction = state.useFunction ? atom.config.get('find-and-replace.useFunction') ? false
     @inCurrentSelection = state.inCurrentSelection ? atom.config.get('find-and-replace.inCurrentSelection') ? false
     @leadingContextLineCount = state.leadingContextLineCount ? atom.config.get('find-and-replace.leadingContextLineCount') ? 0
     @trailingContextLineCount = state.trailingContextLineCount ? atom.config.get('find-and-replace.trailingContextLineCount') ? 0

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -429,8 +429,12 @@ class FindView {
         }
       }
 
-      this.model.replace([currentMarker], this.replaceEditor.getText());
-      this[nextOrPreviousFn]({fieldToFocus: this.replaceEditor});
+      const compiled = this.model.replace([currentMarker], this.replaceEditor.getText());
+      if(compiled){
+        this[nextOrPreviousFn]({fieldToFocus: this.replaceEditor});
+      } else {
+        atom.beep()
+      }
     } else {
       atom.beep();
     }

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -97,6 +97,14 @@ class FindView {
             })
           ),
 
+          $.div({className: 'input-block-btn'},
+            $.span({className: 'btn-group btn-toggle btn-group-replace-function'},
+              $.button({ref: 'functionOptionButton', className: 'btn'},
+                $.svg({className: "icon", innerHTML: '<use href="#find-and-replace-icon-function" />'})
+              )
+            )
+          ),
+
           $.div({className: 'input-block-item'},
             $.div({className: 'btn-group btn-group-replace'},
               $.button({ref: 'replaceNextButton', className: 'btn btn-next'}, 'Replace')
@@ -109,6 +117,10 @@ class FindView {
         ),
 
         $.svg({style: {display: 'none'}, innerHTML: `
+          <symbol id="find-and-replace-icon-function" viewBox="0 0 60 54" stroke="none" fill-rule="evenodd">
+            <path d="M24.703,17.77l-3.428,13.535c-1.602,6.387-3.164,11.016-4.688,13.887s-3.306,4.995-5.347,6.372   c-2.041,1.377-4.38,2.065-7.017,2.065c-1.66,0-2.881-0.318-3.662-0.952c-0.781-0.635-1.172-1.382-1.172-2.241   c0-0.801,0.322-1.494,0.967-2.08s1.494-0.879,2.549-0.879c0.879,0,1.553,0.225,2.021,0.674s0.703,1.016,0.703,1.699   c0,0.625-0.146,1.088-0.439,1.392c-0.293,0.303-0.439,0.503-0.439,0.601l0.146,0.205c0.117,0.098,0.254,0.146,0.41,0.146   c0.586,0,1.084-0.186,1.494-0.557c1.036-0.918,1.807-2.031,2.314-3.34c0.352-0.898,1.025-3.271,2.021-7.119l5.977-23.408h-4.072   l0.967-3.428c1.465,0.02,2.529-0.166,3.193-0.557c0.664-0.391,1.367-1.27,2.109-2.637c2.148-3.965,4.414-6.807,6.797-8.525   c2.383-1.718,5.039-2.578,7.969-2.578c1.875,0,3.237,0.362,4.087,1.084c0.85,0.723,1.274,1.66,1.274,2.813   c0,1.016-0.283,1.821-0.85,2.417c-0.566,0.596-1.27,0.894-2.109,0.894c-0.781,0-1.426-0.244-1.934-0.732   c-0.508-0.488-0.762-1.074-0.762-1.758c0-0.488,0.161-1.006,0.483-1.553c0.322-0.546,0.483-0.918,0.483-1.113   c0-0.215-0.073-0.391-0.22-0.527c-0.146-0.136-0.337-0.205-0.571-0.205c-1.152,0-2.334,0.713-3.545,2.139   c-1.992,2.285-3.594,5.899-4.805,10.84h4.248l-1.025,3.428H24.703z"/><path d="M31.705,15.279l10.225-1.758c1.855,2.911,3.164,6.113,3.926,9.609c1.914-2.832,3.359-4.814,4.336-5.947   c1.309-1.523,2.388-2.515,3.237-2.974c0.85-0.458,1.753-0.688,2.71-0.688c1.074,0,1.899,0.293,2.476,0.879   c0.575,0.586,0.864,1.377,0.864,2.373c0,0.938-0.289,1.704-0.864,2.3c-0.576,0.596-1.294,0.894-2.153,0.894   c-0.625,0-1.344-0.112-2.153-0.337c-0.811-0.224-1.372-0.337-1.685-0.337c-0.82,0-1.602,0.293-2.344,0.879   c-1.016,0.801-2.266,2.51-3.75,5.127c1.66,5.859,2.988,9.434,3.984,10.723c0.586,0.762,1.182,1.143,1.787,1.143   c0.508,0,0.947-0.127,1.318-0.381c0.566-0.41,1.436-1.436,2.607-3.076l1.055,0.615c-1.719,2.773-3.398,4.727-5.039,5.859   c-1.25,0.879-2.48,1.318-3.691,1.318c-1.25,0-2.29-0.278-3.12-0.835c-0.831-0.557-1.567-1.465-2.212-2.725s-1.406-3.276-2.285-6.05   c-2.285,2.91-4.077,5.035-5.376,6.372c-1.3,1.338-2.378,2.212-3.237,2.622S30.543,41.5,29.566,41.5   c-1.015,0-1.821-0.293-2.417-0.879c-0.596-0.586-0.894-1.348-0.894-2.285c0-0.996,0.322-1.816,0.967-2.461s1.465-0.967,2.461-0.967   c0.527,0,1.123,0.156,1.787,0.469c0.977,0.469,1.68,0.703,2.109,0.703c0.566,0,1.074-0.117,1.523-0.352   c0.586-0.293,1.328-0.928,2.227-1.904c0.547-0.605,1.553-1.895,3.018-3.867c-1.875-6.953-3.34-11.113-4.395-12.48   c-0.664-0.879-1.504-1.318-2.52-1.318c-0.527,0-1.172,0.078-1.934,0.234L31.705,15.279z"></path>
+          </symbol>
+
           <symbol id="find-and-replace-icon-regex" viewBox="0 0 20 16" stroke="none" fill-rule="evenodd">
             <rect x="3" y="10" width="3" height="3" rx="1"></rect>
             <rect x="12" y="3" width="2" height="9" rx="1"></rect>
@@ -214,6 +226,12 @@ class FindView {
         title: "Find All",
         keyBindingCommand: 'find-and-replace:find-all',
         keyBindingTarget: this.findEditor.element
+      }),
+
+      atom.tooltips.add(this.refs.functionOptionButton, {
+        title: "Use Function"
+        //keyBindingCommand: 'find-and-replace:use-function',
+        //keyBindingTarget: this.findEditor.element
       })
     );
   }
@@ -253,7 +271,8 @@ class FindView {
       'find-and-replace:toggle-regex-option': this.toggleRegexOption.bind(this),
       'find-and-replace:toggle-case-option': this.toggleCaseOption.bind(this),
       'find-and-replace:toggle-selection-option': this.toggleSelectionOption.bind(this),
-      'find-and-replace:toggle-whole-word-option': this.toggleWholeWordOption.bind(this)
+      'find-and-replace:toggle-whole-word-option': this.toggleWholeWordOption.bind(this),
+      'find-and-replace:toggle-function-option': this.toggleFunctionOption.bind(this)
     }));
 
     this.subscriptions.add(this.model.onDidUpdate(this.markersUpdated.bind(this)));
@@ -266,6 +285,8 @@ class FindView {
     this.refs.caseOptionButton.addEventListener('click', this.toggleCaseOption.bind(this));
     this.refs.selectionOptionButton.addEventListener('click', this.toggleSelectionOption.bind(this));
     this.refs.wholeWordOptionButton.addEventListener('click', this.toggleWholeWordOption.bind(this));
+
+    this.refs.functionOptionButton.addEventListener('click', this.toggleFunctionOption.bind(this));
 
     this.element.addEventListener('focus', () => this.findEditor.element.focus());
     this.element.addEventListener('click', (e) => {
@@ -663,6 +684,8 @@ class FindView {
     this.setOptionButtonState(this.refs.caseOptionButton, this.model.getFindOptions().caseSensitive);
     this.setOptionButtonState(this.refs.selectionOptionButton, this.model.getFindOptions().inCurrentSelection);
     this.setOptionButtonState(this.refs.wholeWordOptionButton, this.model.getFindOptions().wholeWord);
+
+    this.setOptionButtonState(this.refs.functionOptionButton, this.model.getFindOptions().useFunction);
   }
 
   setOptionButtonState(optionButton, selected) {
@@ -708,6 +731,10 @@ class FindView {
     if (!this.anyMarkersAreSelected()) {
       this.selectFirstMarkerAfterCursor();
     }
+  }
+
+  toggleFunctionOption() {
+    this.search({useFunction: !this.model.getFindOptions().useFunction});
   }
 
   updateReplaceEnablement() {

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -229,9 +229,9 @@ class FindView {
       }),
 
       atom.tooltips.add(this.refs.functionOptionButton, {
-        title: "Use Function"
-        //keyBindingCommand: 'find-and-replace:use-function',
-        //keyBindingTarget: this.findEditor.element
+        title: "Use Function",
+        keyBindingCommand: 'find-and-replace:toggle-function-option',
+        keyBindingTarget: this.findEditor.element
       })
     );
   }
@@ -429,8 +429,8 @@ class FindView {
         }
       }
 
-      const compiled = this.model.replace([currentMarker], this.replaceEditor.getText());
-      if(compiled){
+      const error = this.model.replace([currentMarker], this.replaceEditor.getText());
+      if(!error){
         this[nextOrPreviousFn]({fieldToFocus: this.replaceEditor});
       } else {
         atom.beep()

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -650,11 +650,17 @@ class FindView {
   }
 
   updateSyntaxHighlighting() {
-    if (this.model.getFindOptions().useRegex) {
+    const {useRegex, useFunction} = this.model.getFindOptions();
+    if (useRegex) {
       this.findEditor.setGrammar(atom.grammars.grammarForScopeName('source.js.regexp'));
-      this.replaceEditor.setGrammar(atom.grammars.grammarForScopeName('source.js.regexp.replacement'));
     } else {
       this.findEditor.setGrammar(atom.grammars.nullGrammar);
+    }
+    if (useFunction) {
+      this.replaceEditor.setGrammar(atom.grammars.grammarForScopeName('source.js'));
+    } else if (useRegex) {
+      this.replaceEditor.setGrammar(atom.grammars.grammarForScopeName('source.js.regexp.replacement'));
+    } else {
       this.replaceEditor.setGrammar(atom.grammars.nullGrammar);
     }
   }

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -433,7 +433,7 @@ class FindView {
       if(!error){
         this[nextOrPreviousFn]({fieldToFocus: this.replaceEditor});
       } else {
-        atom.beep()
+        atom.beep();
       }
     } else {
       atom.beep();

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "etch": "0.9.3",
     "fs-plus": "^3.0.0",
     "temp": "^0.8.3",
-    "underscore-plus": "1.x"
+    "underscore-plus": "1.x",
+    "vm": "^0.1.0"
   },
   "devDependencies": {
     "coffeelint": "^1.9.7",

--- a/spec/buffer-search-spec.js
+++ b/spec/buffer-search-spec.js
@@ -485,7 +485,7 @@ describe("BufferSearch", () => {
 
   describe("replacing a search result with a replace function", () => {
     beforeEach(() => {
-      editor.scanInBufferRange.reset()
+      editor.scanInBufferRange.reset();
     });
 
     it("replaces the marked text with the correct function replacement", () => {
@@ -515,7 +515,7 @@ describe("BufferSearch", () => {
       expect(currentResultListener).toHaveBeenCalledWith(markers[1]);
       currentResultListener.reset();
 
-      model.replace([markers[1]], "(m,m1,m2,m3) => m1 + m2.toUpperCase() + m3");
+      model.replace([markers[1]], "(m, m1, m2, m3) => m1 + m2.toUpperCase() + m3");
 
       expect(editor.getText()).toBe(dedent`
         -----------

--- a/spec/buffer-search-spec.js
+++ b/spec/buffer-search-spec.js
@@ -483,6 +483,54 @@ describe("BufferSearch", () => {
     });
   });
 
+  describe("replacing a search result with a replace function", () => {
+    beforeEach(() => {
+      editor.scanInBufferRange.reset()
+    });
+
+    it("replaces the marked text with the correct function replacement", () => {
+      const findOptions = new FindOptions({findPattern: "([a-z])([a-z])([a-z])"});
+      model = new BufferSearch(findOptions);
+
+      markersListener = jasmine.createSpy('markersListener');
+      model.onDidUpdate(markersListener);
+
+      currentResultListener = jasmine.createSpy('currentResultListener');
+      model.onDidChangeCurrentResult(currentResultListener);
+
+      model.setEditor(editor);
+      markersListener.reset();
+
+      model.search("([a-z])([a-z])([a-z])", {
+        caseSensitive: false,
+        useRegex: true,
+        wholeWord: false,
+        useFunction: true
+      });
+
+      const markers = markersListener.mostRecentCall.args[0];
+      markersListener.reset();
+
+      editor.setSelectedBufferRange(markers[1].getBufferRange());
+      expect(currentResultListener).toHaveBeenCalledWith(markers[1]);
+      currentResultListener.reset();
+
+      model.replace([markers[1]], "(m,m1,m2,m3) => m1 + m2.toUpperCase() + m3");
+
+      expect(editor.getText()).toBe(dedent`
+        -----------
+        aaa bBb ccc
+        ddd aaa bbb
+        ccc ddd aaa
+        -----------
+        aaa bbb ccc
+        ddd aaa bbb
+        ccc ddd aaa
+        -----------
+      `);
+    });
+  });
+
   describe(".prototype.resultsMarkerLayerForTextEditor(editor)", () =>
     it("creates or retrieves the results marker layer for the given editor", () => {
       const layer1 = model.resultsMarkerLayerForTextEditor(editor);

--- a/spec/find-view-spec.js
+++ b/spec/find-view-spec.js
@@ -1767,6 +1767,25 @@ describe("FindView", () => {
         expect(findView.findEditor.getGrammar().scopeName).toBe("text.plain.null-grammar");
         expect(findView.replaceEditor.getGrammar().scopeName).toBe("text.plain.null-grammar");
       });
+
+      it("uses the basic javascript grammar for replaceEditor when in function mode", () => {
+        atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-function-option");
+        expect(findView.findEditor.getGrammar().scopeName).toBe("text.plain.null-grammar");
+        expect(findView.replaceEditor.getGrammar().scopeName).toBe("source.js");
+
+        atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-function-option");
+        expect(findView.findEditor.getGrammar().scopeName).toBe("text.plain.null-grammar");
+        expect(findView.replaceEditor.getGrammar().scopeName).toBe("text.plain.null-grammar");
+
+        atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-function-option");
+        atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-regex-option");
+        expect(findView.findEditor.getGrammar().scopeName).toBe("source.js.regexp");
+        expect(findView.replaceEditor.getGrammar().scopeName).toBe("source.js");
+
+        atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-function-option");
+        expect(findView.findEditor.getGrammar().scopeName).toBe("source.js.regexp");
+        expect(findView.replaceEditor.getGrammar().scopeName).toBe("source.js.regexp.replacement");
+      });
     });
   });
 

--- a/spec/find-view-spec.js
+++ b/spec/find-view-spec.js
@@ -1451,7 +1451,7 @@ describe("FindView", () => {
           expect(editor.getSelectedBufferRange()).toEqual([[0, 81], [0, 86]]);
         });
 
-        describe('when using function replace', ()=>{
+        describe('when using function replace', () => {
           beforeEach(() => {
             atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-function-option");
             findView.replaceEditor.setText("()=>'cats'");
@@ -1465,7 +1465,7 @@ describe("FindView", () => {
           });
 
           describe("when the replace function contains a mistake", () => {
-            afterEach(()=>{
+            afterEach(() => {
               expect(atom.beep).toHaveBeenCalled();
               expect(findView.refs.descriptionLabel).toHaveClass("text-error");
               // it didn't replace or change the selection

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -1,4 +1,4 @@
-@import "ui-variables";
+ @import "ui-variables";
 @import "syntax-variables";
 
 @find-and-replace-font: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
@@ -63,6 +63,9 @@ atom-workspace.find-visible {
   .input-block-item {
     display: flex;
     flex: 1;
+    padding: @component-padding / 2;
+  }
+  .input-block-btn {
     padding: @component-padding / 2;
   }
 
@@ -161,6 +164,14 @@ atom-workspace.find-visible {
   .btn-group-find-all,
   .btn-group-replace-all {
     flex: 2;
+  }
+
+  .btn-group-replace-function {
+    display: inline-flex;
+    .btn {
+      width: 36px;
+      padding: 0;
+    }
   }
 
   .find-container atom-text-editor {

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -1,4 +1,4 @@
- @import "ui-variables";
+@import "ui-variables";
 @import "syntax-variables";
 
 @find-and-replace-font: Menlo, Consolas, 'DejaVu Sans Mono', monospace;


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR exposes the ability to pass a function as the second argument to javascript's String.prototype.replace() function. This can be useful if you want to replace snake_case with camelCase, for instance with `text.replace(/_([a-z])/g, (m, m1)=>m1.toUpperCase())`. The design is such that one types a javascript function into the Replace text box. 

Careful code design was taken to catch all possible errors, without slowing down the current implementation, and also making it efficient in the new function mode. Careful error analysis catches errors on function compilation and function evaluation, alerting the user appropriately in the error box.

### Alternate Designs

1. For the overall feature design, javascript functions were chosen for scriptable replacements. Alternate feature designs were suggested in #417 such as using a regex-style replace object such as with \U and \L for uppercase and lowercase (as in Sublime), and maybe match syntax `\0` and `\1`. One reason we decided to stick with the original suggestion was that it is immediately supported in javascript, the language in which atom is currently implemented. Specifically, the replace method currently relies on Javascript's string.prototype.replace method. Another is that the function syntax allows more functionality with full freedom to write one's own replace function. The biggest drawback is that one needs to use Javascript, which may not be familiar to all. I would point out that regex replace syntax is not completely standardized and would also be often unfamiliar.

2. We added a button on the replace line to toggle function mode. One could consider adding this to the find options buttons, or otherwise.

3. String.prototype.replace always casts it's result as a string. We chose to override this by first checking that the result is actually a string to help avoid errors such as returning an undefined key, or variable. One can still manually cast to a string in the user-written replace function, as in the error handling demo below.

### Benefits

One can programmatically choose the replace text based on regex matches (or a single text match). Use cases include changing case and using simple logic to chose the replacement text.

### Possible Drawbacks

This makes for more UI (an extra button - see demos below). It also makes the buffer_search code more involved.

### Applicable Issues

This solves #417.