### PR TITLE
Don't show find-and-replace "Copy Path" item in tree-view context menu

### DIFF
--- a/menus/find-and-replace.cson
+++ b/menus/find-and-replace.cson
@@ -28,6 +28,6 @@
   '.list-item.match-row': [
     { 'label': 'Copy', 'command': 'core:copy' }
   ]
-  '.list-item': [
+  '.list-item.match-row, .list-item.path-row': [
     { 'label': 'Copy Path', 'command': 'find-and-replace:copy-path' }
   ]


### PR DESCRIPTION
Fixes #1032.

---

\#1032 reports that the [selector changes](https://github.com/atom/find-and-replace/commit/befebde9a6830e126a156cb33b5a8b99a77191d6) in #1002 cause find-and-replace's "Copy Path" menu item to unintentionally appear in tree-view's context menu. This pull request applies a more specific CSS selector to the "Copy Path" menu item, ensuring that it appears where we want it in the find-and-replace context menu, but not where we don't want it in the tree-view context menu.

The changes in #1002 were first released in find-and-replace v0.215.10. I checked out v0.215.9 to compare the behavior prior to #1002, the behavior in v0.215.10 (after #1002), and the behavior resulting from the changes in this pull request:

| version | tree-view context menu | search results context menu for file | search results context menu for line |
| :------ | :-------------  |  :------------- | :------------- |
| v0.215.9 |  ✅ Not Present [[screenshot](https://user-images.githubusercontent.com/2988/43148909-44126e7e-8f34-11e8-8184-ea33dc4eeb99.png)] | ✅ Present [[screenshot](https://user-images.githubusercontent.com/2988/43145424-577bc886-8f2d-11e8-8e83-aa9bdf6fd02e.png)] | ✅ Not Present [[screenshot](https://user-images.githubusercontent.com/2988/43145423-576ceed8-8f2d-11e8-8caf-52f41356423e.png)] |
| v0.215.10 | ❌ Present (Accidentally introduced in #1002) [[screenshot](https://user-images.githubusercontent.com/2988/43147100-37bf402e-8f30-11e8-973a-85c69c94e8cd.png)] | ✅ Present [[screenshot](https://user-images.githubusercontent.com/2988/43146973-004c9c04-8f30-11e8-9253-d0817c885220.png)] | ✅ Present (Intentionally introduced in #1002) [[screenshot](https://user-images.githubusercontent.com/2988/43146971-002d7cd4-8f30-11e8-8be3-6b6aa8f7f962.png)] |
| This Pull Request | ✅ Present [[screenshot](https://user-images.githubusercontent.com/2988/43148104-a066ee5e-8f32-11e8-8630-f12f17dae3d1.png)] | ✅ Present [[screenshot](https://user-images.githubusercontent.com/2988/43148103-a055e3ca-8f32-11e8-9093-63dd3e849b67.png)] | ✅ Present [[screenshot](https://user-images.githubusercontent.com/2988/43148102-a04440c0-8f32-11e8-8c32-fdbeb8a63849.png)] |

---

/fyi @PoignardAzur (author of #1002)
/fyi @sunz7 (author of #1032)

