### PR TITLE
[WIP] add preserve case option including camel case, snake case, and kebab case

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -38,6 +38,7 @@
   'cmd-alt-c': 'find-and-replace:toggle-case-option'
   'cmd-alt-s': 'find-and-replace:toggle-selection-option'
   'cmd-alt-w': 'find-and-replace:toggle-whole-word-option'
+  'ctrl-alt-cmd-c': 'find-and-replace:toggle-preserve-case-option'
 
 '.platform-win32 .find-and-replace, .platform-linux .find-and-replace':
   'shift-enter': 'find-and-replace:show-previous'
@@ -45,6 +46,7 @@
   'alt-enter': 'find-and-replace:find-all'
   'ctrl-alt-/': 'find-and-replace:toggle-regex-option'
   'ctrl-shift-c': 'find-and-replace:toggle-case-option'
+  'ctrl-alt-shift-c': 'find-and-replace:toggle-case-option'
 
 '.platform-darwin .project-find':
   'cmd-enter': 'project-find:confirm'

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -1,6 +1,7 @@
 const { Point, Range, Emitter, CompositeDisposable, TextBuffer } = require('atom');
 const FindOptions = require('./find-options');
 const escapeHelper = require('./escape-helper');
+const replace = require('preserve-case')
 
 const ResultsMarkerLayersByEditor = new WeakMap;
 
@@ -77,6 +78,7 @@ class BufferSearch {
         changedParams.wholeWord != null ||
         changedParams.caseSensitive != null ||
         changedParams.inCurrentSelection != null ||
+        changedParams.preserveCase != null ||
         (this.findOptions.inCurrentSelection === true && !this.editor.getSelectedBufferRange().isEqual(this.selectedRange))) {
         this.recreateMarkers();
     }
