### PR TITLE
Don’t crash when using find view in tab that’s not an editor

### DIFF
--- a/lib/buffer-search.js
+++ b/lib/buffer-search.js
@@ -72,7 +72,8 @@ class BufferSearch {
     Object.assign(options, otherOptions);
 
     const changedParams = this.findOptions.set(options);
-    if (changedParams.findPattern != null ||
+    if (!this.editor ||
+        changedParams.findPattern != null ||
         changedParams.useRegex != null ||
         changedParams.wholeWord != null ||
         changedParams.caseSensitive != null ||

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -22,6 +22,7 @@ class FindView {
     this.clearMessage();
     this.updateOptionViews();
     this.updateSyntaxHighlighting();
+    this.updateFindEnablement();
     this.updateReplaceEnablement();
     this.createWrapIcon();
   }
@@ -203,17 +204,6 @@ class FindView {
       atom.tooltips.add(this.refs.wholeWordOptionButton, {
         title: "Whole Word",
         keyBindingCommand: 'find-and-replace:toggle-whole-word-option',
-        keyBindingTarget: this.findEditor.element
-      }),
-
-      atom.tooltips.add(this.refs.nextButton, {
-        title: "Find Next",
-        keyBindingCommand: 'find-and-replace:find-next',
-        keyBindingTarget: this.findEditor.element
-      }),
-      atom.tooltips.add(this.refs.findAllButton, {
-        title: "Find All",
-        keyBindingCommand: 'find-and-replace:find-all',
         keyBindingTarget: this.findEditor.element
       })
     );
@@ -429,6 +419,7 @@ class FindView {
     this.markers = markers;
     this.findError = null;
     this.updateResultCounter();
+    this.updateFindEnablement();
     this.updateReplaceEnablement();
 
     if (this.model.getFindOptions().findPattern) {
@@ -726,6 +717,41 @@ class FindView {
     this.search(this.findEditor.getText(), {wholeWord: !this.model.getFindOptions().wholeWord});
     if (!this.anyMarkersAreSelected()) {
       this.selectFirstMarkerAfterCursor();
+    }
+  }
+
+  updateFindEnablement() {
+    let editor = this.model.getEditor();
+    let isDisabled = this.refs.findAllButton.classList.contains('disabled');
+    let hadFindTooltip = !!this.findTooltipSubscriptions;
+
+    if (hadFindTooltip) this.findTooltipSubscriptions.dispose();
+    this.findTooltipSubscriptions = new CompositeDisposable;
+
+    if (editor && (!hadFindTooltip || isDisabled)) {
+      this.refs.findAllButton.classList.remove('disabled');
+      this.refs.nextButton.classList.remove('disabled');
+
+      this.findTooltipSubscriptions.add(atom.tooltips.add(this.refs.nextButton, {
+        title: "Find Next",
+        keyBindingCommand: 'find-and-replace:find-next',
+        keyBindingTarget: this.findEditor.element
+      }));
+      this.findTooltipSubscriptions.add(atom.tooltips.add(this.refs.findAllButton, {
+        title: "Find All",
+        keyBindingCommand: 'find-and-replace:find-all',
+        keyBindingTarget: this.findEditor.element
+      }));
+    } else if (!editor && (!hadFindTooltip || !isDisabled)) {
+      this.refs.findAllButton.classList.add('disabled');
+      this.refs.nextButton.classList.add('disabled');
+
+      this.findTooltipSubscriptions.add(atom.tooltips.add(this.refs.nextButton, {
+        title: "Find Next [when in a text document]"
+      }));
+      this.findTooltipSubscriptions.add(atom.tooltips.add(this.refs.findAllButton, {
+        title: "Find All [when in a text document]"
+      }));
     }
   }
 

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -335,6 +335,8 @@ class FindView {
   }
 
   liveSearch() {
+    const editor = this.model.getEditor();
+    if (!editor) return null;
     let findPattern = this.findEditor.getText();
     if (findPattern.length === 0 || (findPattern.length >= atom.config.get('find-and-replace.liveSearchMinimumCharacters') && !this.model.patternMatchesEmptyString(findPattern))) {
       return this.model.search(findPattern);
@@ -342,6 +344,8 @@ class FindView {
   }
 
   search(findPattern, options) {
+    const editor = this.model.getEditor();
+    if (!editor) return null;
     if (arguments.length === 1 && typeof findPattern === 'object') {
       options = findPattern;
       findPattern = null;

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -325,8 +325,6 @@ class FindView {
   }
 
   liveSearch() {
-    const editor = this.model.getEditor();
-    if (!editor) return null;
     let findPattern = this.findEditor.getText();
     if (findPattern.length === 0 || (findPattern.length >= atom.config.get('find-and-replace.liveSearchMinimumCharacters') && !this.model.patternMatchesEmptyString(findPattern))) {
       return this.model.search(findPattern);
@@ -334,8 +332,6 @@ class FindView {
   }
 
   search(findPattern, options) {
-    const editor = this.model.getEditor();
-    if (!editor) return null;
     if (arguments.length === 1 && typeof findPattern === 'object') {
       options = findPattern;
       findPattern = null;

--- a/spec/find-view-spec.js
+++ b/spec/find-view-spec.js
@@ -1836,7 +1836,7 @@ describe("FindView", () => {
       findView.findEditor.setText("items");
       atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-regex-option");
       expect(findView.model.getFindOptions().useRegex).toBe(true);
-      expect(findView.refs.descriptionLabel.textContent).toContain("no results");
+      expect(findView.refs.descriptionLabel.textContent).toContain("No results");
     });
 
     it("toggles selection via an event and finds text matching the pattern", async () => {
@@ -1847,7 +1847,7 @@ describe("FindView", () => {
       findView.findEditor.setText("items");
       atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-selection-option");
       expect(findView.model.getFindOptions().inCurrentSelection).toBe(true);
-      expect(findView.refs.descriptionLabel.textContent).toContain("no results");
+      expect(findView.refs.descriptionLabel.textContent).toContain("No results");
     });
   });
 });

--- a/spec/find-view-spec.js
+++ b/spec/find-view-spec.js
@@ -1835,7 +1835,19 @@ describe("FindView", () => {
 
       findView.findEditor.setText("items");
       atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-regex-option");
-      expect(findView.refs.descriptionLabel.textContent).toContain("No results");
+      expect(findView.model.getFindOptions().useRegex).toBe(true);
+      expect(findView.refs.descriptionLabel.textContent).toContain("no results");
+    });
+
+    it("toggles selection via an event and finds text matching the pattern", async () => {
+      atom.commands.dispatch(editorView, "find-and-replace:show");
+      editor.destroy();
+      await activationPromise;
+
+      findView.findEditor.setText("items");
+      atom.commands.dispatch(findView.findEditor.element, "find-and-replace:toggle-selection-option");
+      expect(findView.model.getFindOptions().inCurrentSelection).toBe(true);
+      expect(findView.refs.descriptionLabel.textContent).toContain("no results");
     });
   });
 });


### PR DESCRIPTION
### Description of the Change

- Checks for the presence of an editor before trying to search text.
- Make find and find all buttons disabled when their feature is not available and add an helpful tooltip on them.

### Alternate Designs

It is implement in `buffer-search.js` because filters need to be updated, and stopping the search in `find-view.js` would prevent that.

### Benefits

The fact that now the buttons are disabled and provide a hint of why it is disabled will help people understand why the find/find all feature is unavailable here.

### Possible Drawbacks

I can’t see any.

### Applicable Issues

Fix #998 

---

I think these changes need unit tests but I find it more difficult to find what should go where and how to implement these tests properly, so any help to get started is appreciated.

Also during my work, I found that I was able make filters unmodifiable (i.e. clicking filters did nothing) when pane was opened on a non-editor page, so that will need to be tested too.