### PR TITLE
Fix last result not clickable

### DIFF
--- a/lib/project/list-view.js
+++ b/lib/project/list-view.js
@@ -84,6 +84,7 @@ module.exports = class ListView {
 
     return $.div(
       {
+        className: 'results-view-container',
         style: {
           position: 'relative',
           height: '100%',

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -275,6 +275,13 @@ atom-workspace.find-visible {
     position: relative;
     flex: 1;
 
+    &-container {
+      // adds some padding
+      // so the last item can be clicked 
+      // when there is a horizontal scrollbar -> #943
+      padding-bottom: @component-padding;
+    }
+
     .list-tree .path {
       padding: 0 0 0 @component-padding;
     }

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -241,6 +241,7 @@ atom-workspace.find-visible {
   position: relative;
   display: flex;
   flex-direction: column;
+  padding: 0;
 
   .preview-header {
     display: flex;
@@ -274,8 +275,8 @@ atom-workspace.find-visible {
     position: relative;
     flex: 1;
 
-    .list-tree {
-      padding: 0 @component-padding;
+    .list-tree .path {
+      padding: 0 0 0 @component-padding;
     }
 
     .line-number {


### PR DESCRIPTION
### Description of the Change

This PR makes sure there is no horizontal scrollbar so that the last result can be clicked.

The problem is that these `<div>`s have `width: 100%`.

![image](https://user-images.githubusercontent.com/378023/35040087-40dca2b0-fbc3-11e7-90f3-241a268b0f8a.png)

And the parent `list-tree` has some padding. But the `width: 100%` of the children doesn't take the padding into account and so they extend to much, causing the horizontal scrollbar to appear.

**Fix 1**: Move the padding from the parent `list-tree` into the children. Now the `width: 100%` matches the parent's width.

![find](https://user-images.githubusercontent.com/378023/35040334-0bb1ba48-fbc4-11e7-8715-96b3c41e2121.gif)

**Fix 2**: Adds some bottom padding so there is always some space reserved for the horizontal scrollbar. I think it still looks ok.

![find](https://user-images.githubusercontent.com/378023/35077361-3eb49420-fc40-11e7-8f18-dd77ff276b3e.gif)

### Alternate Designs

We could also make these `<div>`s not take up `100%` width, but stretch them with `left: 0 right: 0`.

### Benefits

Last result is clickable.

### Possible Drawbacks

None

### Applicable Issues

Closes #943
