### PR TITLE
Overhaul height invalidation

### DIFF
--- a/lib/project/list-view.js
+++ b/lib/project/list-view.js
@@ -1,6 +1,5 @@
 const etch = require('etch');
 const $ = etch.dom;
-const resizeDetector = require('element-resize-detector');
 
 module.exports = class ListView {
   constructor({items, heightForItem, itemComponent, className}) {
@@ -12,7 +11,8 @@ module.exports = class ListView {
     this.previousClientHeight = 0
     etch.initialize(this);
 
-    resizeDetector({strategy: 'scroll'}).listenTo(this.element, () => etch.update(this));
+    const resizeObserver = new ResizeObserver(() => etch.update(this));
+    resizeObserver.observe(this.element);
     this.element.addEventListener('scroll', () => etch.update(this));
   }
 

--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -30,9 +30,6 @@ class ResultsView {
     this.model = model;
     this.pixelOverdraw = 100;
 
-    this.resolveHeightInvalidationPromise = null
-    this.heightInvalidationPromise = new Promise((resolve) => { this.resolveHeightInvalidationPromise = resolve })
-
     this.resultRowGroups = Object.values(model.results).map(result =>
       new ResultRowGroup(result, this.model.getFindOptions())
     )
@@ -187,7 +184,6 @@ class ResultsView {
       this.contextRowHeight = contextRowHeight;
       this.clientHeight = clientHeight;
       await etch.update(this);
-      this.resolveHeightInvalidationPromise();
     }
 
     etch.update(this);

--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -10,7 +10,6 @@ const {
 
 const ListView = require('./list-view');
 const etch = require('etch');
-const resizeDetector = require('element-resize-detector');
 const binarySearch = require('binary-search')
 
 const path = require('path');
@@ -63,10 +62,8 @@ class ResultsView {
 
     etch.initialize(this);
 
-    resizeDetector({strategy: 'scroll'}).listenTo(
-      this.element,
-      this.invalidateItemHeights.bind(this)
-    );
+    const resizeObserver = new ResizeObserver(this.invalidateItemHeights.bind(this));
+    resizeObserver.observe(this.element);
     this.element.addEventListener('mousedown', this.handleClick.bind(this));
 
     this.subscriptions = new CompositeDisposable(

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "batch-processor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
-      "integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg="
-    },
     "binary-search": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.4.tgz",
@@ -63,14 +58,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
       "integrity": "sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s=",
       "dev": true
-    },
-    "element-resize-detector": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.1.12.tgz",
-      "integrity": "sha1-iz/W7t2hf5wAs2Cg6i35knroC6I=",
-      "requires": {
-        "batch-processor": "^1.0.0"
-      }
     },
     "etch": {
       "version": "0.9.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "binary-search": "^1.3.3",
-    "element-resize-detector": "^1.1.10",
     "etch": "0.9.3",
     "fs-plus": "^3.0.0",
     "temp": "^0.8.3",

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -299,7 +299,6 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           await searchPromise;
 
           const resultsView = getResultsView();
-          await resultsView.heightInvalidationPromise
           expect(resultsView.element).toBeVisible();
           expect(resultsView.refs.listView.element.querySelectorAll(".match-row")).toHaveLength(2);
         })
@@ -313,7 +312,6 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           await searchPromise;
 
           const resultsView = getResultsView();
-          await resultsView.heightInvalidationPromise
           expect(resultsView.element).toBeVisible();
           expect(resultsView.refs.listView.element.querySelectorAll(".match-row")).toHaveLength(1);
         });
@@ -325,7 +323,6 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           await searchPromise;
 
           const resultsView = getResultsView();
-          await resultsView.heightInvalidationPromise
           expect(resultsView.element).toBeVisible();
           expect(resultsView.refs.listView.element.querySelectorAll(".match-row")).toHaveLength(2);
           expect(resultsView.refs.listView.element.querySelectorAll(".match.highlight-info")).toHaveLength(3);
@@ -338,7 +335,6 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           await searchPromise;
 
           const resultsView = getResultsView();
-          await resultsView.heightInvalidationPromise
           expect(resultsView.element).toBeVisible();
           expect(resultsView.refs.listView.element.querySelectorAll(".match-row")).toHaveLength(1);
         });
@@ -710,7 +706,6 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         await waitForSearchResults();
 
         const resultsView = getResultsView();
-        await resultsView.heightInvalidationPromise
         expect(resultsView.element).toBeVisible();
         expect(resultsView.refs.listView.element.querySelectorAll(".match-row")).toHaveLength(11);
         expect(resultsView.refs.listView.element.querySelectorAll(".match.highlight-info")).toHaveLength(13);
@@ -772,7 +767,6 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           const resultsView = getResultsView();
           const resultsPaneView = getExistingResultsPane();
 
