### PR TITLE
Add keymaps for home and end to project search

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -75,3 +75,9 @@
   'ctrl-enter': 'find-and-replace:replace-all'
 '.platform-linux .project-find .replace-container atom-text-editor':
   'ctrl-enter': 'project-find:replace-all'
+
+'.results-view':
+  'home': 'core:move-to-top'
+  'ctrl-home': 'core:move-to-top'
+  'end': 'core:move-to-bottom'
+  'ctrl-end': 'core:move-to-bottom'


### PR DESCRIPTION
### Description of the Change

Adds keymaps when pressing "home" and "end" in project search, that trigger `ResultsView.moveToTop` and `ResultsView.moveToBottom` respectively.

The code for these methods already existed, but it wasn't linked to any keymaps, and the only way to trigger them was to e.g. write "Core: Move To Top" in the command panel.

### Benefits

Being able to quickly select the first/last result in project search using the keyboard.

### Alternate Designs, Possible Drawbacks, Applicable Issues

No alternate design, no likely drawback, I don't think any issue was made on the subject.