### PR TITLE
 Re-search when selection changes and "Only in selection" is set

### DIFF
--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -77,7 +77,7 @@ class BufferSearch {
         changedParams.wholeWord != null ||
         changedParams.caseSensitive != null ||
         changedParams.inCurrentSelection != null ||
-        (this.findOptions.inCurrentSelection === true && this.editor.getSelectedBufferRange() !== this.selectedRange)) {
+        (this.findOptions.inCurrentSelection === true && !this.editor.getSelectedBufferRange().isEqual(this.selectedRange))) {
         this.recreateMarkers();
     }
   }

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -12,17 +12,6 @@ class BufferSearch {
     this.subscriptions = null;
     this.markers = [];
     this.editor = null;
-
-    this.findOptions.onDidChange(changedParams => {
-      if (changedParams && (
-        changedParams.findPattern != null ||
-        changedParams.useRegex != null ||
-        changedParams.wholeWord != null ||
-        changedParams.caseSensitive != null ||
-        changedParams.inCurrentSelection != null)) {
-        this.recreateMarkers();
-      }
-    });
   }
 
   onDidUpdate(callback) {
@@ -80,12 +69,17 @@ class BufferSearch {
 
   search(findPattern, otherOptions) {
     let options = {findPattern};
-    if (otherOptions != null) {
-      for (let key in otherOptions) {
-        options[key] = otherOptions[key];
-      }
+    Object.assign(options, otherOptions);
+
+    const changedParams = this.findOptions.set(options);
+    if (changedParams.findPattern != null ||
+        changedParams.useRegex != null ||
+        changedParams.wholeWord != null ||
+        changedParams.caseSensitive != null ||
+        changedParams.inCurrentSelection != null ||
+        (this.findOptions.inCurrentSelection === true && this.editor.getSelectedBufferRange() !== this.selectedRange)) {
+        this.recreateMarkers();
     }
-    this.findOptions.set(options);
   }
 
   replace(markers, replacePattern) {
@@ -141,10 +135,10 @@ class BufferSearch {
   createMarkers(start, end) {
     let newMarkers = [];
     if (this.findOptions.findPattern && this.editor) {
-      const selectedRange = this.editor.getSelectedBufferRange()
-      if (this.findOptions.inCurrentSelection && !selectedRange.isEmpty()) {
-        start = Point.max(start, selectedRange.start);
-        end = Point.min(end, selectedRange.end);
+      this.selectedRange = this.editor.getSelectedBufferRange()
+      if (this.findOptions.inCurrentSelection && !this.selectedRange.isEmpty()) {
+        start = Point.max(start, this.selectedRange.start);
+        end = Point.min(end, this.selectedRange.end);
       }
 
       const regex = this.getFindPatternRegex()

--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -41,16 +41,17 @@ class FindOptions
     result
 
   set: (newParams={}) ->
-    changedParams = null
+    changedParams = {}
     for key in Params
       if newParams[key]? and newParams[key] isnt this[key]
         changedParams ?= {}
         this[key] = changedParams[key] = newParams[key]
 
-    if changedParams?
+    if Object.keys(changedParams).length
       for param, val of changedParams
         @emitter.emit("did-change-#{param}")
       @emitter.emit('did-change', changedParams)
+    return changedParams
 
   getFindPatternRegex: ->
     flags = 'gm'

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -352,7 +352,7 @@ class FindView {
       findPattern = null;
     }
     if (findPattern == null) { findPattern = this.findEditor.getText(); }
-    return this.model.search(findPattern, options);
+    this.model.search(findPattern, options);
   }
 
   findAll(options = {focusEditorAfter: true}) {

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -119,7 +119,7 @@ module.exports =
 
   consumeElementIcons: (service) ->
     getIconServices().setElementIcons service
-    new Disposable =>
+    new Disposable ->
       getIconServices().resetElementIcons()
 
   consumeFileIcons: (service) ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Previously, we were only researching when the find options or the find text changed.  This meant that when "Only in selection" was enabled and the selection was changed, the aforementioned prerequisites were not met and so cached results were returned rather than searching in the new selection.

To make "Only in selection" searching work correctly, `findOptions.set` now returns the changed params so that `BufferSearch` doesn't have to rely on an `onDidChange` callback.  We can then immediately determine whether or not to execute another search.

### Alternate Designs

None.

### Benefits

In addition to the fix mentioned above, this also improves the code flow.  Before, it was non-obvious why calling `BufferSearch.search` would only call `findOptions.set`, seemingly without doing any searching (since it was done in an emitter subscription callback).  Now `search` directly checks the return result of `findOptions.set` to determine whether or not to perform another search.

### Possible Drawbacks

I don't see any.  I believe that it is safe to remove the `onDidChange` hook from `BufferSearch` due to `FindView` explicitly calling `search` whenever any of the params change.

### Applicable Issues

Fixes #677