-          await resultsView.heightInvalidationPromise
           expect(resultsView.element).toBeVisible();
           expect(resultsView.refs.listView.element.querySelectorAll(".match-row")).toHaveLength(11);
           expect(resultsView.refs.listView.element.querySelectorAll(".match.highlight-info")).toHaveLength(13);
@@ -801,7 +795,6 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           const listView = resultsView.refs.listView;
           const resultsPaneView = getExistingResultsPane();
 
-          await resultsView.heightInvalidationPromise
           expect(listView.element.querySelectorAll(".match-row")).toHaveLength(11);
           expect(listView.element.querySelectorAll(".match.highlight-info")).toHaveLength(13);
           expect(resultsPaneView.refs.previewCount.textContent).toBe("13 results found in 2 files for items");
@@ -847,7 +840,6 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
           const resultsView = getResultsView();
           const resultsPaneView = getExistingResultsPane();
 
-          await resultsView.heightInvalidationPromise
           expect(resultsView.refs.listView.element.querySelectorAll(".list-item")).toHaveLength(13);
           expect(resultsPaneView.refs.previewCount.textContent).toBe("13 results found in 2 files for items");
 

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -22,10 +22,6 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
   function getExistingResultsPane() {
     const pane = atom.workspace.paneForURI(ResultsPaneView.URI);
     if (pane) {
-
-      // Allow element-resize-detector to perform batched measurements
-      advanceClock(1);
-
       return pane.itemForURI(ResultsPaneView.URI);
     }
   }

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -97,7 +97,6 @@ describe('ResultsView', () => {
       await searchPromise;
 
       resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
       expect(resultsView.refs.listView.element.querySelector('.path-name').textContent).toBe("one-long-line.coffee");
       expect(resultsView.refs.listView.element.querySelectorAll('.preview').length).toBe(1);
       expect(resultsView.refs.listView.element.querySelector('.preview').textContent).toBe('test test test test test test test test test test test a b c d e f g h i j k l abcdefghijklmnopqrstuvwxyz');
@@ -116,7 +115,6 @@ describe('ResultsView', () => {
       await searchPromise;
 
       resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
       expect(resultsView.refs.listView.element.querySelector('.path-name').textContent).toBe(path.join("project", "one-long-line.coffee"));
     });
   });
