### PR TITLE
Don't modify selection when toggling "only in selection"

### DIFF
--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -267,7 +267,8 @@ class BufferSearch {
   findMarker(range) {
     if (this.resultsMarkerLayer) {
       return this.resultsMarkerLayer.findMarkers({
-        containedInBufferRange: range,
+        startBufferPosition: range.start,
+        endBufferPosition: range.end
       })[0];
     }
   }

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -267,8 +267,7 @@ class BufferSearch {
   findMarker(range) {
     if (this.resultsMarkerLayer) {
       return this.resultsMarkerLayer.findMarkers({
-        startPosition: range.start,
-        endPosition: range.end
+        containedInBufferRange: range,
       })[0];
     }
   }

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -698,7 +698,7 @@ class FindView {
 
   toggleSelectionOption() {
     this.search({inCurrentSelection: !this.model.getFindOptions().inCurrentSelection});
-    if (!this.anyMarkersAreSelected()) {
+    if (this.model.getEditor().getSelectedBufferRanges().every(range => range.isEmpty())) {
       this.selectFirstMarkerAfterCursor();
     }
   }

--- a/spec/find-view-spec.js
+++ b/spec/find-view-spec.js
@@ -970,7 +970,7 @@ describe("FindView", () => {
           editor.setSelectedBufferRange([[0, 0], [0, 0]]);
         });
 
-        it("toggles find within a selction via and event and only finds matches within the selection", () => {
+        it("toggles find within a selection via an event", () => {
           findView.findEditor.setText("items");
           atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-selection-option");
           expect(editor.getSelectedBufferRange()).toEqual([[1, 22], [1, 27]]);

--- a/spec/find-view-spec.js
+++ b/spec/find-view-spec.js
@@ -951,18 +951,18 @@ describe("FindView", () => {
         editor.setSelectedBufferRange([[2, 0], [4, 0]]);
       });
 
-      it("toggles find within a selction via and event and only finds matches within the selection", () => {
+      it("toggles find within a selection via an event and only finds matches within the selection", () => {
         findView.findEditor.setText("items");
         atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-selection-option");
-        expect(editor.getSelectedBufferRange()).toEqual([[2, 8], [2, 13]]);
-        expect(findView.refs.resultCounter.textContent).toEqual("1 of 3");
+        expect(editor.getSelectedBufferRange()).toEqual([[2, 0], [4, 0]]);
+        expect(findView.refs.resultCounter.textContent).toEqual("3 found");
       });
 
-      it("toggles find within a selction via and button and only finds matches within the selection", () => {
+      it("toggles find within a selection via button and only finds matches within the selection", () => {
         findView.findEditor.setText("items");
         findView.refs.selectionOptionButton.click();
-        expect(editor.getSelectedBufferRange()).toEqual([[2, 8], [2, 13]]);
-        expect(findView.refs.resultCounter.textContent).toEqual("1 of 3");
+        expect(editor.getSelectedBufferRange()).toEqual([[2, 0], [4, 0]]);
+        expect(findView.refs.resultCounter.textContent).toEqual("3 found");
       });
 
       describe("when there is no selection", () => {


### PR DESCRIPTION
When toggling "only in selection," only select the first marker after the cursor if there was no actual selection. Otherwise, when `this.search()` is called immediately before a replaceAll operation, the selection was replaced by the first marker and only the first marker is actually replaced.

Fixes #1005.