### PR TITLE
Insert newline

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -34,7 +34,7 @@
 
 '.platform-darwin .find-and-replace':
   'shift-enter': 'find-and-replace:show-previous'
-  'cmd-enter': 'find-and-replace:confirm'
+  'cmd-enter': 'find-and-replace:insert-newline'
   'alt-enter': 'find-and-replace:find-all'
   'cmd-alt-/': 'find-and-replace:toggle-regex-option'
   'cmd-alt-c': 'find-and-replace:toggle-case-option'
@@ -43,19 +43,19 @@
 
 '.platform-win32 .find-and-replace, .platform-linux .find-and-replace':
   'shift-enter': 'find-and-replace:show-previous'
-  'ctrl-enter': 'find-and-replace:confirm'
+  'ctrl-enter': 'find-and-replace:insert-newline'
   'alt-enter': 'find-and-replace:find-all'
   'ctrl-alt-/': 'find-and-replace:toggle-regex-option'
   'ctrl-shift-c': 'find-and-replace:toggle-case-option'
 
 '.platform-darwin .project-find':
-  'cmd-enter': 'project-find:confirm'
+  'cmd-enter': 'project-find:insert-newline'
   'cmd-alt-/': 'project-find:toggle-regex-option'
   'cmd-alt-c': 'project-find:toggle-case-option'
   'cmd-alt-w': 'project-find:toggle-whole-word-option'
 
 '.platform-win32 .project-find, .platform-linux .project-find':
-  'ctrl-enter': 'project-find:confirm'
+  'ctrl-enter': 'project-find:insert-newline'
   'ctrl-alt-/': 'project-find:toggle-regex-option'
   'ctrl-shift-c': 'project-find:toggle-case-option'
 
@@ -64,19 +64,19 @@
   'shift-tab': 'find-and-replace:focus-previous'
 
 '.platform-darwin .find-and-replace .replace-container atom-text-editor':
-  'cmd-enter': 'find-and-replace:replace-all'
+  'alt-enter': 'find-and-replace:replace-all'
 '.platform-darwin .project-find .replace-container atom-text-editor':
-  'cmd-enter': 'project-find:replace-all'
+  'alt-enter': 'project-find:replace-all'
 
 '.platform-win32 .find-and-replace .replace-container atom-text-editor':
-  'ctrl-enter': 'find-and-replace:replace-all'
+  'alt-enter': 'find-and-replace:replace-all'
 '.platform-win32 .project-find .replace-container atom-text-editor':
-  'ctrl-enter': 'project-find:replace-all'
+  'alt-enter': 'project-find:replace-all'
 
 '.platform-linux .find-and-replace .replace-container atom-text-editor':
-  'ctrl-enter': 'find-and-replace:replace-all'
+  'alt-enter': 'find-and-replace:replace-all'
 '.platform-linux .project-find .replace-container atom-text-editor':
-  'ctrl-enter': 'project-find:replace-all'
+  'alt-enter': 'project-find:replace-all'
 
 '.results-view':
   'home': 'core:move-to-top'

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -246,10 +246,12 @@ class FindView {
     this.subscriptions.add(atom.commands.add(this.findEditor.element, {
       'core:confirm': () => this.confirm(),
       'find-and-replace:confirm': () => this.confirm(),
+      'find-and-replace:insert-newline': () => this.insertNewline(),
       'find-and-replace:show-previous': () => this.showPrevious()
     }));
 
     this.subscriptions.add(atom.commands.add(this.replaceEditor.element, {
+      'find-and-replace:insert-newline': () => this.insertNewline(),
       'core:confirm': () => this.replaceNext()
     }));
 
@@ -801,5 +803,15 @@ class FindView {
     this.wrapIcon.className = `find-wrap-icon ${icon} visible`;
     clearTimeout(this.wrapTimeout);
     this.wrapTimeout = setTimeout((() => this.wrapIcon.classList.remove('visible')), 500);
+  }
+
+  insertNewline() {
+    if (this.findEditor.element.hasFocus()) {
+      this.findEditor.insertNewline();
+    } else if (this.replaceEditor.element.hasFocus()) {
+      this.replaceEditor.insertNewline();
+    } else {
+      console.log("Can't insert newline: no appropriate editor selected");
+    }
   }
 };

--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -194,6 +194,7 @@ class ProjectFindView {
     this.subscriptions.add(atom.commands.add(this.element, {
       'find-and-replace:focus-next': () => this.focusNextElement(1),
       'find-and-replace:focus-previous': () => this.focusNextElement(-1),
+      'find-and-replace:insert-newline': () => this.insertNewline(),
       'core:confirm': () => this.confirm(),
       'core:close': () => this.panel && this.panel.hide(),
       'core:cancel': () => this.panel && this.panel.hide(),
@@ -562,5 +563,16 @@ class ProjectFindView {
 
   toggleWholeWordOption() {
     this.search({onlyRunIfActive: true, wholeWord: !this.model.getFindOptions().wholeWord});
+  }
+
+  insertNewline() {
+    if (this.findEditor.element.hasFocus()) {
+      this.findEditor.insertNewline();
+    } else if (this.replaceEditor.element.hasFocus()) {
+      this.replaceEditor.insertNewline();
+    } else {
+      // Can't imagine newlines would be useful in the path editor
+      console.log("Can't insert newline: no appropriate editor selected");
+    }
   }
 };


### PR DESCRIPTION
### Description of the Change

Add support for inserting newlines into find and replace fields using a keyboard shortcut (Cmd/Ctrl-Enter by default)

### Alternate Designs

Used Cmd/Ctrl-Enter for the default keyboard shortcut because it's functions tended to overlap with other shortcuts, making it redundant.

### Benefits

Ability to find + replace strings containing newlines without needing to copy/paste the newline into the text field

### Possible Drawbacks

Remapping of default keyboard shortcuts may affect existing workflows.

The code literally just allows for easier insertion of newlines into the text fields. How the program handles newlines is not affected, so if the program is unable to handle newlines in certain cases, this won't change that.

### Applicable Issues
Direct solution for #396 
Also affects #398 
