### PR TITLE
Optimize buffer search using findAndMarkAllInRangeSync

### DIFF
--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -144,9 +144,24 @@ class BufferSearch {
       const regex = this.getFindPatternRegex()
       if (regex) {
         try {
-          this.editor.scanInBufferRange(regex, Range(start, end), ({range}) => {
-            newMarkers.push(this.createMarker(range));
-          });
+          const buffer = this.editor.getBuffer()
+
+          // TODO - remove this conditional after Atom 1.25 ships
+          if (buffer.findAndMarkAllInRangeSync) {
+            newMarkers = this.editor.getBuffer().findAndMarkAllInRangeSync(
+              this.resultsMarkerLayer.bufferMarkerLayer,
+              regex,
+              Range(start, end),
+              {invalidate: 'inside'}
+            );
+            for (let i = 0, n = newMarkers.length; i < n; i++) {
+              newMarkers[i] = this.resultsMarkerLayer.getMarker(newMarkers[i].id)
+            }
+          } else {
+            buffer.scanInRange(regex, Range(start, end), ({range}) => {
+              newMarkers.push(this.createMarker(range));
+            });
+          }
         } catch (error) {
           // TODO - remove after Atom 1.25 ships.
           if (/RegExp too big$/.test(error.message)) {


### PR DESCRIPTION
Refs https://github.com/atom/text-buffer/pull/289
Refs https://github.com/atom/superstring/pull/50

This was just a quick win I wanted to do after I had to reimplement `TextBuffer.scanInRange` in order to fix https://github.com/atom/atom/issues/15325.

We should still restructure this code at some point (maybe adding an async variant of `findAndMarkAllInRange`), but this small code change already makes a pretty big difference. Searching the letter 'e' in a big file like jquery used to take about **285ms** on my machine, and now it takes about **65ms**. A big part of this cost is now instantiating `Marker` objects. Finding and marking the ranges takes about 39ms.

/cc @nathansobo

