### PR TITLE
Try fixing flaky tests in results-view-spec.js

### DIFF
--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -686,28 +686,28 @@ describe('ResultsView', () => {
     });
 
     it("copies the selected file path to the clipboard when there are multiple project folders", async () => {
-        const folder1 = temp.mkdirSync('folder-1')
-        const file1 = path.join(folder1, 'sample.txt')
-        fs.writeFileSync(file1, 'items')
+      const folder1 = temp.mkdirSync('folder-1')
+      const file1 = path.join(folder1, 'sample.txt')
+      fs.writeFileSync(file1, 'items')
 
-        const folder2 = temp.mkdirSync('folder-2')
-        const file2 = path.join(folder2, 'sample.txt')
-        fs.writeFileSync(file2, 'items')
+      const folder2 = temp.mkdirSync('folder-2')
+      const file2 = path.join(folder2, 'sample.txt')
+      fs.writeFileSync(file2, 'items')
 
-        atom.project.setPaths([folder1, folder2]);
-        projectFindView.findEditor.setText('items');
-        atom.commands.dispatch(projectFindView.element, 'core:confirm');
-        await searchPromise;
+      atom.project.setPaths([folder1, folder2]);
+      projectFindView.findEditor.setText('items');
+      atom.commands.dispatch(projectFindView.element, 'core:confirm');
+      await searchPromise;
 
-        resultsView = getResultsView();
-        await resultsView.heightInvalidationPromise;
-        resultsView.selectFirstResult();
-        resultsView.collapseResult();
-        atom.commands.dispatch(resultsView.element, 'find-and-replace:copy-path');
-        expect(atom.clipboard.read()).toBe(path.join(path.basename(folder1), path.basename(file1)));
-        atom.commands.dispatch(resultsView.element, 'core:move-down');
-        atom.commands.dispatch(resultsView.element, 'find-and-replace:copy-path');
-        expect(atom.clipboard.read()).toBe(path.join(path.basename(folder2), path.basename(file2)));
+      resultsView = getResultsView();
+      await resultsView.heightInvalidationPromise;
+      resultsView.selectFirstResult();
+      resultsView.collapseResult();
+      atom.commands.dispatch(resultsView.element, 'find-and-replace:copy-path');
+      expect(atom.clipboard.read()).toBe(path.join(path.basename(folder1), path.basename(file1)));
+      atom.commands.dispatch(resultsView.element, 'core:move-down');
+      atom.commands.dispatch(resultsView.element, 'find-and-replace:copy-path');
+      expect(atom.clipboard.read()).toBe(path.join(path.basename(folder2), path.basename(file2)));
     });
   });
 

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -669,6 +669,8 @@ describe('ResultsView', () => {
 
   describe("copying path with find-and-replace:copy-path", () => {
     it("copies the selected file path to clipboard", async () => {
+      jasmine.useRealClock()
+
       projectFindView.findEditor.setText('items');
       atom.commands.dispatch(projectFindView.element, 'core:confirm');
       await searchPromise;
@@ -686,6 +688,8 @@ describe('ResultsView', () => {
     });
 
     it("copies the selected file path to the clipboard when there are multiple project folders", async () => {
+      jasmine.useRealClock()
+
       const folder1 = temp.mkdirSync('folder-1')
       const file1 = path.join(folder1, 'sample.txt')
       fs.writeFileSync(file1, 'items')


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/19480

This pull request is an attempt at fixing the flaky tests described in the above issue. Such tests were failing in the following way:

```
ResultsView
  copying path with find-and-replace:copy-path
    it ResultsView copying path with find-and-replace:copy-path copies the selected file path to clipboard
      timeout: timed out after 60000 msec waiting for spec promise to resolve
    it ResultsView copying path with find-and-replace:copy-path copies the selected file path to the clipboard when there are multiple project folders
      timeout: timed out after 60000 msec waiting for spec promise to resolve
```

After analyzing those two code paths, it seems like the so-called `heightInvalidationPromise` may be what the tests get stuck on every now and then on CI. That promise is resolved after a `resize` event occurs, and resize detection is implemented in terms of [element-resize-detector](https://github.com/wnr/element-resize-detector).

I noticed that `element-resize-detector` seems to [use `setTimeout`](https://github.com/wnr/element-resize-detector/blob/27983e59dce9d8f1296d8f555dc2340840fb0804/dist/element-resize-detector.js#L88-L92) to report `resize` events in batches. Given that the default jasmine test runner mocks `setTimeout` and `setInterval`, it is possible that a resize event is occurring but `element-resize-detector` can't report it because of the mocked timer functions.

With these changes, we will avoid mocking `setTimeout` and `setInterval` for those two tests to see if it helps improve their flakiness. 🤞 