### PR TITLE
Keep collapsed items in sync with search results

### DIFF
--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -193,6 +193,11 @@ class ResultsView {
         this.selectedMatchIndex = selectedResult.matches.length - 1;
       }
     }
+
+    // Update the collapsedResultIndices to keep collapsed items in sync when a new result is added
+    if (filePathInsertedIndex != null) {
+      this.collapsedResultIndices.splice(filePathInsertedIndex, 0, false);
+    }
     etch.update(this);
   }
 
@@ -210,6 +215,9 @@ class ResultsView {
       }
       this.selectedMatchIndex = -1;
     }
+
+    // Update the collapsedResultIndices to keep collapsed items in sync when a result is removed
+    this.collapsedResultIndices.splice(filePathRemovedIndex, 1);
     etch.update(this);
   }
 

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -363,6 +363,50 @@ describe('ResultsView', () => {
 
       expect(resultsView.element.querySelector('.collapsed')).toBe(null);
     })
+
+    it('preserves the collapsed state of the right files when results are removed', async () => {
+      projectFindView.findEditor.setText('push');
+      atom.commands.dispatch(projectFindView.element, 'core:confirm');
+      await searchPromise;
+      resultsView = getResultsView();
+
+      // collapse the first result
+      resultsView.selectFirstResult();
+      resultsView.collapseResult();
+
+      // remove the first result
+      const firstPath = resultsView.model.getPaths()[0];
+      const firstResult = resultsView.model.getResult(firstPath);
+      resultsView.model.removeResult(firstPath);
+
+      // Check that the first result is not collapsed
+      const matchedPaths = resultsView.refs.listView.element.querySelectorAll('.path.list-nested-item');
+      expect(matchedPaths[0]).not.toHaveClass('collapsed')
+    });
+
+    it('preserves the collapsed state of the right files when results are added', async () => {
+      projectFindView.findEditor.setText('push');
+      atom.commands.dispatch(projectFindView.element, 'core:confirm');
+      await searchPromise;
+      resultsView = getResultsView();
+
+      // remove the first result
+      const firstPath = resultsView.model.getPaths()[0];
+      const firstResult = resultsView.model.getResult(firstPath);
+      resultsView.model.removeResult(firstPath);
+
+      // collapse the new first result
+      resultsView.selectFirstResult();
+      resultsView.collapseResult();
+
+      // re-add the old first result
+      resultsView.model.addResult(firstPath, firstResult);
+
+      // Check that the first result is not collapsed while the second one still is
+      const matchedPaths = resultsView.refs.listView.element.querySelectorAll('.path.list-nested-item');
+      expect(matchedPaths[0]).not.toHaveClass('collapsed')
+      expect(matchedPaths[1]).toHaveClass('collapsed')
+    });
   });
 
   describe("opening results", () => {


### PR DESCRIPTION
### Description of the Change

When searching across projects, if some items are collapsed in the search results view and new results are added, the collapsed items do not stay in sync with the results. Instead, collapsed items are "sliding" up and down as results are added/removed. This is due to the collapsed state being represented by an array of booleans that does not get updated when search results change. This commit introduces a fix to that issue by making sure that we update the aforementioned array as needed.

### Alternate Designs

An alternative to this design would have been to store the collapsed state directly on the element representing a "matched file" but it would entail a pretty big refactoring of the code which I don't feel I am familiar enough to start modifying in such length.

### Benefits

Whenever search results are updated, if some results were collapsed, these results will stay collapsed as expected. Previously, this "collapsed state" would be transferred to the search result above/below a collapsed item depending of the index where a search result would get inserted/removed.

### Possible Drawbacks

This might introduce some performance issues on very big sets of results as the array representing the collapsed items gets updated every time search results get updated.

### Applicable Issues

#916