### PR TITLE
Responsive results header

### DIFF
--- a/lib/project/results-pane.js
+++ b/lib/project/results-pane.js
@@ -93,7 +93,7 @@ class ResultsPaneView {
             {
               ref: 'previewControls',
               className: 'preview-controls',
-              style: {visibility: matchCount > 0 ? 'visible' : 'hidden'}
+              style: {display: matchCount > 0 ? '' : 'none'}
             },
 
             this.searchContextLineCountBefore > 0 ?

--- a/lib/project/results-pane.js
+++ b/lib/project/results-pane.js
@@ -96,63 +96,61 @@ class ResultsPaneView {
               style: {visibility: matchCount > 0 ? 'visible' : 'hidden'}
             },
 
-            $.div({className: 'btn-toolbar'},
-              this.searchContextLineCountBefore > 0 ?
-                $.div({className: 'btn-group'},
-                  $.button(
-                    {
-                      ref: 'decrementLeadingContextLines',
-                      className: 'btn' + (this.model.getFindOptions().leadingContextLineCount === 0 ? ' disabled' : '')
-                    }, '-'),
-                  $.button(
-                    {
-                      ref: 'toggleLeadingContextLines',
-                      className: 'btn'
-                    },
-                    $.svg(
-                      {
-                        className: 'icon',
-                        innerHTML: '<use xlink:href="#find-and-replace-context-lines-before" />'
-                      }
-                    )
-                  ),
-                  $.button(
-                    {
-                      ref: 'incrementLeadingContextLines',
-                      className: 'btn' + (this.model.getFindOptions().leadingContextLineCount >= this.searchContextLineCountBefore ? ' disabled' : '')
-                    }, '+')
-                ) : null,
-
-              this.searchContextLineCountAfter > 0 ?
-                $.div({className: 'btn-group'},
-                  $.button(
-                    {
-                      ref: 'decrementTrailingContextLines',
-                      className: 'btn' + (this.model.getFindOptions().trailingContextLineCount === 0 ? ' disabled' : '')
-                    }, '-'),
-                  $.button(
-                    {
-                      ref: 'toggleTrailingContextLines',
-                      className: 'btn'
-                    },
-                    $.svg(
-                      {
-                        className: 'icon',
-                        innerHTML: '<use xlink:href="#find-and-replace-context-lines-after" />'
-                      }
-                    )
-                  ),
-                  $.button(
-                    {
-                      ref: 'incrementTrailingContextLines',
-                      className: 'btn' + (this.model.getFindOptions().trailingContextLineCount >= this.searchContextLineCountAfter ? ' disabled' : '')
-                    }, '+')
-                ) : null,
-
+            this.searchContextLineCountBefore > 0 ?
               $.div({className: 'btn-group'},
-                $.button({ref: 'collapseAll', className: 'btn'}, 'Collapse All'),
-                $.button({ref: 'expandAll', className: 'btn'}, 'Expand All')
-              )
+                $.button(
+                  {
+                    ref: 'decrementLeadingContextLines',
+                    className: 'btn' + (this.model.getFindOptions().leadingContextLineCount === 0 ? ' disabled' : '')
+                  }, '-'),
+                $.button(
+                  {
+                    ref: 'toggleLeadingContextLines',
+                    className: 'btn'
+                  },
+                  $.svg(
+                    {
+                      className: 'icon',
+                      innerHTML: '<use xlink:href="#find-and-replace-context-lines-before" />'
+                    }
+                  )
+                ),
+                $.button(
+                  {
+                    ref: 'incrementLeadingContextLines',
+                    className: 'btn' + (this.model.getFindOptions().leadingContextLineCount >= this.searchContextLineCountBefore ? ' disabled' : '')
+                  }, '+')
+              ) : null,
+
+            this.searchContextLineCountAfter > 0 ?
+              $.div({className: 'btn-group'},
+                $.button(
+                  {
+                    ref: 'decrementTrailingContextLines',
+                    className: 'btn' + (this.model.getFindOptions().trailingContextLineCount === 0 ? ' disabled' : '')
+                  }, '-'),
+                $.button(
+                  {
+                    ref: 'toggleTrailingContextLines',
+                    className: 'btn'
+                  },
+                  $.svg(
+                    {
+                      className: 'icon',
+                      innerHTML: '<use xlink:href="#find-and-replace-context-lines-after" />'
+                    }
+                  )
+                ),
+                $.button(
+                  {
+                    ref: 'incrementTrailingContextLines',
+                    className: 'btn' + (this.model.getFindOptions().trailingContextLineCount >= this.searchContextLineCountAfter ? ' disabled' : '')
+                  }, '+')
+              ) : null,
+
+            $.div({className: 'btn-group'},
+              $.button({ref: 'collapseAll', className: 'btn'}, 'Collapse All'),
+              $.button({ref: 'expandAll', className: 'btn'}, 'Expand All')
             )
           ),
 

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -590,7 +590,7 @@ describe('ResultsView', () => {
       projectFindView.findEditor.setText('thiswillnotmatchanythingintheproject');
       atom.commands.dispatch(projectFindView.element, 'core:confirm');
       await searchPromise;
-      expect(getResultsPane().refs.previewControls.style.visibility).toBe('hidden');
+      expect(getResultsPane().refs.previewControls.style.display).toBe('none');
     });
   });
 

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -245,16 +245,26 @@ atom-workspace.find-visible {
 
   .preview-header {
     display: flex;
-    padding: @component-padding/2 @component-padding/2 @component-padding/2 @component-padding;
+    flex-wrap: wrap;
+    padding: @component-padding/2;
     align-items: center;
     justify-content: space-between;
+    overflow: hidden;
     font-weight: normal;
     border-bottom: 1px solid @panel-heading-border-color;
     background-color: @panel-heading-background-color;
   }
 
+  .preview-count {
+    margin: @component-padding/2;
+  }
+
   .preview-controls {
-    flex-shrink: 0;
+    display: flex;
+    flex-wrap: wrap;
+    .btn-group {
+      margin: @component-padding/2;
+    }
   }
 
   .loading-spinner-tiny,

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -296,6 +296,15 @@ atom-workspace.find-visible {
       padding: 0 0 0 @component-padding;
     }
 
+    // decrease intentation
+    .search-result.search-result.search-result {
+      padding-left: 0;
+      margin-left: @component-padding;
+    }
+    .search-result > .list-tree > .list-item {
+      margin-left: 8px;
+    }
+
     .line-number {
       margin-right: 1ex;
       text-align: right;


### PR DESCRIPTION
### Description of the Change

- [x] This PR makes the results header responsive, so it can be used in more narrow panes or even as a dock item.
- [x] Reduces the indentation of the code in search results.

![find](https://user-images.githubusercontent.com/378023/35137002-4cf68c4c-fd2a-11e7-8967-871086859e45.gif)


### Alternate Designs

Personally I'd like the "Collapse All" and "Expand All" just be a single toggle button. And also only have a single show/hide more lines number stepper that changes above and below.

### Benefits

Allows the search results be in a narrow place.

### Possible Drawbacks

None.

### Applicable Issues

This is a follow up to #992.
