### PR TITLE
Avoid prefixing dashes with backslashes in non-regex searches

### DIFF
--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -66,8 +66,15 @@ class FindOptions
     if @useRegex
       expression = @findPattern
     else
-      expression = _.escapeRegExp(@findPattern)
+      expression = escapeRegExp(@findPattern)
 
     expression = "\\b#{expression}\\b" if @wholeWord
 
     new RegExp(expression, flags)
+
+# This is different from _.escapeRegExp, which escapes dashes. Escaped dashes
+# are not allowed outside of character classes in RegExps with the `u` flag.
+#
+# See atom/find-and-replace#1022
+escapeRegExp = (string) ->
+  string.replace(/[\/\\^$*+?.()|[\]{}]/g, '\\$&')

--- a/spec/find-view-spec.js
+++ b/spec/find-view-spec.js
@@ -725,6 +725,14 @@ describe("FindView", () => {
       expect(findView.wrapIcon).not.toBeVisible();
     });
 
+    it("allows searching for dashes in combination with non-ascii characters (regression)", () => {
+      editor.setText("123-Âbc");
+      findView.findEditor.setText("3-â");
+      atom.commands.dispatch(findView.findEditor.element, "find-and-replace:find-next");
+      expect(findView.refs.descriptionLabel).not.toHaveClass("text-error");
+      expect(editor.getSelectedBufferRange()).toEqual([[0, 2], [0, 5]]);
+    });
+
     describe("when find-and-replace:use-selection-as-find-pattern is triggered", () => {
       it("places the selected text into the find editor", () => {
         editor.setSelectedBufferRange([[1, 6], [1, 10]]);


### PR DESCRIPTION
Fixes https://github.com/atom/find-and-replace/issues/1022 (this time without breaking everything else).