### PR TITLE
Find within TextEditors within non-editor pane items

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -32,6 +32,8 @@ module.exports =
     @subscriptions.add atom.workspace.getCenter().observeActivePaneItem (paneItem) =>
       if atom.workspace.isTextEditor(paneItem)
         @findModel.setEditor(paneItem)
+      else if paneItem?.getEmbeddedTextEditor?
+        @findModel.setEditor(paneItem.getEmbeddedTextEditor())
       else
         @findModel.setEditor(null)
 

--- a/spec/find-spec.js
+++ b/spec/find-spec.js
@@ -1,10 +1,15 @@
 const {it, fit, ffit, beforeEach, afterEach} = require('./async-spec-helpers') // eslint-disable-line no-unused-vars
 
 const BufferSearch = require('../lib/buffer-search')
+const EmbeddedEditorItem = require('./item/embedded-editor-item')
+const UnrecognizedItem = require('./item/unrecognized-item');
 
 describe('Find', () => {
   describe('updating the find model', () => {
     beforeEach(async () => {
+      atom.workspace.addOpener(EmbeddedEditorItem.opener)
+      atom.workspace.addOpener(UnrecognizedItem.opener)
+
       const activationPromise = atom.packages.activatePackage('find-and-replace')
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'find-and-replace:show')
       await activationPromise
@@ -20,10 +25,13 @@ describe('Find', () => {
       expect(BufferSearch.prototype.setEditor).toHaveBeenCalledWith(editor)
     })
 
-    it("sets the find model's editor to null if a non-editor is focused", async () => {
-      spyOn(atom.workspace, 'isTextEditor').andReturn(false)
+    it("sets the find model's editor to an embedded text editor", async () => {
+      const embedded = await atom.workspace.open(EmbeddedEditorItem.uri)
+      expect(BufferSearch.prototype.setEditor).toHaveBeenCalledWith(embedded.refs.theEditor)
+    })
 
-      await atom.workspace.open()
+    it("sets the find model's editor to null if a non-editor is focused", async () => {
+      await atom.workspace.open(UnrecognizedItem.uri)
       expect(BufferSearch.prototype.setEditor).toHaveBeenCalledWith(null)
     })
   })

--- a/spec/item/embedded-editor-item.js
+++ b/spec/item/embedded-editor-item.js
@@ -1,0 +1,38 @@
+// An active workspace item that embeds an AtomTextEditor we wish to expose to Find and Replace.
+
+const etch = require('etch');
+const $ = etch.dom;
+
+const { TextEditor } = require('atom');
+
+class EmbeddedEditorItem {
+  static opener(u) {
+    if (u === EmbeddedEditorItem.uri) {
+      return new EmbeddedEditorItem();
+    } else {
+      return undefined;
+    }
+  }
+
+  constructor() {
+    etch.initialize(this);
+  }
+
+  render() {
+    return (
+      $.div({className: 'wrapper'},
+        etch.dom(TextEditor, {ref: 'theEditor'})
+      )
+    )
+  }
+
+  update() {}
+
+  getEmbeddedTextEditor() {
+    return this.refs.theEditor
+  }
+}
+
+EmbeddedEditorItem.uri = 'atom://find-and-replace/spec/embedded-editor'
+
+module.exports = EmbeddedEditorItem

--- a/spec/item/unrecognized-item.js
+++ b/spec/item/unrecognized-item.js
@@ -1,0 +1,30 @@
+// An active workspace item that doesn't contain a TextEditor.
+
+const etch = require('etch');
+const $ = etch.dom;
+
+class UnrecognizedItem {
+  static opener(u) {
+    if (u === UnrecognizedItem.uri) {
+      return new UnrecognizedItem();
+    } else {
+      return undefined;
+    }
+  }
+
+  constructor() {
+    etch.initialize(this);
+  }
+
+  render() {
+    return (
+      $.div({className: 'wrapper'}, 'Some text')
+    )
+  }
+
+  update() {}
+}
+
+UnrecognizedItem.uri = 'atom://find-and-replace/spec/unrecognized'
+
+module.exports = UnrecognizedItem


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

In atom/github, we open several pane items that _embed_ TextEditor elements, but are not TextEditors themselves: ChangedFileItems for single file diffs (stage and unchanged), CommitPreviewItems for commit previews, and the "Files Changed" tab within the pull request detail item. <kbd>Cmd-F</kbd> doesn't search them, which is inconvenient, because especially the last two can be large.

To accommodate them, and any other packages that created pane items with internal TextEditors, I'm allowing pane items to implement a `getEmbeddedTextEditor()` method. If present on the active pane item, when the find view is opened, that embedded item will be searched.

### Alternate Designs

I thought about making the method `getEmbeddedTextEditors()`, plural, and allowing a pane item to return multiple editors and search across all of them. It would have been a fair bit more work and we didn't actually need it for atom/github, so I held off to keep the scope small.

### Benefits

`find-and-replace:show` will be able to be used to search buffers embedded in custom pane items as well as core TextEditors.

### Possible Drawbacks

It's possible that there are items in third-party packages that already implement a method with that name. Although this is kind of a bonus too?

### Applicable Issues

_N/A_
