### PR TITLE
Improve efficiency of replace algorithm

### DIFF
--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -107,7 +107,8 @@ class BufferSearch {
       }
 
       function removeInPlace(array, setToRemove) {
-        for (let src = 0, dest = 0, end = array.length; src < end; src++) {
+        let dest = 0
+        for (let src = 0, end = array.length; src < end; src++) {
           const elem = array[src];
           if (!setToRemove.has(elem)) array[dest++] = elem;
         }

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -95,8 +95,6 @@ class BufferSearch {
         replacePattern = escapeHelper.unescapeEscapeSequence(replacePattern);
       }
 
-      const replacedMarkers = new Set(markers);
-
       for (let i = 0, n = markers.length; i < n; i++) {
         const marker = markers[i];
         const bufferRange = marker.getBufferRange();
@@ -107,7 +105,17 @@ class BufferSearch {
 
         marker.destroy();
       }
-      this.markers = this.markers.filter(marker => !replacedMarkers.has(marker));
+
+      function removeInPlace(array, setToRemove) {
+        for (let src = 0, dest = 0, end = array.length; src < end; src++) {
+          const elem = array[src];
+          if (!setToRemove.has(elem)) array[dest++] = elem;
+        }
+        array.length = dest;
+      }
+
+      const replacedMarkers = new Set(markers);
+      removeInPlace(this.markers, replacedMarkers);
     });
 
     return this.emitter.emit('did-update', this.markers.slice());

--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -95,8 +95,10 @@ class BufferSearch {
         replacePattern = escapeHelper.unescapeEscapeSequence(replacePattern);
       }
 
+      const replacedMarkers = new Set(markers);
+
       for (let i = 0, n = markers.length; i < n; i++) {
-        const marker = markers[i]
+        const marker = markers[i];
         const bufferRange = marker.getBufferRange();
         const replacementText = findRegex ?
           this.editor.getTextInBufferRange(bufferRange).replace(findRegex, replacePattern) :
@@ -104,8 +106,8 @@ class BufferSearch {
         this.editor.setTextInBufferRange(bufferRange, replacementText);
 
         marker.destroy();
-        this.markers.splice(this.markers.indexOf(marker), 1);
       }
+      this.markers = this.markers.filter(marker => !replacedMarkers.has(marker));
     });
 
     return this.emitter.emit('did-update', this.markers.slice());


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

The current code for `replace` is O(n^2), where n is the number of markers: for each marker, it does an O(n) search for that marker in `this.markers`, and then does an `O(n)` splice to remove that marker.

I have re-sanctified it by creating a `Set` of the markers that will be replaced (O(n)), replacing the markers (O(n), ignoring the fact that `this.editor.setTextInBufferRange` is probably not truly constant time), and then filtering out the markers that are in the set (O(n)).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
A more proper solution would use a `Set` or `Map` (or maybe multiple indexes) for `this.markers`.  This is an interim solution that creates a temporary `Set` to make removing the replaced markers more efficient.

### Benefits

<!-- What benefits will be realized by the code change? -->
The asymptotic efficiency of `replace` goes from O(n^2) to O(n).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Laymen who have not be initiated into the mystic wisdom of big-O notation may be baffled by this change.  As with any good religion, we will have to exhort them to accept it upon faith.

### Applicable Issues

<!-- Enter any applicable Issues here -->
#653 