### PR TITLE
Add option to save search resulst from being overwrittenby next search

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -21,7 +21,7 @@ module.exports =
     atom.config.unset('find-and-replace.openProjectFindResultsInRightPane')
 
     atom.workspace.addOpener (filePath) ->
-      new ResultsPaneView() if filePath is ResultsPaneView.URI
+      new ResultsPaneView() if filePath.indexOf(ResultsPaneView.URI) isnt -1
 
     @subscriptions = new CompositeDisposable
     @currentItemSub = new Disposable
@@ -207,7 +207,12 @@ module.exports =
     #    And on each new model, it will run the search again.
     #
     # See https://github.com/atom/find-and-replace/issues/63
-    ResultsPaneView.model = @resultsModel
+    #ResultsPaneView.model = @resultsModel
+    # This makes projectFindView accesible in ResultsPaneView so that resultsModel
+    # can be properly set for ResultsPaneView instances and ProjectFindView instance
+    # as different pane views don't necessarily use same models anymore
+    # but most recent pane view and projectFindView do
+    ResultsPaneView.projectFindView = @projectFindView
 
     @toggleAutocompletions atom.config.get('find-and-replace.autocompleteSearches')
 
@@ -225,7 +230,6 @@ module.exports =
     @projectFindView = null
 
     ResultsPaneView.model = null
-    @resultsModel = null
 
     @autocompleteSubscriptions?.dispose()
     @autocompleteManagerService = null

