### PR TITLE
Fix editing the search input when toggling the search pane

### DIFF
--- a/lib/find-options.coffee
+++ b/lib/find-options.coffee
@@ -31,6 +31,9 @@ class FindOptions
   onDidChange: (callback) ->
     @emitter.on('did-change', callback)
 
+  onDidChangeUseRegex: (callback) ->
+    @emitter.on('did-change-useRegex', callback)
+
   onDidChangeReplacePattern: (callback) ->
     @emitter.on('did-change-replacePattern', callback)
 

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -21,6 +21,7 @@ class FindView {
     this.handleEvents();
     this.clearMessage();
     this.updateOptionViews();
+    this.updateSyntaxHighlighting();
     this.updateReplaceEnablement();
     this.createWrapIcon();
   }
@@ -277,6 +278,7 @@ class FindView {
     this.subscriptions.add(this.model.onDidError(this.findError.bind(this)));
     this.subscriptions.add(this.model.onDidChangeCurrentResult(this.updateResultCounter.bind(this)));
     this.subscriptions.add(this.model.getFindOptions().onDidChange(this.updateOptionViews.bind(this)));
+    this.subscriptions.add(this.model.getFindOptions().onDidChangeUseRegex(this.updateSyntaxHighlighting.bind(this)));
 
     this.refs.closeButton.addEventListener('click', () => this.panel && this.panel.hide());
     this.refs.regexOptionButton.addEventListener('click', this.toggleRegexOption.bind(this));
@@ -633,7 +635,6 @@ class FindView {
   updateOptionViews() {
     this.updateOptionButtons();
     this.updateOptionsLabel();
-    this.updateSyntaxHighlighting();
   }
 
   updateSyntaxHighlighting() {

--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -32,6 +32,7 @@ class ProjectFindView {
 
     this.clearMessages();
     this.updateOptionViews();
+    this.updateSyntaxHighlighting();
   }
 
   update() {}
@@ -235,6 +236,7 @@ class ProjectFindView {
     this.subscriptions.add(this.model.onDidNoopSearch(afterSearch));
     this.subscriptions.add(this.model.onDidFinishSearching(searchFinished));
     this.subscriptions.add(this.model.getFindOptions().onDidChange(this.updateOptionViews.bind(this)));
+    this.subscriptions.add(this.model.getFindOptions().onDidChangeUseRegex(this.updateSyntaxHighlighting.bind(this)));
 
     this.element.addEventListener('focus', () => this.findEditor.element.focus());
     this.refs.closeButton.addEventListener('click', () => this.panel && this.panel.hide());
@@ -492,7 +494,6 @@ class ProjectFindView {
   updateOptionViews() {
     this.updateOptionButtons();
     this.updateOptionsLabel();
-    this.updateSyntaxHighlighting();
   }
 
   updateSyntaxHighlighting() {

--- a/spec/find-view-spec.js
+++ b/spec/find-view-spec.js
@@ -109,6 +109,26 @@ describe("FindView", () => {
         "current < pivot \\? left\\.push\\(current\\) : right\\.push\\(current\\);"
       );
     });
+
+    it('selects the text to find when the panel is re-shown', async () => {
+      atom.commands.dispatch(editorView, "find-and-replace:show");
+      await activationPromise;
+
+      const stringToSearch = "not found";
+      const findEditor = findView.findEditor;
+
+      findEditor.setText(stringToSearch);
+
+      atom.commands.dispatch(findEditor.element, "core:confirm");
+      atom.commands.dispatch(document.activeElement, "core:cancel");
+      atom.commands.dispatch(editorView, "find-and-replace:show");
+
+      expect(findEditor.getSelectedBufferRange()).toEqual([[0, 0], [0, stringToSearch.length]]);
+
+      const selectionElement = findEditor.getElement().querySelector('.highlight.selection .selection');
+
+      expect(selectionElement.getBoundingClientRect().width).toBeGreaterThan(0);
+    });
   });
 
   describe("when find-and-replace:toggle is triggered", () => {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The find and replace package was causing some issues with the cursor when hiding and showing the search panel under some circumstances. I could find two scenarios where this was happening:

* **Scenario 1**: When searching for an existing text but not selecting it from the document (by not pressing `Enter` after searching). This is the scenario described in https://github.com/atom/find-and-replace/issues/1067
* **Scenario 2**: When searching for a non-existing text and then hiding and showing the search panel.

The issues comes from the fact that on every search the find view [is re-setting](https://github.com/atom/find-and-replace/blob/master/lib/find-view.js#L641) the `TextEditor` grammar, and under some circumstances (when hiding and showing the panel) this causes a bad state on the `TextEditor`, which prevents the cursor from moving correctly within the find input.

I haven't been able to find the root issue that's causing the bad state on the `TextEditor`, but anyways this PR prevents it from happening by only setting the grammar of the `TextEditor` when it's needed.

I haven't added any automated test that verifies the correct behaviour, since it may be a bit complex to reproduce the issue programatically (haven't checked it though), but I'll happily add a test case if you think it's worth it :)

### Alternate Designs

N/A

### Benefits

Users won't get confused when toggling the search bar and not being able to change the search text.

### Possible Drawbacks

N/A

### Applicable Issues

This closes https://github.com/atom/find-and-replace/issues/1067
