### PR TITLE
Remove hardcoded fonts so that search view always use Atom’s font

### DIFF
--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -1,8 +1,6 @@
 @import "ui-variables";
 @import "syntax-variables";
 
-@find-and-replace-font: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-
 // result markers
 atom-text-editor {
   .find-result .region {
@@ -311,7 +309,6 @@ atom-workspace.find-visible {
       margin-right: 1ex;
       text-align: right;
       display: inline-block;
-      font-family: @find-and-replace-font;
     }
     .match-row.selected .line-number {
       color: @text-color-selected;
@@ -324,7 +321,6 @@ atom-workspace.find-visible {
 
     .preview {
       word-break: break-all;
-      font-family: @find-and-replace-font;
       white-space: pre;
       color: @text-color-subtle;
     }


### PR DESCRIPTION
### Description of the Change

Remove the hardcoded font names, so that the package use Atom’s font.

Before (setting the Editor font to Inconsolata):
![screenshot_20181220_052703](https://user-images.githubusercontent.com/2446451/50263889-51d2b380-0418-11e9-84ab-79734b630bed.png)

After:
![screenshot_20181220_052831](https://user-images.githubusercontent.com/2446451/50263890-51d2b380-0418-11e9-9f86-47797cc04444.png)

### Alternate Designs

Expose the font used for file names as a configuration option, but I fail to find a compelling use case.

### Benefits

Less code, uniform look, don’t need to change several fonts.

### Possible Drawbacks

Can’t use another font for file names in search results.

### Applicable Issues

Fix #1057 