@@ -135,7 +133,6 @@ describe('ResultsView', () => {
       await searchPromise;
 
       resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
       expect(resultsView.refs.listView.element.querySelector('.path-name').textContent).toBe("one-long-line.coffee");
       expect(resultsView.refs.listView.element.querySelectorAll('.preview').length).toBe(1);
       expect(resultsView.refs.listView.element.querySelector('.match').textContent).toBe('ghijkl');
@@ -147,7 +144,6 @@ describe('ResultsView', () => {
       await searchPromise;
 
       resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
       expect(resultsView.refs.listView.element.querySelector('.match').textContent).toBe('ghijkl');
       expect(resultsView.refs.listView.element.querySelector('.match')).toHaveClass('highlight-info');
       expect(resultsView.refs.listView.element.querySelector('.replacement').textContent).toBe('');
@@ -179,7 +175,6 @@ describe('ResultsView', () => {
       await searchPromise;
 
       resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
       const listElement = resultsView.refs.listView.element;
       expect(listElement.querySelectorAll('.match')[0].textContent).toBe('function ()');
       expect(listElement.querySelectorAll('.replacement')[0].textContent).toBe('() =>');
@@ -198,7 +193,6 @@ describe('ResultsView', () => {
       await searchPromise;
 
       resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
       const {listView} = resultsView.refs;
       expect(listView.element.scrollTop).toBe(0);
       expect(listView.element.scrollHeight).toBeGreaterThan(listView.element.offsetHeight);
@@ -303,7 +297,6 @@ describe('ResultsView', () => {
       projectFindView.confirm();
       await searchPromise;
       resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
     });
 
     it("selects the first/last item when core:move-to-top/move-to-bottom is triggered", async () => {
@@ -343,7 +336,6 @@ describe('ResultsView', () => {
       await searchPromise;
 
       resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
 
       resultsView.moveDown();
       resultsView.moveDown();
@@ -382,7 +374,6 @@ describe('ResultsView', () => {
       await searchPromise;
 
       resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
 
       await resultsView.collapseResult();
       expect(resultsView.element.querySelector('.collapsed')).not.toBe(null);
@@ -450,7 +441,6 @@ describe('ResultsView', () => {
       await searchPromise;
 
       resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
       resultsView.selectFirstResult();
     });
 
@@ -546,7 +536,6 @@ describe('ResultsView', () => {
       await searchPromise;
 
       resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
 
       let {length: resultCount} = resultsView.refs.listView.element.querySelectorAll(".match-row");
       expect(resultCount).toBe(11);
@@ -594,7 +583,6 @@ describe('ResultsView', () => {
         atom.commands.dispatch(projectFindView.element, 'core:confirm');
         await searchPromise;
         resultsView = getResultsView();
-        await resultsView.heightInvalidationPromise;
       });
 
       it("shows the preview-controls", () => {
@@ -753,7 +741,6 @@ describe('ResultsView', () => {
         await searchPromise;
 
         resultsView = getResultsView();
-        await resultsView.heightInvalidationPromise;
         let fileIconClasses = Array.from(resultsView.refs.listView.element.querySelectorAll('.path-row .icon')).map(el => el.className);
         expect(fileIconClasses).toContain('first-icon-class second-icon-class icon');
         expect(fileIconClasses).toContain('third-icon-class fourth-icon-class icon');
@@ -933,7 +920,6 @@ describe('ResultsView', () => {
       await searchPromise;
 
       resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
     });
 
     it('maintains selected result when adding and removing results', async () => {

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -24,10 +24,6 @@ describe('ResultsView', () => {
 
   function getResultsPane() {
     let pane = atom.workspace.paneForURI(ResultsPaneView.URI);
-
-    // Allow element-resize-detector to perform batched measurements
-    advanceClock(1);
-
     if (pane) return pane.itemForURI(ResultsPaneView.URI);
   }
 

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -35,37 +35,41 @@ describe('ResultsView', () => {
     return getResultsPane().refs.resultsView;
   }
 
-  function buildResultsView() {
+  function buildResultsView(options = {}) {
     const FindOptions = require("../lib/find-options")
     const ResultsModel = require("../lib/project/results-model")
     const { Result } = ResultsModel
     const ResultsView = require("../lib/project/results-view")
     const model = new ResultsModel(new FindOptions({}), null)
     const resultsView = new ResultsView({ model })
-    model.addResult("/a/b.txt", Result.create({
-      filePath: "/a/b.txt",
-      matches: [
-        {
-          lineText: "hello world",
-          matchText: "world",
-          range: {start: {row: 0, column: 6}, end: {row: 0, column: 11}},
-          leadingContextLines: [],
-          trailingContextLines: []
-        }
-      ]
-    }))
-    model.addResult("/c/d.txt", Result.create({
-      filePath: "/c/d.txt",
-      matches: [
-        {
-          lineText: "goodnight moon",
-          matchText: "night",
-          range: {start: {row: 0, column: 4}, end: {row: 0, column: 8}},
-          leadingContextLines: [],
-          trailingContextLines: []
-        }
-      ]
-    }))
+
+    if (!options.empty) {
+      model.addResult("/a/b.txt", Result.create({
+        filePath: "/a/b.txt",
+        matches: [
+          {
+            lineText: "hello world",
+            matchText: "world",
+            range: {start: {row: 0, column: 6}, end: {row: 0, column: 11}},
+            leadingContextLines: [],
+            trailingContextLines: []
+          }
+        ]
+      }))
+      model.addResult("/c/d.txt", Result.create({
+        filePath: "/c/d.txt",
+        matches: [
+          {
+            lineText: "goodnight moon",
+            matchText: "night",
+            range: {start: {row: 0, column: 4}, end: {row: 0, column: 8}},
+            leadingContextLines: [],
+            trailingContextLines: []
+          }
+        ]
+      }))
+    }
+
     return resultsView
   }
 
@@ -660,11 +664,7 @@ describe('ResultsView', () => {
 
   describe("when the results view is empty", () => {
     it("ignores core:confirm and other commands for selecting results", async () => {
-      projectFindView.findEditor.setText('thiswillnotmatchanythingintheproject');
-      atom.commands.dispatch(projectFindView.element, 'core:confirm');
-      await searchPromise;
-      resultsView = getResultsView();
-      await resultsView.heightInvalidationPromise;
+      const resultsView = buildResultsView({ empty: true });
       atom.commands.dispatch(resultsView.element, 'core:confirm');
       atom.commands.dispatch(resultsView.element, 'core:move-down');
       atom.commands.dispatch(resultsView.element, 'core:move-up');
@@ -675,10 +675,8 @@ describe('ResultsView', () => {
     });
 
     it("won't show the preview-controls", async () => {
-      projectFindView.findEditor.setText('thiswillnotmatchanythingintheproject');
-      atom.commands.dispatch(projectFindView.element, 'core:confirm');
-      await searchPromise;
-      expect(getResultsPane().refs.previewControls.style.display).toBe('none');
+      const resultsPane = new ResultsPaneView();
+      expect(resultsPane.refs.previewControls.style.display).toBe('none');
     });
   });
 


### PR DESCRIPTION
:pear:'d with @as-cii 

Fixes https://github.com/atom/atom/issues/19554

In investigating https://github.com/atom/atom/issues/19554, we discovered that every single test that was awaiting the `heightInvalidationPromise` on its view still passes if we *don't* await that promise. Since we're concerned that these `await`s are the source of timeouts like the one in the linked issue, we decided to completely remove that logic from all tests.

We also took the opportunity to replace `element-resize-detector` with the native `ResizeObserver` API which was introduced after the code in this package was written.

Hopefully this addresses all of the remaining flakiness in our tests for this package.