### PR TITLE
improve replace performance take 2 (this time I have confirmed substantial improvements in the profiler)

### DIFF
--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -95,17 +95,27 @@ class BufferSearch {
         replacePattern = escapeHelper.unescapeEscapeSequence(replacePattern);
       }
 
+      const replacementChunks = [];
+      const text = this.editor.getText();
+      const buffer = this.editor.getBuffer();
+
+      let end = 0;
+
       for (let i = 0, n = markers.length; i < n; i++) {
-        const marker = markers[i]
+        const marker = markers[i];
         const bufferRange = marker.getBufferRange();
-        const replacementText = findRegex ?
-          this.editor.getTextInBufferRange(bufferRange).replace(findRegex, replacePattern) :
-          replacePattern;
-        this.editor.setTextInBufferRange(bufferRange, replacementText);
+        const start = buffer.characterIndexForPosition(bufferRange.start);
+        replacementChunks.push(text.substring(end, start));
+        end = buffer.characterIndexForPosition(bufferRange.end);
+        replacementChunks.push(findRegex ?
+          text.substring(start, end).replace(findRegex, replacePattern)
+          : replacePattern);
 
         marker.destroy();
         this.markers.splice(this.markers.indexOf(marker), 1);
       }
+      replacementChunks.push(text.substring(end));
+      this.editor.setText(replacementChunks.join(''));
     });
 
     return this.emitter.emit('did-update', this.markers.slice());


### PR DESCRIPTION
@maxbrunsfeld I did some more digging on this.  The way changes are communicated to the marker layer doesn't seem to be the main culprit in my profiling results; instead I'm seeing `splice` calls from within `setTextInBufferRange` taking the most time:
![image](https://user-images.githubusercontent.com/1448194/45332665-91dfeb80-b537-11e8-8337-35a5ea245afd.png)

I haven't figured out why each `splice` operation is taking roughly a millisecond, but it means that if 60000 markers get replaced, the `splice`s consume a combined total of a whole minute, which is indeed at least how long it took for the editor to respond (I stopped the profiler after about 40 seconds).

When I changed `replace` to use plain JS string operations and then called `setTextInBufferRange` once to replace the entire buffer text at the end, the same 60000 replacements took about 5.5 seconds:

![image](https://user-images.githubusercontent.com/1448194/45332413-01ed7200-b536-11e8-8f6c-fd335dc2e6fc.png)

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Instead of calling `getTextInBufferRange` and `setTextInBufferRange` for each individual replacement, I get the entire text of the buffer, build up the replacement buffer text with native JS string operations, and replace the entire buffer text with a single call to `setTextInBufferRange` at the end. 

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
This is really just an experiment right now to contribute to the discussion of `text-buffer` performance

### Benefits

<!-- What benefits will be realized by the code change? -->
In my profiling test case (replacing "foo" with "hello" in a buffer with 60000 lines of "foo bar baz qux")
The time to replace is reduced from over a minute to 5.5 seconds.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Unfortunately, replacing the entire buffer text clears the selection, so I doubt you will want to merge this PR as-is.

### Applicable Issues

<!-- Enter any applicable Issues here -->
#653 