### PR TITLE
Ensure that word boundaries are matching start/end of query

### DIFF
--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -61,6 +61,6 @@ class FindOptions
     else
       expression = _.escapeRegExp(@findPattern)
 
-    expression = "\\b#{expression}\\b" if @wholeWord
+    expression = "\\b(?:#{expression})\\b" if @wholeWord
 
     new RegExp(expression, flags)

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -666,7 +666,7 @@ describe('ProjectFindView', () => {
 
         await searchPromise;
         expect(projectFindView.refs.wholeWordOptionButton).toHaveClass('selected');
-        expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/\bwholeword\b/gim);
+        expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/\b(?:wholeword)\b/gim);
       });
 
       it("toggles whole word option via a button and finds files matching the pattern", async () => {
@@ -676,7 +676,7 @@ describe('ProjectFindView', () => {
         await searchPromise;
 
         expect(projectFindView.refs.wholeWordOptionButton).toHaveClass('selected');
-        expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/\bwholeword\b/gim);
+        expect(atom.workspace.scan.mostRecentCall.args[0]).toEqual(/\b(?:wholeword)\b/gim);
       });
     });
 


### PR DESCRIPTION
### Description of the Change

When the original expression is not grouped and a regex-query is used,
the boundaries might not be matched. For example:

    this|is|a|test

was matching all letters "a", not just the word "a" - even if "whole
word" is enabled.

![screenshot from 2017-11-18 18-51-32](https://user-images.githubusercontent.com/719105/32984883-5c9d37fa-ccaf-11e7-80c6-13cd1e42b9e5.png)
![screenshot from 2017-11-18 18-52-00](https://user-images.githubusercontent.com/719105/32984885-5f528edc-ccaf-11e7-957a-f7f0c142567d.png)

