### PR TITLE
Honor reversed orientation of previous selections when "selecting next"

### DIFF
--- a/lib/select-next.coffee
+++ b/lib/select-next.coffee
@@ -79,7 +79,8 @@ class SelectNext
     foundRange
 
   addSelection: (range) ->
-    selection = @editor.addSelectionForBufferRange(range)
+    reversed = @editor.getLastSelection().isReversed()
+    selection = @editor.addSelectionForBufferRange(range, {reversed})
     @updateSavedSelections selection
 
   scanForNextOccurrence: (range, callback) ->

--- a/spec/select-next-spec.js
+++ b/spec/select-next-spec.js
@@ -225,6 +225,29 @@ describe("SelectNext", () => {
         ]);
       });
     });
+
+    it('honors the reversed orientation of previous selections', () => {
+      editor.setText('ab ab ab ab')
+      editor.setSelectedBufferRange([[0, 0], [0, 2]], {reversed: true})
+
+      atom.commands.dispatch(editorElement, 'find-and-replace:select-next')
+      expect(editor.getSelections().length).toBe(2)
+      expect(editor.getSelections().every(s => s.isReversed())).toBe(true)
+
+      atom.commands.dispatch(editorElement, 'find-and-replace:select-next')
+      expect(editor.getSelections().length).toBe(3)
+      expect(editor.getSelections().every(s => s.isReversed())).toBe(true)
+
+      editor.setSelectedBufferRange([[0, 0], [0, 2]], {reversed: false})
+
+      atom.commands.dispatch(editorElement, 'find-and-replace:select-next')
+      expect(editor.getSelections().length).toBe(2)
+      expect(editor.getSelections().every(s => !s.isReversed())).toBe(true)
+
+      atom.commands.dispatch(editorElement, 'find-and-replace:select-next')
+      expect(editor.getSelections().length).toBe(3)
+      expect(editor.getSelections().every(s => !s.isReversed())).toBe(true)
+    })
   });
 
   describe("find-and-replace:select-all", () => {
@@ -323,6 +346,21 @@ describe("SelectNext", () => {
         ]);
       });
     });
+
+    it('honors the reversed orientation of previous selections', () => {
+      editor.setText('ab ab ab ab')
+      editor.setSelectedBufferRange([[0, 0], [0, 2]], {reversed: true})
+
+      atom.commands.dispatch(editorElement, 'find-and-replace:select-all')
+      expect(editor.getSelections().length).toBe(4)
+      expect(editor.getSelections().every(s => s.isReversed())).toBe(true)
+
+      editor.setSelectedBufferRange([[0, 0], [0, 2]], {reversed: false})
+
+      atom.commands.dispatch(editorElement, 'find-and-replace:select-all')
+      expect(editor.getSelections().length).toBe(4)
+      expect(editor.getSelections().every(s => !s.isReversed())).toBe(true)
+    })
   });
 
   describe("find-and-replace:select-undo", () => {
@@ -570,5 +608,30 @@ describe("SelectNext", () => {
         ]);
       });
     });
+
+    it('honors the reversed orientation of previous selections', () => {
+      editor.setText('ab ab ab ab')
+      editor.setSelectedBufferRange([[0, 0], [0, 2]], {reversed: true})
+
+      atom.commands.dispatch(editorElement, 'find-and-replace:select-skip')
+      expect(editor.getSelections().length).toBe(1)
+      expect(editor.getSelections().every(s => s.isReversed())).toBe(true)
+
+      atom.commands.dispatch(editorElement, 'find-and-replace:select-next')
+      atom.commands.dispatch(editorElement, 'find-and-replace:select-skip')
+      expect(editor.getSelections().length).toBe(2)
+      expect(editor.getSelections().every(s => s.isReversed())).toBe(true)
+
+      editor.setSelectedBufferRange([[0, 0], [0, 2]], {reversed: false})
+
+      atom.commands.dispatch(editorElement, 'find-and-replace:select-skip')
+      expect(editor.getSelections().length).toBe(1)
+      expect(editor.getSelections().every(s => !s.isReversed())).toBe(true)
+
+      atom.commands.dispatch(editorElement, 'find-and-replace:select-next')
+      atom.commands.dispatch(editorElement, 'find-and-replace:select-skip')
+      expect(editor.getSelections().length).toBe(2)
+      expect(editor.getSelections().every(s => !s.isReversed())).toBe(true)
+    })
   });
 });


### PR DESCRIPTION
### Description of the Change

With this pull request, the find and replace package will start honoring the reversed orientation of previous selections when the user dispatches the following commands:

* `find-and-replace:select-next`
* `find-and-replace:select-all`
* `find-and-replace:select-skip`

### Alternate Designs

None.

### Benefits

Selections will look consistent when created using the commands above.

### Possible Drawbacks

Unclear.

### Applicable Issues

Fixes #928
