### PR TITLE
Explicitly wait for a non-pending item

### DIFF
--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -377,11 +377,13 @@ describe('ResultsView', () => {
       resultsView.selectFirstResult();
     });
 
-    function paneItemOpening() {
+    function paneItemOpening(pending = null) {
       return new Promise(resolve => {
-        const subscription = atom.workspace.onDidOpen(() => {
-          resolve()
-          subscription.dispose()
+        const subscription = atom.workspace.onDidOpen(({pane, item}) => {
+          if (pending === null || (pane.getPendingItem() === item) === pending) {
+            resolve()
+            subscription.dispose()
+          }
         })
       })
     }
@@ -412,7 +414,7 @@ describe('ResultsView', () => {
       // Otherwise, the double click will transfer focus back to the results view
       expect(click2.defaultPrevented).toBe(true);
 
-      await paneItemOpening()
+      await paneItemOpening(false)
       const editor = atom.workspace.getCenter().getActiveTextEditor();
       expect(atom.workspace.getCenter().getActivePane().getPendingItem()).toBe(null);
       expect(atom.views.getView(editor)).toHaveFocus();

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -742,7 +742,7 @@ describe('ResultsView', () => {
           })
         }
         let disposable
-        
+
         waitsForPromise(() => {
           disposable = atom.packages.serviceHub.provide('file-icons.element-icons', '1.0.0', provider)
           expect(getIconServices().elementIcons).toBe(provider)


### PR DESCRIPTION
The work in atom/atom#17021 causes this spec to fail:

```
ResultsView
  opening results
    it opens the file containing the result in a non-pending state when the search result is double-clicked
      Expected <TextEditor 1552> to be null.
        Error: Expected <TextEditor 1552> to be null.
        at /Users/distiller/atom/node_modules/find-and-replace/spec/results-view-spec.js:417:75
        at Generator.next (<anonymous>)
        at step (/Users/distiller/atom/node_modules/find-and-replace/spec/results-view-spec.js:1:428)
        at <anonymous>
```

This is because `await paneItemOpening()` now resolves after the single-click's `Workspace.open()` call resolves, but before the double-click's does to activate the item as non-pending. By explicitly waiting for a non-pending item to appear before resolving the helper we can make this more reliable.