### PR TITLE
Check if an active editor exists when toggling "Only in Selection"

### DIFF
--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -698,7 +698,9 @@ class FindView {
 
   toggleSelectionOption() {
     this.search({inCurrentSelection: !this.model.getFindOptions().inCurrentSelection});
-    if (this.model.getEditor().getSelectedBufferRanges().every(range => range.isEmpty())) {
+
+    let editor = this.model.getEditor();
+    if (editor && editor.getSelectedBufferRanges().every(range => range.isEmpty())) {
       this.selectFirstMarkerAfterCursor();
     }
   }


### PR DESCRIPTION
### Description of the Change

This resolves the null reference error reported in #1012 by simply checking if an active editor exists in the workspace. The bug was introduced in #1007, specifically [this change](https://github.com/atom/find-and-replace/pull/1007/files#diff-031d2cf6de79608fdbf0fde30f0fc2f8R701).

Note that I haven't found a simple way of implementing a regression test for this. I tried spying on `atom.onDidThrowError`, the notification system, etc. They work OK-ish when the test fails prior to applying this PR since I was using `waitsFor`. Although, that means once the fix has been applied, the `waitsFor` block in the regression test waits until timeout, which seems a bit unfortunate. Any proposals for writing a good regression test is very much appreciated.

### Alternate Designs

No other alternatives were considered.

### Benefits

Fixes an uncaught exception thrown by core functionality.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #1012 