--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -19,6 +19,7 @@ class ProjectFindView {
     this.replaceHistoryCycler = replaceHistoryCycler;
     this.pathsHistoryCycler = pathsHistoryCycler;
     this.subscriptions = new CompositeDisposable()
+    this.modelSupbscriptions = new CompositeDisposable()
 
     etch.initialize(this)
 
@@ -120,6 +121,8 @@ class ProjectFindView {
   destroy() {
     if (this.subscriptions) this.subscriptions.dispose();
     if (this.tooltipSubscriptions) this.tooltipSubscriptions.dispose();
+    if (this.modelSupbscriptions) this.modelSupbscriptions.dispose();
+    this.model = null;
   }
 
   setPanel(panel) {
@@ -214,10 +217,11 @@ class ProjectFindView {
       this.updateReplaceAllButtonEnablement(results);
     };
 
-    let resetInterface = () => {
+    const resetInterface = () => {
       this.clearMessages();
       this.updateReplaceAllButtonEnablement(null);
     };
+    this.handleEvents.resetInterface = resetInterface;
 
     let afterSearch = () => {
       if (atom.config.get('find-and-replace.closeFindPanelAfterSearch')) {
@@ -230,13 +234,17 @@ class ProjectFindView {
       updateInterfaceForResults(results);
     };
 
-    this.subscriptions.add(this.model.onDidClear(resetInterface));
-    this.subscriptions.add(this.model.onDidClearReplacementState(updateInterfaceForResults));
-    this.subscriptions.add(this.model.onDidStartSearching(updateInterfaceForSearching));
-    this.subscriptions.add(this.model.onDidNoopSearch(afterSearch));
-    this.subscriptions.add(this.model.onDidFinishSearching(searchFinished));
-    this.subscriptions.add(this.model.getFindOptions().onDidChange(this.updateOptionViews.bind(this)));
-    this.subscriptions.add(this.model.getFindOptions().onDidChangeUseRegex(this.updateSyntaxHighlighting.bind(this)));
+    const addModelHandlers = () => {
+      this.modelSupbscriptions.add(this.model.onDidClear(resetInterface));
+      this.modelSupbscriptions.add(this.model.onDidClearReplacementState(updateInterfaceForResults));
+      this.modelSupbscriptions.add(this.model.onDidStartSearching(updateInterfaceForSearching));
+      this.modelSupbscriptions.add(this.model.onDidNoopSearch(afterSearch));
+      this.modelSupbscriptions.add(this.model.onDidFinishSearching(searchFinished));
+      this.modelSupbscriptions.add(this.model.getFindOptions().onDidChange(this.updateOptionViews.bind(this)));
+      this.modelSupbscriptions.add(this.model.getFindOptions().onDidChangeUseRegex(this.updateSyntaxHighlighting.bind(this)));
+    }
+    this.handleEvents.addModelHandlers=addModelHandlers;
+    addModelHandlers();
 
     this.element.addEventListener('focus', () => this.findEditor.element.focus());
     this.refs.closeButton.addEventListener('click', () => this.panel && this.panel.hide());
@@ -260,19 +268,23 @@ class ProjectFindView {
     this.replaceEditor.getBuffer().onDidChange(() => this.model.clearReplacementState());
     this.replaceEditor.onDidStopChanging(() => this.model.getFindOptions().set({replacePattern: this.replaceEditor.getText()}));
     this.replacementsMade = 0;
-    this.subscriptions.add(this.model.onDidStartReplacing(promise => {
-      this.replacementsMade = 0;
-      this.refs.replacmentInfoBlock.style.display = '';
-      this.refs.replacementProgress.removeAttribute('value');
-    }));
+    const addReplaceModelHandlers = () => {
+      this.modelSupbscriptions.add(this.model.onDidStartReplacing(promise => {
+        this.replacementsMade = 0;
+        this.refs.replacmentInfoBlock.style.display = '';
+        this.refs.replacementProgress.removeAttribute('value');
+      }));
 
-    this.subscriptions.add(this.model.onDidReplacePath(result => {
-      this.replacementsMade++;
-      this.refs.replacementProgress.value = this.replacementsMade / this.model.getPathCount();
-      this.refs.replacmentInfo.textContent = `Replaced ${this.replacementsMade} of ${_.pluralize(this.model.getPathCount(), 'file')}`;
-    }));
+      this.modelSupbscriptions.add(this.model.onDidReplacePath(result => {
+        this.replacementsMade++;
+        this.refs.replacementProgress.value = this.replacementsMade / this.model.getPathCount();
+        this.refs.replacmentInfo.textContent = `Replaced ${this.replacementsMade} of ${_.pluralize(this.model.getPathCount(), 'file')}`;
+      }));
 
-    this.subscriptions.add(this.model.onDidFinishReplacing(result => this.onFinishedReplacing(result)));
+      this.modelSupbscriptions.add(this.model.onDidFinishReplacing(result => this.onFinishedReplacing(result)));
+    }
+    this.handleEventsForReplace.addReplaceModelHandlers=addReplaceModelHandlers;
+    addReplaceModelHandlers();
   }
 
   focusNextElement(direction) {

--- a/lib/project/results-pane.js
+++ b/lib/project/results-pane.js
@@ -1,14 +1,16 @@
 const _ = require('underscore-plus');
 const {CompositeDisposable} = require('atom');
 const ResultsView = require('./results-view');
+const ResultsModel = require('./results-model');
 const {showIf, getSearchResultsMessage, escapeHtml} = require('./util');
 const etch = require('etch');
 const $ = etch.dom;
 
+
 module.exports =
 class ResultsPaneView {
   constructor() {
-    this.model = this.constructor.model;
+    this.model = ResultsPaneView.projectFindView.model;
     this.model.setActive(true);
     this.isLoading = false;
     this.searchErrors = [];
@@ -17,6 +19,7 @@ class ResultsPaneView {
     this.numberOfPathsSearched = 0;
     this.searchContextLineCountBefore = 0;
     this.searchContextLineCountAfter = 0;
+    this.uri = ResultsPaneView.URI;
 
     etch.initialize(this);
 
@@ -47,6 +50,8 @@ class ResultsPaneView {
           break;
         case this.refs.incrementTrailingContextLines:
           this.incrementTrailingContextLines();
+        case this.refs.dontOverrideTab:
+          this.dontOverrideTab();
           break;
       }
     })
@@ -68,6 +73,8 @@ class ResultsPaneView {
   destroy() {
     this.model.setActive(false);
     this.subscriptions.dispose();
+    if(this.separatePane)
+      this.model = null;
   }
 
   render() {
@@ -88,6 +95,13 @@ class ResultsPaneView {
               ? 'Searching...'
               : (getSearchResultsMessage(this.searchResults) || 'Project search results')
           }),
+
+          $.button(
+            {
+              ref: 'dontOverrideTab',
+              style: {display: matchCount == 0 || this.isLoading ? 'none' : ''},
+              className: 'btn'
+            }, "Don't override this tab"),
 
           $.div(
             {
@@ -209,7 +223,7 @@ class ResultsPaneView {
   }
 
   getURI() {
-    return this.constructor.URI;
+    return this.uri;
   }
 
   focused() {
@@ -329,6 +343,19 @@ class ResultsPaneView {
     if (findOptionsChanged) {
       etch.update(this.refs.resultsView);
     }
+  }
+
+  dontOverrideTab(){
+    let view = ResultsPaneView.projectFindView;
+    view.handleEvents.resetInterface();
+    view.model = new ResultsModel(view.model.findOptions,view.model.metricsReporter);
+    this.uri = ResultsPaneView.URI + "/" + this.model.getLastFindPattern();
+    this.refs.dontOverrideTab.classList.add('disabled');
+
+    view.modelSupbscriptions.dispose();
+    view.handleEvents.addModelHandlers();
+    view.handleEventsForReplace.addReplaceModelHandlers();
+    this.separatePane=true;
   }
 }
 

--- a/spec/project-find-view-spec.js
+++ b/spec/project-find-view-spec.js
@@ -1153,6 +1153,24 @@ describe(`ProjectFindView (ripgrep=${ripgrep})`, () => {
         atom.commands.dispatch(projectFindView.element, 'project-find:toggle-whole-word-option');
       });
     });
+
+    describe("when user asked not to override last search results", () => {
+      beforeEach(async () => {
+        atom.commands.dispatch(editorElement, 'project-find:show');
+        projectFindView.findEditor.setText('items');
+        atom.commands.dispatch(projectFindView.element, 'core:confirm');
+        await searchPromise;
+
+      });
+      it("opens new search results in new panel", async () => {
+        const result_pane = getExistingResultsPane();
+        result_pane.dontOverrideTab();
+        projectFindView.findEditor.setText('items2');
+        atom.commands.dispatch(projectFindView.element, 'core:confirm');
+        await searchPromise;
+        expect(result_pane).not.toBe(getExistingResultsPane());
+      });
+    });
   });
 
   describe("replacing", () => {


### PR DESCRIPTION
### Description of the Change

Every project search, overrides last search's results. This PR adds button to results tab, that when clicked, saves that tab, so it won't be overwritten by next search. Next search will open results in new tab (that can be overwritten, unless button in that one is clicked). After clicking button gets disabled

![image](https://user-images.githubusercontent.com/30386578/70854868-0edbdc80-1ec2-11ea-9347-4ca79cc9d334.png)
![image](https://user-images.githubusercontent.com/30386578/70854869-113e3680-1ec2-11ea-9aef-fe7e1d5416e5.png)


### Alternate Designs

Main focus is to have multiple results open at the same time. Other approach was to put this button, but it was easy to lose track of what tabs would stay open, and what overwritten.
![image](https://user-images.githubusercontent.com/30386578/70853652-26f73000-1eb1-11ea-8b5d-11d625ed3cf6.png)

### Benefits

Easier code navigation

### Possible Drawbacks

### Applicable Issues


https://github.com/atom/find-and-replace/issues/360

