### PR TITLE
Construct ResultsView directly to fix some flaky tests

### DIFF
--- a/lib/project/results-model.js
+++ b/lib/project/results-model.js
@@ -387,3 +387,6 @@ module.exports = class ResultsModel {
     return pathsPattern.trim().split(',').map((inputPath) => inputPath.trim())
   }
 }
+
+// Exported for tests
+module.exports.Result = Result


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/19480

Previously, all tests on the `ResultsView` actually ran a real search against the file system to populate their results. We're seeing intermittent failures in a few tests, so I decided to eliminate the async behavior by constructing a `ResultsView` directly with a model and then populating some fake results on the model. This makes the test synchronous and should hopefully eliminate the flakiness.