### PR TITLE
Added separators in context menu for better UI

### DIFF
--- a/menus/find-and-replace.cson
+++ b/menus/find-and-replace.cson
@@ -24,13 +24,16 @@
 'context-menu':
   '.tree-view li.directory': [
     { 'label': 'Search in Folder', 'command': 'project-find:show-in-current-directory' }
+    { 'type': 'separator' }
   ]
   '.list-item.match-row': [
     { 'label': 'Open in New Tab', 'command': 'find-and-replace:open-in-new-tab' }
     { 'label': 'Copy', 'command': 'core:copy' }
     { 'label': 'Copy Path', 'command': 'find-and-replace:copy-path' }
+    { 'type': 'separator' }
   ]
   '.list-item.path-row': [
     { 'label': 'Open in New Tab', 'command': 'find-and-replace:open-in-new-tab' }
     { 'label': 'Copy Path', 'command': 'find-and-replace:copy-path' }
+    { 'type': 'separator' }
   ]


### PR DESCRIPTION
### Description of the Change

I noticed that there was no separator after this package's context menu in the tree view. This separator is necessary since other packages which also add menu elements are currently just grouped together. ( I discovered this while building another package and needing a context menu in the tree view)

#### Current Menu ('Other package' has added a context  menu item)- 
<img width="247" alt="Screenshot 2022-08-14 at 1 13 53 PM" src="https://user-images.githubusercontent.com/53078712/184527434-b74541f0-18bc-4e10-9182-d5470da26ecb.png">

#### Behaviour after change 
<img width="249" alt="Screenshot 2022-08-14 at 1 14 22 PM" src="https://user-images.githubusercontent.com/53078712/184527461-36452f24-a9e9-46e9-865e-4f21d0d22f77.png">

### Benefits

Better cleaner tree view context menu for other packages.

### Possible Drawbacks

UI changes a bit, but nothing major.

### Applicable Issues

N/A. Just a small fix.
