### PR TITLE
Add extra placeholder text on how to exclude files in the find-and-replace 3rd field

### DIFF
--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -103,7 +103,7 @@ class ProjectFindView {
             etch.dom(TextEditor, {
               ref: 'pathsEditor',
               mini: true,
-              placeholderText: 'File/directory pattern. eg. `src` to search in the "src" directory; `*.js` to search all JavaScript files; `!*.png` to exclude all PNG files',
+              placeholderText: 'File/directory pattern: For example `src` to search in the "src" directory; `*.js` to search all JavaScript files; `!*.png` to exclude all PNG files',
               buffer: this.pathsBuffer
             })
           )

--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -103,7 +103,7 @@ class ProjectFindView {
             etch.dom(TextEditor, {
               ref: 'pathsEditor',
               mini: true,
-              placeholderText: 'File/directory pattern: For example `src` to search in the "src" directory; `*.js` to search all JavaScript files; `!*.png` to exclude all PNG files',
+              placeholderText: 'File/directory pattern: For example `src` to search in the "src" directory; `*.js` to search all JavaScript files; `!src` to exclude the "src" directory; `!*.json` to exclude all JSON files',
               buffer: this.pathsBuffer
             })
           )

--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -103,7 +103,7 @@ class ProjectFindView {
             etch.dom(TextEditor, {
               ref: 'pathsEditor',
               mini: true,
-              placeholderText: 'File/directory pattern. eg. `src` to search in the "src" directory or `*.js` to search all JavaScript files',
+              placeholderText: 'File/directory pattern. eg. `src` to search in the "src" directory; `*.js` to search all JavaScript files; `!*.png` to exclude all PNG files',
               buffer: this.pathsBuffer
             })
           )


### PR DESCRIPTION
### Description of the Change
When the `ctrl+shft+f` is pressed the search and replace feature opens. The screenshot below shows the field that I'm proposing to edit (3rd field that allows users to specify what path they prefer to search)
 
![image](https://user-images.githubusercontent.com/4140247/43342848-297b0c08-91b2-11e8-90e5-17f39959ed97.png)

Currently the placeholder for the 3rd field reads as follows:
> File/directory pattern. eg. `src` to search in the "src" directory or `*.js` to search all JavaScript files

I'm proposing for the placeholder text to read as follows: 
> File/directory pattern. eg. `src` to search in the "src" directory; `*.js` to search all JavaScript files; `!*.png` to exclude all PNG files

_Note:_ The screenshot's function is to show where I mean to replace the placeholder text. I tried to actually manipulate the UI in the js console but atom reported an error so apologies for not demoing what it would look like. 

Ref: #149 

### Why Should This Be In find and replace?

I imagine that users wouldn't know that atom uses certain markup to dilienate (`!*.js`) what not to search. A user needs to dig around to find this out. I propose to educate the user on how to exclude files/directories in the placeholder text _directly_. I discovered this by searching the issue queue.  

### Benefits

Inform the user immediately through the placeholder how to achieve what they need


### Possible Drawbacks

Someone might view this as 'bloaty' or 'crowded' even though for me it fits perfectly all on one line

