### PR TITLE
Add font resizing in project search (#21125)

### DIFF
--- a/lib/project/list-view.js
+++ b/lib/project/list-view.js
@@ -14,6 +14,22 @@ module.exports = class ListView {
     const resizeObserver = new ResizeObserver(() => etch.update(this));
     resizeObserver.observe(this.element);
     this.element.addEventListener('scroll', () => etch.update(this));
+
+    this.registerFontResizing();
+  }
+
+  registerFontResizing() {
+    atom.commands.add('atom-workspace', {
+      'window:increase-font-size': () => {
+        etch.update(this)
+      },
+      'window:decrease-font-size': () => {
+        etch.update(this)
+      },
+      'window:reset-font-size': () => {
+        etch.update(this)
+      }
+    })
   }
 
   update({items, heightForItem, itemComponent, className} = {}) {
@@ -54,18 +70,20 @@ module.exports = class ListView {
         children.push(
           $.div(
             {
+              className: "item-container",
               style: {
-                position: 'absolute',
+                fontSize: `${atom.config.get("editor.fontSize")}px`,
+                position: "absolute",
                 height: `${itemHeight}px`,
-                width: '100%',
-                top: `${itemTopPosition}px`
+                width: "100%",
+                top: `${itemTopPosition}px`,
               },
-              key: i
+              key: i,
             },
             etch.dom(this.itemComponent, {
               item: item,
               top: Math.max(0, scrollTop - itemTopPosition),
-              bottom: Math.min(itemHeight, scrollBottom - itemTopPosition)
+              bottom: Math.min(itemHeight, scrollBottom - itemTopPosition),
             })
           )
         );

--- a/lib/project/results-view.js
+++ b/lib/project/results-view.js
@@ -96,18 +96,28 @@ class ResultsView {
   }
 
   getRowHeight(resultRow) {
+    let baseHeight;
+
     if (resultRow instanceof LeadingContextRow) {
-      return this.contextRowHeight
+      baseHeight = this.contextRowHeight
     } else if (resultRow instanceof TrailingContextRow) {
-      return this.contextRowHeight
+      baseHeight = this.contextRowHeight
     } else if (resultRow instanceof ResultPathRow) {
-      return this.pathRowHeight
+      baseHeight = this.pathRowHeight
     } else if (resultRow instanceof MatchRow) {
-      return this.matchRowHeight
+      baseHeight = this.matchRowHeight
     }
+
+    return this.getHeightAdjustedToFontSize(baseHeight)
   }
 
-  render () {
+  getHeightAdjustedToFontSize(baseHeight) {
+    const lineHeight = 2;
+    const baseFontSize = 12;
+    return baseHeight + lineHeight * (atom.config.get('editor.fontSize') - baseFontSize);
+  }
+
+  render() {
     this.maintainPreviousScrollPosition();
 
     let regex = null, replacePattern = null;

--- a/spec/results-view-spec.js
+++ b/spec/results-view-spec.js
@@ -979,6 +979,50 @@ describe('ResultsView', () => {
     });
   });
 
+  describe('changing font size', () => {
+    it('should increase font size on window:increase-font-size', async () => {
+      const resultsView = buildResultsView();
+      await resultsView.invalidateItemHeights()
+      const currentFontSize = atom.config.get("editor.fontSize");
+
+      await dispatchCommandAndWaitUntilUpdate(resultsView, 'window:increase-font-size');
+
+      getItemContainers(resultsView).forEach(container => expect(container.style.fontSize).toBe(`${currentFontSize + 1}px`))
+    })
+
+    it('should decrease font size on window:decrease-font-size', async () => {
+      const resultsView = buildResultsView();
+      await resultsView.invalidateItemHeights()
+      const currentFontSize = atom.config.get("editor.fontSize");
+
+      await dispatchCommandAndWaitUntilUpdate(resultsView, 'window:decrease-font-size');
+
+      getItemContainers(resultsView).forEach(container => expect(container.style.fontSize).toBe(`${currentFontSize - 1}px`))
+    })
+
+
+    it('should reset font size on window:reset-font-size', async () => {
+      const resultsView = buildResultsView();
+      await resultsView.invalidateItemHeights()
+      const defaultFontSize = atom.config.get("editor.defaultFontSize")
+
+      await dispatchCommandAndWaitUntilUpdate(resultsView, 'window:increase-font-size');
+      await dispatchCommandAndWaitUntilUpdate(resultsView, 'window:increase-font-size');
+      await dispatchCommandAndWaitUntilUpdate(resultsView, 'window:reset-font-size');
+
+      getItemContainers(resultsView).forEach(container => expect(container.style.fontSize).toBe(`${defaultFontSize}px`))
+    })
+
+    async function dispatchCommandAndWaitUntilUpdate(element, command) {
+      atom.commands.dispatch(projectFindView.element, command);
+      await etch.update(element)
+    }
+
+    function getItemContainers(resultsView) {
+      return resultsView.refs.listView.element.querySelectorAll('.item-container');
+    }
+  })
+
   describe('selected result and match index', () => {
     beforeEach(async () => {
       projectFindView.findEditor.setText('push');

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -374,3 +374,7 @@ atom-workspace.find-visible {
     }
   }
 }
+
+.list-tree.has-collapsable-children .list-nested-item > .list-item::before {
+  vertical-align: middle;
+}


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Add possibility to change font size in project find results view. The font size is connected to _editor.fontSize_ property. It can be changed by using _window:increase-font-size_, _window:decrease-font-size_, _window:reset-font-size_ commands, similarly as you can do for editor view.

Video presenting the feature: https://youtu.be/fqGRfRE3b6M

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

I don't see any alternate designs.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Possibility to change font size in project find results view.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

I don't see any.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

https://github.com/atom/atom/issues/21125

<!-- Enter any applicable Issues here -->
