### PR TITLE
Understand observeEmbeddedTextEditor to follow embedded TextEditor changes

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -36,8 +36,8 @@ module.exports =
 
       if atom.workspace.isTextEditor(paneItem)
         @findModel.setEditor(paneItem)
-      else if paneItem?.onDidChangeEmbeddedTextEditor?
-        @currentItemSub = paneItem.onDidChangeEmbeddedTextEditor (editor) =>
+      else if paneItem?.observeEmbeddedTextEditor?
+        @currentItemSub = paneItem.observeEmbeddedTextEditor (editor) =>
           if atom.workspace.getCenter().getActivePaneItem() is paneItem
             @findModel.setEditor(editor)
         @subscriptions.add @currentItemSub

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -21,6 +21,7 @@ module.exports =
       new ResultsPaneView() if filePath is ResultsPaneView.URI
 
     @subscriptions = new CompositeDisposable
+    @currentItemSub = new Disposable
     @findHistory = new History(findHistory)
     @replaceHistory = new History(replaceHistory)
     @pathsHistory = new History(pathsHistory)
@@ -30,8 +31,16 @@ module.exports =
     @resultsModel = new ResultsModel(@findOptions)
 
     @subscriptions.add atom.workspace.getCenter().observeActivePaneItem (paneItem) =>
+      @subscriptions.delete @currentItemSub
+      @currentItemSub.dispose()
+
       if atom.workspace.isTextEditor(paneItem)
         @findModel.setEditor(paneItem)
+      else if paneItem?.onDidChangeEmbeddedTextEditor?
+        @currentItemSub = paneItem.onDidChangeEmbeddedTextEditor (editor) =>
+          if atom.workspace.getCenter().getActivePaneItem() is paneItem
+            @findModel.setEditor(editor)
+        @subscriptions.add @currentItemSub
       else if paneItem?.getEmbeddedTextEditor?
         @findModel.setEditor(paneItem.getEmbeddedTextEditor())
       else

--- a/spec/find-spec.js
+++ b/spec/find-spec.js
@@ -2,6 +2,7 @@ const {it, fit, ffit, beforeEach, afterEach} = require('./async-spec-helpers') /
 
 const BufferSearch = require('../lib/buffer-search')
 const EmbeddedEditorItem = require('./item/embedded-editor-item')
+const DeferredEditorItem = require('./item/deferred-editor-item');
 const UnrecognizedItem = require('./item/unrecognized-item');
 
 describe('Find', () => {
@@ -9,6 +10,7 @@ describe('Find', () => {
     beforeEach(async () => {
       atom.workspace.addOpener(EmbeddedEditorItem.opener)
       atom.workspace.addOpener(UnrecognizedItem.opener)
+      atom.workspace.addOpener(DeferredEditorItem.opener)
 
       const activationPromise = atom.packages.activatePackage('find-and-replace')
       atom.commands.dispatch(atom.views.getView(atom.workspace), 'find-and-replace:show')
@@ -28,6 +30,17 @@ describe('Find', () => {
     it("sets the find model's editor to an embedded text editor", async () => {
       const embedded = await atom.workspace.open(EmbeddedEditorItem.uri)
       expect(BufferSearch.prototype.setEditor).toHaveBeenCalledWith(embedded.refs.theEditor)
+    })
+
+    it("sets the find model's editor to an embedded text editor after activation", async () => {
+      const deferred = await atom.workspace.open(DeferredEditorItem.uri)
+      expect(BufferSearch.prototype.setEditor).not.toHaveBeenCalled()
+
+      await deferred.showEditor()
+      expect(BufferSearch.prototype.setEditor).toHaveBeenCalledWith(deferred.refs.theEditor)
+
+      await deferred.hideEditor()
+      expect(BufferSearch.prototype.setEditor).toHaveBeenCalledWith(null)
     })
 
     it("sets the find model's editor to null if a non-editor is focused", async () => {

--- a/spec/item/deferred-editor-item.js
+++ b/spec/item/deferred-editor-item.js
@@ -1,0 +1,68 @@
+// An active workspace item that embeds an AtomTextEditor we wish to expose to Find and Replace that does not become
+// available until some time after the item is activated.
+
+const etch = require('etch');
+const $ = etch.dom;
+
+const { TextEditor, Emitter } = require('atom');
+
+class DeferredEditorItem {
+  static opener(u) {
+    if (u === DeferredEditorItem.uri) {
+      return new DeferredEditorItem();
+    } else {
+      return undefined;
+    }
+  }
+
+  constructor() {
+    this.editorShown = false;
+    this.emitter = new Emitter();
+
+    etch.initialize(this);
+  }
+
+  render() {
+    if (this.editorShown) {
+      return (
+        $.div({className: 'wrapper'},
+          etch.dom(TextEditor, {ref: 'theEditor'})
+        )
+      )
+    } else {
+      return (
+        $.div({className: 'wrapper'}, 'Empty')
+      )
+    }
+  }
+
+  update() {
+    return etch.update(this)
+  }
+
+  onDidChangeEmbeddedTextEditor(cb) {
+    return this.emitter.on('did-change-embedded-text-editor', cb)
+  }
+
+  async showEditor() {
+    const wasShown = this.editorShown
+    this.editorShown = true
+    await this.update()
+    if (!wasShown) {
+      this.emitter.emit('did-change-embedded-text-editor', this.refs.theEditor)
+    }
+  }
+
+  async hideEditor() {
+    const wasShown = this.editorShown
+    this.editorShown = false
+    await this.update()
+    if (wasShown) {
+      this.emitter.emit('did-change-embedded-text-editor', null)
+    }
+  }
+}
+
+DeferredEditorItem.uri = 'atom://find-and-replace/spec/deferred-editor'
+
+module.exports = DeferredEditorItem

--- a/spec/item/deferred-editor-item.js
+++ b/spec/item/deferred-editor-item.js
@@ -40,7 +40,10 @@ class DeferredEditorItem {
     return etch.update(this)
   }
 
-  onDidChangeEmbeddedTextEditor(cb) {
+  observeEmbeddedTextEditor(cb) {
+    if (this.editorShown) {
+      cb(this.refs.theEditor)
+    }
     return this.emitter.on('did-change-embedded-text-editor', cb)
   }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This is a follow-on enhancement to #1068. If the active pane item implements `observeEmbeddedTextEditor`, the find model will track changes to the embedded TextEditor after the pane item activation completes.

### Alternate Designs

_N/A_

### Benefits

atom/github will be able to use this API with React refs, which aren't available synchronously on item activation (oops).

### Possible Drawbacks

_N/A_

### Applicable Issues

_N/A_
