### PR TITLE
Add pcre2 ripgrep option

### DIFF
--- a/lib/project/results-model.js
+++ b/lib/project/results-model.js
@@ -217,6 +217,7 @@ module.exports = class ResultsModel {
 
     const startTime = Date.now()
     const useRipgrep = atom.config.get('find-and-replace.useRipgrep')
+    const enablePCRE2 = atom.config.get('find-and-replace.enablePCRE2')
 
     this.inProgressSearchPromise = atom.workspace.scan(
       this.regex,
@@ -225,6 +226,7 @@ module.exports = class ResultsModel {
         onPathsSearched,
         leadingContextLineCount,
         ripgrep: useRipgrep,
+        PCRE2: enablePCRE2,
         trailingContextLineCount
       },
       (result, error) => {

--- a/package.json
+++ b/package.json
@@ -130,6 +130,12 @@
       "title": "Use ripgrep",
       "description": "Use the experimental `ripgrep` search crawler. This will make searches substantially faster on large projects."
     },
+    "enablePCRE2": {
+      "type": "boolean",
+      "default": false,
+      "title": "Enable PCRE2 regex engine",
+      "description": "Enable PCRE2 regex engine (applies only to `ripgrep` search). This will enable additional regex features such as lookbehind, but may make searches slower."
+    },
     "autocompleteSearches": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
### Description of the Change

Added option to enable `pcre2` ripgrep regex engine, as discussed [in here](https://github.com/atom/find-and-replace/pull/1086#issuecomment-502605862).

**NOTE:** I haven't written any specs because I'm not sure what steps to take. Should I wrap all the specs in additional loop, same as [prev PR has done with ripgrep support](https://github.com/atom/find-and-replace/pull/1086/files#diff-3529658c67b9493659c04f7644950802R12)?

**NOTE:** cannot build Atom ATM so haven't tested the changes locally.

### Benefits

Allows additional regex features such as lookbehind.

### Possible Drawbacks

Enabling PCRE2 potentially incurs performance penalty, as explained on [ripgrep's wiki](https://github.com/BurntSushi/ripgrep/blob/7b3fe6b3251a18d2b8d3efe7ee6a85c9e9e4e565/FAQ.md#why-does-ripgrep-get-slower-when-i-enable-pcre2-regexes), thus this PR does not enable it by default, and instead adds an option.

### Applicable Issues

Addresses https://github.com/atom/find-and-replace/issues/571

Accompanying [PR in atom core](https://github.com/atom/atom/pull/19615)