@@ -88,19 +90,27 @@ class BufferSearch {
     this.findOptions.set({replacePattern});
 
     this.editor.transact(() => {
-      let findRegex = null
+      let findRegex = null, findPattern = this.findOptions.findPattern;
 
       if (this.findOptions.useRegex) {
         findRegex = this.getFindPatternRegex();
         replacePattern = escapeHelper.unescapeEscapeSequence(replacePattern);
       }
+      const {preserveCase} = this.findOptions;
 
       for (let i = 0, n = markers.length; i < n; i++) {
         const marker = markers[i]
         const bufferRange = marker.getBufferRange();
-        const replacementText = findRegex ?
-          this.editor.getTextInBufferRange(bufferRange).replace(findRegex, replacePattern) :
-          replacePattern;
+        let replacementText;
+        if (preserveCase) {
+          replacementText = findRegex ?
+            replace(this.editor.getTextInBufferRange(bufferRange), findRegex, replacePattern) :
+            replace(this.editor.getTextInBufferRange(bufferRange), findPattern, replacePattern);
+        } else {
+          replacementText = findRegex ?
+            this.editor.getTextInBufferRange(bufferRange).replace(findRegex, replacePattern) :
+            replacePattern;
+        }
         this.editor.setTextInBufferRange(bufferRange, replacementText);
 
         marker.destroy();

--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -72,7 +72,7 @@ class FindOptions
     else
       expression = escapeRegExp(@findPattern)
 
-    expression = "\\b(?:#{expression})\\b" if @wholeWord
+    expression = "\\b#{expression}\\b" if @wholeWord
 
     new RegExp(expression, flags)
 

--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -1,4 +1,5 @@
 _ = require 'underscore-plus'
+replace = require 'preserve-case'
 {Emitter} = require 'atom'
 
 Params = [
@@ -8,6 +9,7 @@ Params = [
   'useRegex'
   'wholeWord'
   'caseSensitive'
+  'preserveCase'
   'inCurrentSelection'
   'leadingContextLineCount'
   'trailingContextLineCount'
@@ -65,10 +67,12 @@ class FindOptions
 
     if @useRegex
       expression = @findPattern
+    else if @preserveCase and not @caseSensitive
+      expression = replace.createSearchRegExp(@findPattern)
     else
       expression = escapeRegExp(@findPattern)
 
-    expression = "\\b#{expression}\\b" if @wholeWord
+    expression = "\\b(?:#{expression})\\b" if @wholeWord
 
     new RegExp(expression, flags)
 

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -57,6 +57,10 @@ class FindView {
 
               $.button({ref: 'wholeWordOptionButton', className: 'btn option-whole-word'},
                 $.svg({className: "icon", innerHTML: '<use href="#find-and-replace-icon-word" />'})
+              ),
+
+              $.button({ref: 'preserveCaseOptionButton', className: 'btn option-preserve-case'},
+                'C'
               )
             )
           )
@@ -204,6 +208,11 @@ class FindView {
         keyBindingCommand: 'find-and-replace:toggle-whole-word-option',
         keyBindingTarget: this.findEditor.element
       }),
+      atom.tooltips.add(this.refs.preserveCaseOptionButton, {
+        title: "Preserve Case",
+        keyBindingCommand: 'find-and-replace:toggle-preserve-case-option',
+        keyBindingTarget: this.findEditor.element
+      }),
 
       atom.tooltips.add(this.refs.nextButton, {
         title: "Find Next",
@@ -253,7 +262,8 @@ class FindView {
       'find-and-replace:toggle-regex-option': this.toggleRegexOption.bind(this),
       'find-and-replace:toggle-case-option': this.toggleCaseOption.bind(this),
       'find-and-replace:toggle-selection-option': this.toggleSelectionOption.bind(this),
-      'find-and-replace:toggle-whole-word-option': this.toggleWholeWordOption.bind(this)
+      'find-and-replace:toggle-whole-word-option': this.toggleWholeWordOption.bind(this),
+      'find-and-replace:toggle-preserve-case-option': this.togglePreserveCaseOption.bind(this)
     }));
 
     this.subscriptions.add(this.model.onDidUpdate(this.markersUpdated.bind(this)));
@@ -266,6 +276,7 @@ class FindView {
     this.refs.caseOptionButton.addEventListener('click', this.toggleCaseOption.bind(this));
     this.refs.selectionOptionButton.addEventListener('click', this.toggleSelectionOption.bind(this));
     this.refs.wholeWordOptionButton.addEventListener('click', this.toggleWholeWordOption.bind(this));
+    this.refs.preserveCaseOptionButton.addEventListener('click', this.togglePreserveCaseOption.bind(this));
 
     this.element.addEventListener('focus', () => this.findEditor.element.focus());
     this.element.addEventListener('click', (e) => {
@@ -655,6 +666,10 @@ class FindView {
       label.push('Whole Word');
     }
 
+    if (this.model.getFindOptions().preserveCase) {
+      label.push('Preserve Case');
+    }
+
     this.refs.optionsLabel.textContent = label.join(', ');
   }
 
@@ -663,6 +678,7 @@ class FindView {
     this.setOptionButtonState(this.refs.caseOptionButton, this.model.getFindOptions().caseSensitive);
     this.setOptionButtonState(this.refs.selectionOptionButton, this.model.getFindOptions().inCurrentSelection);
     this.setOptionButtonState(this.refs.wholeWordOptionButton, this.model.getFindOptions().wholeWord);
+    this.setOptionButtonState(this.refs.preserveCaseOptionButton, this.model.getFindOptions().preserveCase);
   }
 
   setOptionButtonState(optionButton, selected) {
@@ -707,6 +723,13 @@ class FindView {
 
   toggleWholeWordOption() {
     this.search(this.findEditor.getText(), {wholeWord: !this.model.getFindOptions().wholeWord});
+    if (!this.anyMarkersAreSelected()) {
+      this.selectFirstMarkerAfterCursor();
+    }
+  }
+
+  togglePreserveCaseOption() {
+    this.search({preserveCase: !this.model.getFindOptions().preserveCase});
     if (!this.anyMarkersAreSelected()) {
       this.selectFirstMarkerAfterCursor();
     }

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -60,7 +60,8 @@ class FindView {
               ),
 
               $.button({ref: 'preserveCaseOptionButton', className: 'btn option-preserve-case'},
-                'C'
+                $.span({}, 'A'),
+                $.span({style: {opacity: 0.6}}, 'B')
               )
             )
           )

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "element-resize-detector": "^1.1.10",
     "etch": "0.9.3",
     "fs-plus": "^3.0.0",
+    "preserve-case": "^1.1.1",
     "temp": "^0.8.3",
     "underscore-plus": "1.x"
   },


### PR DESCRIPTION
Happy birthday folks!  🎉 
I need to add tests still.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This adds an option to preserve case when replacing.  It's very comprehensive, for instance replacing `foo bar` with `hello world` will make the following replacements, more than any other editor I've used is capable of:

```
foo bar -> hello world
Foo Bar -> Hello World
Foo bar -> Hello world
FOO BAR -> HELLO WORLD
fooBar -> helloWorld
FooBar -> HelloWorld
foo-bar -> hello-world
Foo-Bar -> Hello-World
foo_bar -> hello_world
FOO_BAR -> HELLO_WORLD
```

It can preserve case equally well when replacing regular expressions, though the matches will be limited by the regexp.  For instance, replacing `(foo) (bar)` with `$2 $1` will make the following replacements:

```
foo bar -> bar foo
Foo Bar -> Bar Foo
Foo bar -> Bar foo
FOO BAR -> BAR FOO
```

And replacing `(baz)[-_ ]?(qux)` with `$2 $1` will make these replacements:
```
baz qux -> qux baz
Baz Qux -> Qux Baz
Baz qux -> Qux baz
BAZ QUX -> QUX BAZ
bazQux -> quxBaz
BazQux -> QuxBaz
baz-qux -> qux-baz
Baz-Qux -> Qux-Baz
baz_qux -> qux_baz
BAZ_QUX -> QUX_BAZ
```

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
The implementation uses my `preserve-case` package.
I have seen other packages for doing this, but none are as comprehensive.

### Benefits

<!-- What benefits will be realized by the code change? -->

Case-preserving replace can be extremely useful for programmers.  Often the same term will appear in multiple cases in code.  For instance in `find-view.js` you can find `wholeWord`, `WholeWord`, and `whole-word`.  Being able to replace all of these in one fell swoop without botching the case is very convenient.

### Possible Drawbacks

At the moment, `foo_bar` won't find `foo_Bar` when preserve case is turned on, because it only searches for the supported case types rather than doing a true case-insensitive search.

Turning preserve case on may actually increase find results since `hello world` will additionally match `hello-world`, `hello_world`, and `helloWorld`.

Using this with regexes can be a bit counterintuitive, because it performs the regex substitution first, then restores the original case of the match, which may end up adding or removing a space or `-` or `_`, regardless of what was in the replacement pattern.

### Applicable Issues

<!-- Enter any applicable Issues here -->
