### PR TITLE
 Use getBuffer() instead of attempting to directly access the buffer

### DIFF
--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -31,7 +31,7 @@ class BufferSearch {
     if (this.subscriptions) this.subscriptions.dispose();
     if (this.editor) {
       this.subscriptions = new CompositeDisposable;
-      this.subscriptions.add(this.editor.buffer.onDidStopChanging(this.bufferStoppedChanging.bind(this)));
+      this.subscriptions.add(this.editor.getBuffer().onDidStopChanging(this.bufferStoppedChanging.bind(this)));
       this.subscriptions.add(this.editor.onDidAddSelection(this.setCurrentMarkerFromSelection.bind(this)));
       this.subscriptions.add(this.editor.onDidChangeSelectionRange(this.setCurrentMarkerFromSelection.bind(this)));
       this.resultsMarkerLayer = this.resultsMarkerLayerForTextEditor(this.editor);

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -30,7 +30,7 @@ module.exports =
     @resultsModel = new ResultsModel(@findOptions)
 
     @subscriptions.add atom.workspace.getCenter().observeActivePaneItem (paneItem) =>
-      if paneItem?.getBuffer?()
+      if paneItem?.getBuffer?() and paneItem?.buffer?
         @findModel.setEditor(paneItem)
       else
         @findModel.setEditor(null)

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -30,7 +30,7 @@ module.exports =
     @resultsModel = new ResultsModel(@findOptions)
 
     @subscriptions.add atom.workspace.getCenter().observeActivePaneItem (paneItem) =>
-      if paneItem?.getBuffer?() and paneItem?.buffer?
+      if paneItem?.getBuffer?()
         @findModel.setEditor(paneItem)
       else
         @findModel.setEditor(null)

--- a/spec/buffer-search-spec.js
+++ b/spec/buffer-search-spec.js
@@ -581,4 +581,15 @@ describe('BufferSearch', () => {
       }
     })
   );
+
+  describe("setEditor", () => {
+    it("does not attempt to directly access the buffer property of an editor", () => {
+      editor.buffer2 = buffer
+      editor.buffer = undefined
+      spyOn(editor, "getBuffer").andReturn(editor.buffer2);
+      expect(() => model.setEditor(editor)).not.toThrow();
+
+      editor.buffer = editor.buffer2 // Reset for spec teardown
+    })
+  })
 });

--- a/spec/buffer-search-spec.js
+++ b/spec/buffer-search-spec.js
@@ -8,7 +8,7 @@ describe('BufferSearch', () => {
 
   beforeEach(() => {
     editor = new TextEditor();
-    buffer = editor.buffer;
+    buffer = editor.getBuffer();
 
     // TODO - remove this conditional after Atom 1.25 ships
     if (buffer.findAndMarkAllInRangeSync) {
@@ -28,7 +28,7 @@ describe('BufferSearch', () => {
       ccc ddd aaa
       -----------
     `);
-    advanceClock(editor.buffer.stoppedChangingDelay);
+    advanceClock(buffer.stoppedChangingDelay);
 
     const findOptions = new FindOptions({findPattern: "a+"});
     model = new BufferSearch(findOptions);
@@ -122,7 +122,7 @@ describe('BufferSearch', () => {
           [[7, 8], [7, 11]]
         ]);
 
-        advanceClock(editor.buffer.stoppedChangingDelay);
+        advanceClock(buffer.stoppedChangingDelay);
 
         expectUpdateEvent();
         expect(getHighlightedRanges()).toEqual([
@@ -158,7 +158,7 @@ describe('BufferSearch', () => {
           [[7, 8], [7, 11]]
         ]);
 
-        advanceClock(editor.buffer.stoppedChangingDelay);
+        advanceClock(buffer.stoppedChangingDelay);
 
         expectUpdateEvent();
         expect(getHighlightedRanges()).toEqual([
@@ -192,7 +192,7 @@ describe('BufferSearch', () => {
           [[6, 4], [6, 7]]
         ]);
 
-        advanceClock(editor.buffer.stoppedChangingDelay);
+        advanceClock(buffer.stoppedChangingDelay);
 
         expectUpdateEvent();
         expect(getHighlightedRanges()).toEqual([
@@ -226,7 +226,7 @@ describe('BufferSearch', () => {
           [[7, 8], [7, 11]]
         ]);
 
-        advanceClock(editor.buffer.stoppedChangingDelay);
+        advanceClock(buffer.stoppedChangingDelay);
 
         expectUpdateEvent();
         expect(getHighlightedRanges()).toEqual([
@@ -263,7 +263,7 @@ describe('BufferSearch', () => {
           [[7, 8], [7, 11]]
         ]);
 
-        advanceClock(editor.buffer.stoppedChangingDelay);
+        advanceClock(buffer.stoppedChangingDelay);
 
         expectUpdateEvent();
         expect(getHighlightedRanges()).toEqual([
@@ -292,7 +292,7 @@ describe('BufferSearch', () => {
           [[7, 8], [7, 11]]
         ]);
 
-        advanceClock(editor.buffer.stoppedChangingDelay);
+        advanceClock(buffer.stoppedChangingDelay);
 
         expect(getHighlightedRanges()).toEqual([
           [[1, 0], [1, 3]],
@@ -324,7 +324,7 @@ describe('BufferSearch', () => {
           [[7, 8], [7, 11]]
         ]);
 
-        advanceClock(editor.buffer.stoppedChangingDelay);
+        advanceClock(buffer.stoppedChangingDelay);
 
         expectUpdateEvent();
         expect(getHighlightedRanges()).toEqual([
@@ -357,7 +357,7 @@ describe('BufferSearch', () => {
           [[7, 8], [7, 11]]
         ]);
 
-        advanceClock(editor.buffer.stoppedChangingDelay);
+        advanceClock(buffer.stoppedChangingDelay);
 
         expectUpdateEvent();
         expect(getHighlightedRanges()).toEqual([
@@ -392,7 +392,7 @@ describe('BufferSearch', () => {
           [[7, 8], [7, 11]]
         ]);
 
-        advanceClock(editor.buffer.stoppedChangingDelay);
+        advanceClock(buffer.stoppedChangingDelay);
 
         expect(getHighlightedRanges()).toEqual([
           [[1, 0], [1, 3]],
@@ -512,7 +512,7 @@ describe('BufferSearch', () => {
       expect(currentResultListener).toHaveBeenCalledWith(markerToSelect);
       currentResultListener.reset();
 
-      advanceClock(editor.buffer.stoppedChangingDelay);
+      advanceClock(buffer.stoppedChangingDelay);
 
       expectUpdateEvent();
       expect(getHighlightedRanges()).toEqual([


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

find.coffee checks for the existence of a `getBuffer()` method on the pane item before calling BufferSearch's `setEditor`, but `setEditor` ends up trying to directly access the `buffer` property rather than going through `getBuffer()`, which we know exists.
We now use `getBuffer()` in `setEditor` to avoid the case where `buffer` doesn't exist.

### Alternate Designs

None.

### Benefits

Bugfix.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #898
Fixes #815
Fixes #679
Fixes #649
Fixes #582
Supersedes and closes #966