### PR TITLE
Add searchAllPanes option

### DIFF
--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -483,6 +483,7 @@ class ResultsView {
       const match = selectedRow.data.matches[0]
       const editor = await atom.workspace.open(selectedRow.group.result.filePath, {
         pending,
+        searchAllPanes: true,
         split: reverseDirections[atom.config.get('find-and-replace.projectSearchResultsPaneSplitDirection')]
       })
       editor.unfoldBufferRow(match.range.start.selectedRow)


### PR DESCRIPTION
Enables atom to focus on a file with matched results if the file is open
in a different pane from the search results

Resolves: #1058