### PR TITLE
Instantly update live search.

### DIFF
--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -277,7 +277,7 @@ class FindView {
   }
 
   handleFindEvents() {
-    this.findEditor.onDidStopChanging(() => this.liveSearch());
+    this.findEditor.onDidChange(() => this.liveSearch());
     this.refs.nextButton.addEventListener('click', e => e.shiftKey ? this.findPrevious({focusEditorAfter: true}) : this.findNext({focusEditorAfter: true}));
     this.refs.findAllButton.addEventListener('click', this.findAll.bind(this));
     this.subscriptions.add(atom.commands.add('atom-workspace', {


### PR DESCRIPTION
### Description of the Change

This change causes find-and-replace to react instantly to keystrokes in the `findEditor` (the "Find in current buffer" field), rather than after a [300ms debounce delay](https://github.com/atom/text-buffer/blob/0484f6327d133542f4bf1e9aa015a2e55e20e96f/src/text-buffer.coffee#L120).

This is especially import when the `scrollToResultOnLiveSearch` setting is enabled, as it lets you instantly see when you're at the right place in the file, just like when you search a web page in Chrome.

### Alternate Designs

One could make this behavior changeable with a setting. But I'm not sure if that's even necessary.

### Benefits

Search feels snappier.

### Possible Drawbacks

I haven't tested the performance impact of this with large buffers or on slower CPUs. We wouldn't want the editor to become unresponsive as you type into the search field.

### Applicable Issues

When I tried running the test suite I had some failing tests on master, so I'm not sure if this broke any tests.