### PR TITLE
Wait for Etch component to render before consuming

### DIFF
--- a/lib/get-icon-services.js
+++ b/lib/get-icon-services.js
@@ -48,10 +48,10 @@ class IconServices {
   getIconClasses (view) {
     let iconClass = ''
     if (this.elementIcons) {
-      if (!view.iconDisposable) {
-        view.iconDisposable = new CompositeDisposable()
-      }
-      process.nextTick(() => {
+      this.waitToAttach(view).then(() => {
+        if (!view.iconDisposable) {
+          view.iconDisposable = new CompositeDisposable()
+        }
         view.iconDisposable.add(this.elementIcons(view.refs.icon, view.filePath))
       })
     } else {
@@ -61,5 +61,14 @@ class IconServices {
       }
     }
     return iconClass
+  }
+
+  async waitToAttach(view, delay = 10){
+    if (view.refs && view.refs.icon instanceof Element) {
+      return Promise.resolve()
+    } else {
+      await new Promise(done => setTimeout(done, delay))
+      return this.waitToAttach(view, delay)
+    }
   }
 }


### PR DESCRIPTION
Fixes atom/atom#16133. Notes copied from my commit:

The `process.nextTick` hack assumed that ALL Etch components would their child elements on the same thread. As it turns out, there can be a delay between constructing a VirtualDOM node and when it's attached to the DOM tree.

@nathansobo I wasn't sure how to go about adding tests for this, since it would involve a fixtures folder full of dozens of files and all with numerous matches... Would you be okay with that? I don't think the current tests are long enough to delay rendering until the user scrolls far enough.

/cc @alexdevero, @50Wliu