### PR TITLE
Add config option to use `ripgrep` for scanning files

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -17,6 +17,7 @@ Currently Find and Replace does not log any counter events.
   |-------|-------|
   | `ec` | `time-to-search`
   | `ev` | Number of found results
+  | `el` | Search system in use (`ripgrep` or `standard`)
 
 ## Standard events
 

--- a/lib/project/results-model.js
+++ b/lib/project/results-model.js
@@ -216,6 +216,7 @@ module.exports = class ResultsModel {
     const trailingContextLineCount = atom.config.get('find-and-replace.searchContextLineCountAfter')
 
     const startTime = Date.now()
+    const useRipgrep = atom.config.get('find-and-replace.useRipgrep')
 
     this.inProgressSearchPromise = atom.workspace.scan(
       this.regex,
@@ -223,6 +224,7 @@ module.exports = class ResultsModel {
         paths: searchPaths,
         onPathsSearched,
         leadingContextLineCount,
+        ripgrep: useRipgrep,
         trailingContextLineCount
       },
       (result, error) => {
@@ -244,7 +246,11 @@ module.exports = class ResultsModel {
     } else {
       const resultsSummary = this.getResultsSummary()
 
-      this.metricsReporter.sendSearchEvent(Date.now() - startTime, resultsSummary.matchCount)
+      this.metricsReporter.sendSearchEvent(
+        Date.now() - startTime,
+        resultsSummary.matchCount,
+        useRipgrep ? 'ripgrep' : 'standard'
+      )
       this.inProgressSearchPromise = null
       this.emitter.emit('did-finish-searching', resultsSummary)
     }

--- a/lib/reporter-proxy.js
+++ b/lib/reporter-proxy.js
@@ -19,10 +19,11 @@ module.exports = class ReporterProxy {
     delete this.reporter
   }
 
-   sendSearchEvent (duration, numResults) {
+   sendSearchEvent (duration, numResults, crawler) {
     const metadata = {
       ec: 'time-to-search',
-      ev: numResults
+      ev: numResults,
+      el: crawler
     }
 
      this._addTiming(duration, metadata)

--- a/package.json
+++ b/package.json
@@ -125,6 +125,12 @@
       "title": "Show Search Wrap Icon",
       "description": "Display a visual cue over the editor when looping through search results."
     },
+    "useRipgrep": {
+      "type": "boolean",
+      "default": false,
+      "title": "Use ripgrep",
+      "description": "Use the experimental `ripgrep` search crawler. This will make searches substantially faster on large projects."
+    },
     "autocompleteSearches": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
## Summary

This PR adds a config option to enable `ripgrep` powered find and replace on this package. The integration with `ripgrep` has been done in Atom core on https://github.com/atom/atom/pull/19348 and this PR just opts in the find and replace package to use it.

<img width="808" alt="Screenshot 2019-05-24 at 12 14 38" src="https://user-images.githubusercontent.com/408035/58342205-5d575a00-7e50-11e9-8f2a-307cd3cf2b93.png">

## Benefits

Using `ripgrep` speeds up drastically the time to find files on any kind of repository (we're taking about **up to 22X faster times**):

| Type | Num Files | Time (standard)  | Time (ripgrep) | Improvements  |
|---|---|---|---|---|
|  Small | 2K  | 940ms  | 62ms | **15X** faster  🎉 |
|  Medium |  30K | 7.7s  | 620ms  | **12X** faster 🎉 |
|  Large (returning 5 results) | 270K  |  129s  |  5.9s  |  **22X** faster 🎉 |
|  Large (returning 26k results) | 270K  |  142s  |  17.5s  |  **8X** faster 🎉 |

*(the last measure has been done to check the less favourable case for `ripgrep`, which is a search that returns a lot of results (26k) which need to be passed from the `ripgrep` process to Atom. This is still 8X times faster than the current search logic. We could limit the number of results, but this can be done as a separate PR).*

## Possible Drawbacks

The search behaviour with `ripgrep` is slightly different than the one currently implemented, and there may be still some edge cases to polish. There's more information about the changes in https://github.com/atom/atom/pull/19348.

To mitigate that, I've done quite extensive tests but I'll keep checking for potential edge cases. Also, I'm planning to leave this config flag at least for 1 version of Atom so we can catch as many issues as possible before shipping this to users by default .

## Applicable Issues

https://github.com/atom/find-and-replace/issues/1075
