### PR TITLE
Fix `this` bug

### DIFF
--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -235,7 +235,7 @@ class FindView {
       'find-and-replace:use-selection-as-replace-pattern': this.setSelectionAsReplacePattern.bind(this)
     }));
 
-    this.refs.replaceNextButton.addEventListener('click', e => e.shiftKey ? this.replacePrevious() : this.replaceNext()));
+    this.refs.replaceNextButton.addEventListener('click', e => e.shiftKey ? this.replacePrevious.bind(this) : this.replaceNext.bind(this)));
     this.refs.replaceAllButton.addEventListener('click', this.replaceAll.bind(this));
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'find-and-replace:replace-previous': this.replacePrevious.bind(this),


### PR DESCRIPTION
See https://github.com/atom/find-and-replace/commit/9da051259931daac46feba55f26d3dcea9b39abd#commitcomment-55840601

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The original code calls the function, instead of simply providing the function

Also based on the nearby functions, the functions need to be "bound" to the `this` value
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
