### PR TITLE
Use editor.onDidStopChanging, not editor.getBuffer().onDidStopChanging

### DIFF
--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -31,7 +31,7 @@ class BufferSearch {
     if (this.subscriptions) this.subscriptions.dispose();
     if (this.editor) {
       this.subscriptions = new CompositeDisposable;
-      this.subscriptions.add(this.editor.getBuffer().onDidStopChanging(this.bufferStoppedChanging.bind(this)));
+      this.subscriptions.add(this.editor.onDidStopChanging(this.bufferStoppedChanging.bind(this)));
       this.subscriptions.add(this.editor.onDidAddSelection(this.setCurrentMarkerFromSelection.bind(this)));
       this.subscriptions.add(this.editor.onDidChangeSelectionRange(this.setCurrentMarkerFromSelection.bind(this)));
       this.resultsMarkerLayer = this.resultsMarkerLayerForTextEditor(this.editor);


### PR DESCRIPTION
Quick follow-up from #966, to definitively make clear that the existence of a buffer does not matter; rather, it is the text editor itself that counts.
There is no change in functionality, as `editor.onDidStopChanging` [directly calls the TextBuffer version](https://github.com/atom/atom/blob/62690f7783da86e6975398bca758563de99b4e2e/src/text-editor.js#L685).